### PR TITLE
Fix macOS Doc Q&A document imports

### DIFF
--- a/Foundation Lab/Services/RAGService.swift
+++ b/Foundation Lab/Services/RAGService.swift
@@ -33,14 +33,7 @@ final class RAGService {
             }
         }
 
-        let importsDirectory = try FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        .appendingPathComponent("RAGImports", isDirectory: true)
-
+        let importsDirectory = try importsDirectoryURL()
         try FileManager.default.createDirectory(
             at: importsDirectory,
             withIntermediateDirectories: true
@@ -73,12 +66,33 @@ final class RAGService {
 
     func resetDatabase() async throws {
         try await lumoKit.resetDB()
+        try removeImportedDocuments()
     }
 
     var documentCount: Int {
         get async throws {
             try await lumoKit.documentCount()
         }
+    }
+}
+
+private extension RAGService {
+    func importsDirectoryURL() throws -> URL {
+        try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        .appendingPathComponent("RAGImports", isDirectory: true)
+    }
+
+    func removeImportedDocuments() throws {
+        let importsDirectory = try importsDirectoryURL()
+        guard FileManager.default.fileExists(atPath: importsDirectory.path) else {
+            return
+        }
+        try FileManager.default.removeItem(at: importsDirectory)
     }
 }
 

--- a/Foundation Lab/Services/RAGService.swift
+++ b/Foundation Lab/Services/RAGService.swift
@@ -66,7 +66,8 @@ final class RAGService {
 
     func resetDatabase() async throws {
         try await lumoKit.resetDB()
-        try removeImportedDocuments()
+        // Keep the user-visible reset consistent even if cached import cleanup fails.
+        try? removeImportedDocuments()
     }
 
     var documentCount: Int {

--- a/Foundation Lab/Services/RAGService.swift
+++ b/Foundation Lab/Services/RAGService.swift
@@ -21,13 +21,35 @@ final class RAGService {
     }
 
     func indexDocument(url: URL) async throws -> [UUID] {
+        let readableURL = try copyImportedDocumentToAppStorage(from: url)
+        return try await lumoKit.parseAndIndex(url: readableURL, chunkingConfig: chunkingConfig)
+    }
+
+    private func copyImportedDocumentToAppStorage(from url: URL) throws -> URL {
         let accessing = url.startAccessingSecurityScopedResource()
         defer {
             if accessing {
                 url.stopAccessingSecurityScopedResource()
             }
         }
-        return try await lumoKit.parseAndIndex(url: url, chunkingConfig: chunkingConfig)
+
+        let importsDirectory = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        .appendingPathComponent("RAGImports", isDirectory: true)
+
+        try FileManager.default.createDirectory(
+            at: importsDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let fileName = url.lastPathComponent.isEmpty ? "ImportedDocument" : url.lastPathComponent
+        let destinationURL = importsDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+        try FileManager.default.copyItem(at: url, to: destinationURL)
+        return destinationURL
     }
 
     func indexText(_ text: String) async throws -> [UUID] {

--- a/Foundation Lab/Services/RAGService.swift
+++ b/Foundation Lab/Services/RAGService.swift
@@ -21,28 +21,36 @@ final class RAGService {
     }
 
     func indexDocument(url: URL) async throws -> [UUID] {
-        let readableURL = try copyImportedDocumentToAppStorage(from: url)
-        return try await lumoKit.parseAndIndex(url: readableURL, chunkingConfig: chunkingConfig)
+        let readableURL = try await copyImportedDocumentToAppStorage(from: url)
+
+        do {
+            return try await lumoKit.parseAndIndex(url: readableURL, chunkingConfig: chunkingConfig)
+        } catch {
+            await removeImportedDocumentIfPossible(at: readableURL)
+            throw error
+        }
     }
 
-    private func copyImportedDocumentToAppStorage(from url: URL) throws -> URL {
-        let accessing = url.startAccessingSecurityScopedResource()
-        defer {
-            if accessing {
-                url.stopAccessingSecurityScopedResource()
+    private func copyImportedDocumentToAppStorage(from url: URL) async throws -> URL {
+        try await Task.detached(priority: .userInitiated) {
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessing {
+                    url.stopAccessingSecurityScopedResource()
+                }
             }
-        }
 
-        let importsDirectory = try importsDirectoryURL()
-        try FileManager.default.createDirectory(
-            at: importsDirectory,
-            withIntermediateDirectories: true
-        )
+            let importsDirectory = try Self.importsDirectoryURL()
+            try FileManager.default.createDirectory(
+                at: importsDirectory,
+                withIntermediateDirectories: true
+            )
 
-        let fileName = url.lastPathComponent.isEmpty ? "ImportedDocument" : url.lastPathComponent
-        let destinationURL = importsDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
-        try FileManager.default.copyItem(at: url, to: destinationURL)
-        return destinationURL
+            let fileName = url.lastPathComponent.isEmpty ? "ImportedDocument" : url.lastPathComponent
+            let destinationURL = importsDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+            try FileManager.default.copyItem(at: url, to: destinationURL)
+            return destinationURL
+        }.value
     }
 
     func indexText(_ text: String) async throws -> [UUID] {
@@ -78,7 +86,7 @@ final class RAGService {
 }
 
 private extension RAGService {
-    func importsDirectoryURL() throws -> URL {
+    nonisolated static func importsDirectoryURL() throws -> URL {
         try FileManager.default.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,
@@ -89,11 +97,17 @@ private extension RAGService {
     }
 
     func removeImportedDocuments() throws {
-        let importsDirectory = try importsDirectoryURL()
+        let importsDirectory = try Self.importsDirectoryURL()
         guard FileManager.default.fileExists(atPath: importsDirectory.path) else {
             return
         }
         try FileManager.default.removeItem(at: importsDirectory)
+    }
+
+    func removeImportedDocumentIfPossible(at url: URL) async {
+        _ = await Task.detached(priority: .utility) {
+            try? FileManager.default.removeItem(at: url)
+        }.result
     }
 }
 

--- a/Foundation Lab/Services/RAGService.swift
+++ b/Foundation Lab/Services/RAGService.swift
@@ -75,7 +75,7 @@ final class RAGService {
     func resetDatabase() async throws {
         try await lumoKit.resetDB()
         // Keep the user-visible reset consistent even if cached import cleanup fails.
-        try? removeImportedDocuments()
+        await removeImportedDocumentsIfPossible()
     }
 
     var documentCount: Int {
@@ -96,12 +96,14 @@ private extension RAGService {
         .appendingPathComponent("RAGImports", isDirectory: true)
     }
 
-    func removeImportedDocuments() throws {
-        let importsDirectory = try Self.importsDirectoryURL()
-        guard FileManager.default.fileExists(atPath: importsDirectory.path) else {
-            return
-        }
-        try FileManager.default.removeItem(at: importsDirectory)
+    func removeImportedDocumentsIfPossible() async {
+        _ = await Task.detached(priority: .utility) {
+            let importsDirectory = try Self.importsDirectoryURL()
+            guard FileManager.default.fileExists(atPath: importsDirectory.path) else {
+                return
+            }
+            try? FileManager.default.removeItem(at: importsDirectory)
+        }.result
     }
 
     func removeImportedDocumentIfPossible(at url: URL) async {


### PR DESCRIPTION
## Summary
- copy imported Doc Q&A files into app Application Support storage before indexing
- index the sandbox-owned copy so async PicoDocs/LumoKit parsing does not rely on the original security-scoped URL

## Verification
- xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=iOS Simulator,name=iPhone 17 Pro" build
- xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=macOS" build

Fixes #122