### PR TITLE
Update optional field handling to use new API syntax

### DIFF
--- a/Foundation Lab/Models/DataModels.swift
+++ b/Foundation Lab/Models/DataModels.swift
@@ -218,7 +218,7 @@ struct BusinessIdeaOptionalSemantics {
   @Guide(description: "Initial startup costs estimate")
   let estimatedStartupCost: String
 
-  @Guide(description: "Expected timeline or phases for launch and growth", semantics: .possiblyAbsent)
+  @Guide(description: "Expected timeline or phases for launch and growth")
   let timeline: String?
 }
 
@@ -227,39 +227,39 @@ struct BusinessIdeaOptionalSemantics {
 @available(watchOS, unavailable)
 @Generable
 struct EnterpriseExpansionPlan {
-  @Guide(description: "Primary region targeted for expansion", semantics: .possiblyNull)
+  @Guide(description: "Primary region targeted for expansion")
   let region: String?
 
-  @Guide(description: "Projected marketing investment in USD", semantics: .possiblyNull)
+  @Guide(description: "Projected marketing investment in USD")
   let marketingBudget: String?
 
-  @Guide(description: "Planned engineering headcount for the launch", semantics: .possiblyNull)
+  @Guide(description: "Planned engineering headcount for the launch")
   let engineeringHeadcount: String?
 
-  @Guide(description: "Quarterly revenue expectations", semantics: .possiblyNull)
+  @Guide(description: "Quarterly revenue expectations")
   let revenueTargets: String?
 
-  @Guide(description: "Strategic partnerships to secure", semantics: .possiblyNull)
+  @Guide(description: "Strategic partnerships to secure")
   let partnerships: [String]?
 
-  @Guide(description: "Key compliance milestones", semantics: .possiblyNull)
+  @Guide(description: "Key compliance milestones")
   let complianceStatus: [String]?
 
-  @Guide(description: "Identified risks and mitigation plans", semantics: .possiblyNull)
+  @Guide(description: "Identified risks and mitigation plans")
   let riskAssessment: [String]?
 
-  @Guide(description: "Infrastructure or tooling upgrades required", semantics: .possiblyNull)
+  @Guide(description: "Infrastructure or tooling upgrades required")
   let infrastructureNeeds: [String]?
 
-  @Guide(description: "Localization status for product and support", semantics: .possiblyNull)
+  @Guide(description: "Localization status for product and support")
   let localizationStatus: [String]?
 
-  @Guide(description: "Customer support readiness milestones", semantics: .possiblyNull)
+  @Guide(description: "Customer support readiness milestones")
   let supportStrategy: [String]?
 
-  @Guide(description: "Training material requirements", semantics: .possiblyNull)
+  @Guide(description: "Training material requirements")
   let trainingPlan: [String]?
 
-  @Guide(description: "Dependencies that could delay launch", semantics: .possiblyNull)
+  @Guide(description: "Dependencies that could delay launch")
   let launchDependencies: [String]?
 }

--- a/Foundation Lab/Views/Examples/DynamicSchemas/OptionalFieldsSchemaView.swift
+++ b/Foundation Lab/Views/Examples/DynamicSchemas/OptionalFieldsSchemaView.swift
@@ -147,7 +147,7 @@ struct OptionalFieldsSchemaView: View {
         let type: String
         let description: String
         let schema: DynamicGenerationSchema
-        let optionality: DynamicGenerationSchema.Optionality
+        let isOptional: Bool
     }
 
     private var schemaFields: [SchemaField] {
@@ -174,42 +174,42 @@ struct OptionalFieldsSchemaView: View {
                     type: "String",
                     description: "The person's full name",
                     schema: .init(type: String.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 SchemaField(
                     name: "age",
                     type: "Int",
                     description: "The person's age",
                     schema: .init(type: Int.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 SchemaField(
                     name: "location",
                     type: "String",
                     description: "Where the person is from or lives",
                     schema: .init(type: String.self),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "occupation",
                     type: "String",
                     description: "The person's job or profession",
                     schema: .init(type: String.self),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "bio",
                     type: "String",
                     description: "Brief biographical information",
                     schema: .init(type: String.self),
-                    optionality: .possiblyNull
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "interests",
                     type: "[String]",
                     description: "Hobbies or interests mentioned",
                     schema: .init(arrayOf: .init(type: String.self)),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 )
             ]
 
@@ -220,42 +220,42 @@ struct OptionalFieldsSchemaView: View {
                     type: "String",
                     description: "Product name",
                     schema: .init(type: String.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 SchemaField(
                     name: "price",
                     type: "Float",
                     description: "Product price",
                     schema: .init(type: Float.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 SchemaField(
                     name: "description",
                     type: "String",
                     description: "Product description",
                     schema: .init(type: String.self),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "colors",
                     type: "[String]",
                     description: "Available colors",
                     schema: .init(arrayOf: .init(type: String.self)),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "inStock",
                     type: "Bool",
                     description: "Whether the product is in stock",
                     schema: .init(type: Bool.self),
-                    optionality: .possiblyNull
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "discount",
                     type: "Float",
                     description: "Discount percentage if any",
                     schema: .init(type: Float.self),
-                    optionality: .possiblyNull
+                    isOptional: true
                 )
             ]
 
@@ -266,42 +266,42 @@ struct OptionalFieldsSchemaView: View {
                     type: "String",
                     description: "Event title",
                     schema: .init(type: String.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 SchemaField(
                     name: "date",
                     type: "String",
                     description: "Event date",
                     schema: .init(type: String.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 SchemaField(
                     name: "venue",
                     type: "String",
                     description: "Event location or venue",
                     schema: .init(type: String.self),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "capacity",
                     type: "Int",
                     description: "Maximum attendees",
                     schema: .init(type: Int.self),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "registration",
                     type: "String",
                     description: "Registration requirements",
                     schema: .init(type: String.self),
-                    optionality: .possiblyNull
+                    isOptional: true
                 ),
                 SchemaField(
                     name: "earlyBird",
                     type: "Bool",
                     description: "Early bird discount available",
                     schema: .init(type: Bool.self),
-                    optionality: .possiblyNull
+                    isOptional: true
                 )
             ]
         }
@@ -362,7 +362,7 @@ struct OptionalFieldsSchemaView: View {
                 name: field.name,
                 description: field.description,
                 schema: field.schema,
-                optionality: field.optionality
+                isOptional: field.isOptional
             )
         }
 
@@ -421,35 +421,34 @@ struct OptionalFieldsSchemaView: View {
                     name: "name",
                     description: "Full name",
                     schema: .init(type: String.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 DynamicGenerationSchema.Property(
                     name: "email",
                     description: "Email address",
                     schema: .init(type: String.self),
-                    optionality: .possiblyAbsent
+                    isOptional: true
                 ),
                 DynamicGenerationSchema.Property(
                     name: "age",
                     description: "User age",
                     schema: .init(type: Int.self),
-                    optionality: .required
+                    isOptional: false
                 ),
                 DynamicGenerationSchema.Property(
                     name: "preferences",
                     description: "User preferences",
                     schema: .init(arrayOf: .init(type: String.self)),
-                    optionality: .possiblyNull
+                    isOptional: true
                 )
             ]
         )
 
-        // Optionality options (iOS 26.1+):
-        // • .required: model must emit the field
-        // • .possiblyAbsent: field may be omitted entirely
-        // • .possiblyNull: field may appear with a null value
+        // Optional field handling (iOS 26.1+):
+        // • isOptional: false - model must emit the field (required)
+        // • isOptional: true - field may be omitted or null
 
-        // Use the optionality parameter to control field requirements
+        // Use the isOptional parameter to control field requirements
         let response = try await session.respond(
             to: "Extract user information",
             schema: GenerationSchema(root: userSchema, dependencies: [])


### PR DESCRIPTION
Remove deprecated `semantics` parameter from @Guide macro and migrate to the new `isOptional` parameter pattern introduced in iOS 26.1+.

Changes:
- DataModels.swift: Remove `semantics: .possiblyNull/.possiblyAbsent` from @Guide annotations in BusinessIdeaOptionalSemantics and EnterpriseExpansionPlan structs
- OptionalFieldsSchemaView.swift: Replace `Optionality` enum with `isOptional: Bool` parameter in DynamicGenerationSchema.Property

This fixes build errors related to deprecated FoundationModels API and ensures compatibility with the latest framework version.