### PR TITLE
Add Lab tab and native Studio workbench

### DIFF
--- a/Foundation Lab/Extensions/Color+Extensions.swift
+++ b/Foundation Lab/Extensions/Color+Extensions.swift
@@ -23,4 +23,15 @@ extension Color {
         Color.gray.opacity(0.1)
         #endif
     }
+
+    /// Tertiary background color for quieter grouped content surfaces
+    static var tertiaryBackgroundColor: Color {
+        #if os(iOS)
+        Color(UIColor.tertiarySystemBackground)
+        #elseif os(macOS)
+        Color(NSColor.underPageBackgroundColor)
+        #else
+        Color.gray.opacity(0.06)
+        #endif
+    }
 }

--- a/Foundation Lab/Health/Views/Chat/HealthChatView.swift
+++ b/Foundation Lab/Health/Views/Chat/HealthChatView.swift
@@ -240,7 +240,11 @@ struct WelcomeMessageView: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 16))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
         .padding(.horizontal)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Welcome to Health AI. I'm your personal health coach.")
@@ -264,7 +268,11 @@ struct ToolCallView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
         .padding(.horizontal)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Analyzing your \(formatToolName(toolName))")

--- a/Foundation Lab/Health/Views/Dashboard/HealthDashboardView.swift
+++ b/Foundation Lab/Health/Views/Dashboard/HealthDashboardView.swift
@@ -114,7 +114,11 @@ private extension HealthDashboardView {
                 .foregroundStyle(.secondary)
         }
         .padding()
-        .glassEffect(.regular, in: .rect(cornerRadius: 20))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 
     var dailyProgressSection: some View {
@@ -132,7 +136,11 @@ private extension HealthDashboardView {
                             goalValue: type.defaultGoal,
                             animationNamespace: animationNamespace
                         )
-                        .glassEffect(.regular, in: .rect(cornerRadius: 16))
+                        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: CornerRadius.large)
+                                .stroke(.quaternary, lineWidth: 1)
+                        }
                     }
                 }
             }
@@ -340,7 +348,11 @@ struct InsightPlaceholderView: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .glassEffect(.regular, in: .rect(cornerRadius: 16))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 }
 

--- a/Foundation Lab/Health/Views/Dashboard/InsightCardView.swift
+++ b/Foundation Lab/Health/Views/Dashboard/InsightCardView.swift
@@ -31,13 +31,10 @@ struct InsightCardView: View {
         cardContent
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
-            .glassEffect(
-                .regular,
-                in: .rect(cornerRadius: 16)
-            )
+            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
             .overlay(
-                RoundedRectangle(cornerRadius: 16)
-                    .stroke(insight.isRead ? Color.clear : Color.primary.opacity(0.1), lineWidth: 1)
+                RoundedRectangle(cornerRadius: CornerRadius.large)
+                    .stroke(insight.isRead ? Color.secondary.opacity(0.2) : Color.primary.opacity(0.1), lineWidth: 1)
             )
             .onTapGesture {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {

--- a/Foundation Lab/Health/Views/Dashboard/MetricCardView.swift
+++ b/Foundation Lab/Health/Views/Dashboard/MetricCardView.swift
@@ -40,13 +40,10 @@ struct MetricCardView: View {
         .frame(height: 120)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .glassEffect(
-            .regular,
-            in: .rect(cornerRadius: 16)
-        )
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(isSelected ? Color.primary.opacity(0.2) : Color.clear, lineWidth: 1)
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(isSelected ? Color.primary.opacity(0.2) : Color.secondary.opacity(0.2), lineWidth: 1)
         )
         .scaleEffect(isSelected ? 1.02 : 1.0)
         .animation(.easeInOut(duration: 0.2), value: isSelected)

--- a/Foundation Lab/Models/NavigationCoordinator.swift
+++ b/Foundation Lab/Models/NavigationCoordinator.swift
@@ -16,6 +16,7 @@ final class NavigationCoordinator {
     var tabSelection: TabSelection = .home
     var splitViewSelection: TabSelection? = .home
     var homePath = NavigationPath()
+    var labPath = NavigationPath()
     var studioPath = NavigationPath()
     var insightsPath = NavigationPath()
 
@@ -35,6 +36,11 @@ final class NavigationCoordinator {
             homePath.append(example)
         case .session:
             openChat()
+        case .lab:
+            tabSelection = .lab
+            splitViewSelection = .lab
+            labPath = NavigationPath()
+            labPath.append(example)
         case .studio:
             tabSelection = .studio
             splitViewSelection = .studio
@@ -49,24 +55,24 @@ final class NavigationCoordinator {
     }
 
     public func navigateToTool(_ tool: ToolExample) {
-        tabSelection = .studio
-        splitViewSelection = .studio
-        studioPath = NavigationPath()
-        studioPath.append(tool)
+        tabSelection = .lab
+        splitViewSelection = .lab
+        labPath = NavigationPath()
+        labPath.append(tool)
     }
 
     public func navigateToSchema(_ schema: DynamicSchemaExampleType) {
-        tabSelection = .studio
-        splitViewSelection = .studio
-        studioPath = NavigationPath()
-        studioPath.append(schema)
+        tabSelection = .lab
+        splitViewSelection = .lab
+        labPath = NavigationPath()
+        labPath.append(schema)
     }
 
     public func navigateToLanguage(_ language: LanguageExample) {
-        tabSelection = .studio
-        splitViewSelection = .studio
-        studioPath = NavigationPath()
-        studioPath.append(language)
+        tabSelection = .lab
+        splitViewSelection = .lab
+        labPath = NavigationPath()
+        labPath.append(language)
     }
 
     public func openChat() {

--- a/Foundation Lab/Models/StudioWorkspace.swift
+++ b/Foundation Lab/Models/StudioWorkspace.swift
@@ -190,7 +190,7 @@ struct StudioRunSummary: Identifiable {
 }
 
 struct StudioActivityEvent: Identifiable {
-    let id = UUID()
+    let id: String
     let title: String
     let detail: String
     let date: Date

--- a/Foundation Lab/Models/StudioWorkspace.swift
+++ b/Foundation Lab/Models/StudioWorkspace.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FoundationLabCore
 
 enum StudioWorkspace: String, CaseIterable, Identifiable {
     case promptTesting
@@ -123,6 +124,46 @@ enum StudioWorkspace: String, CaseIterable, Identifiable {
     }
 }
 
+enum StudioPipelineStage: String, CaseIterable, Identifiable {
+    case settings
+    case runs
+    case evaluation
+    case preview
+    case output
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .settings:
+            return "Settings"
+        case .runs:
+            return "Runs"
+        case .evaluation:
+            return "Evaluation"
+        case .preview:
+            return "Preview"
+        case .output:
+            return "Output"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .settings:
+            return "slider.horizontal.3"
+        case .runs:
+            return "play.circle"
+        case .evaluation:
+            return "chart.bar.doc.horizontal"
+        case .preview:
+            return "eye"
+        case .output:
+            return "square.and.arrow.up"
+        }
+    }
+}
+
 struct StudioRunSummary: Identifiable {
     let id = UUID()
     let name: String
@@ -146,4 +187,103 @@ struct StudioRunSummary: Identifiable {
             detail: "Median setup overhead before generation"
         )
     ]
+}
+
+struct StudioActivityEvent: Identifiable {
+    let id = UUID()
+    let title: String
+    let detail: String
+    let date: Date
+}
+
+enum StudioPromptVariant: String, CaseIterable, Identifiable {
+    case baseline
+    case concise
+    case structured
+    case productTone
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .baseline:
+            return "Baseline"
+        case .concise:
+            return "Concise"
+        case .structured:
+            return "Structured"
+        case .productTone:
+            return "Product Tone"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .baseline:
+            return "Plain prompt with default instructions."
+        case .concise:
+            return "Short, direct answer with low temperature."
+        case .structured:
+            return "Answer with a summary and validation notes."
+        case .productTone:
+            return "Useful answer written like a developer tool."
+        }
+    }
+
+    var systemPrompt: String? {
+        switch self {
+        case .baseline:
+            return nil
+        case .concise:
+            return "Answer directly. Prefer concrete wording and avoid filler."
+        case .structured:
+            return "Return a clear answer with sections: Summary, Details, and Validation Notes."
+        case .productTone:
+            return "You are helping an Apple platforms developer evaluate local Foundation Models behavior. Be practical, specific, and product-minded."
+        }
+    }
+
+    var generationOptions: FoundationLabGenerationOptions {
+        switch self {
+        case .baseline:
+            return FoundationLabGenerationOptions(maximumResponseTokens: 260)
+        case .concise:
+            return FoundationLabGenerationOptions(
+                sampling: .greedy,
+                temperature: 0.2,
+                maximumResponseTokens: 180
+            )
+        case .structured:
+            return FoundationLabGenerationOptions(
+                sampling: .randomProbabilityThreshold(0.85),
+                temperature: 0.5,
+                maximumResponseTokens: 360
+            )
+        case .productTone:
+            return FoundationLabGenerationOptions(
+                sampling: .randomTop(40),
+                temperature: 0.7,
+                maximumResponseTokens: 320
+            )
+        }
+    }
+}
+
+struct StudioPromptRun: Identifiable, Hashable {
+    let id = UUID()
+    let variant: StudioPromptVariant
+    let prompt: String
+    let output: String
+    let duration: TimeInterval
+    let tokenCount: Int?
+    let finishedAt: Date
+
+    var durationLabel: String {
+        duration.formatted(.number.precision(.fractionLength(2))) + "s"
+    }
+
+    var tokenLabel: String {
+        guard let tokenCount else { return "No token count" }
+        return "\(tokenCount) tokens"
+    }
 }

--- a/Foundation Lab/Models/StudioWorkspace.swift
+++ b/Foundation Lab/Models/StudioWorkspace.swift
@@ -1,0 +1,149 @@
+//
+//  StudioWorkspace.swift
+//  Foundation Lab
+//
+//  Created by Codex on 5/23/26.
+//
+
+import Foundation
+
+enum StudioWorkspace: String, CaseIterable, Identifiable {
+    case promptTesting
+    case structuredOutput
+    case benchmarkRuns
+    case capabilityMatrix
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .promptTesting:
+            return "Prompt Testing"
+        case .structuredOutput:
+            return "Structured Output"
+        case .benchmarkRuns:
+            return "Benchmark Runs"
+        case .capabilityMatrix:
+            return "Capability Matrix"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .promptTesting:
+            return "Compare instructions, sampling, and prompt variants."
+        case .structuredOutput:
+            return "Validate generated values against dynamic schemas."
+        case .benchmarkRuns:
+            return "Run repeatable suites with latency and quality signals."
+        case .capabilityMatrix:
+            return "Map model behavior across tasks, tools, and languages."
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .promptTesting:
+            return "text.bubble"
+        case .structuredOutput:
+            return "checklist.checked"
+        case .benchmarkRuns:
+            return "speedometer"
+        case .capabilityMatrix:
+            return "square.grid.3x3"
+        }
+    }
+
+    var status: String {
+        switch self {
+        case .promptTesting:
+            return "First Slice"
+        case .structuredOutput:
+            return "Next"
+        case .benchmarkRuns:
+            return "Planned"
+        case .capabilityMatrix:
+            return "Planned"
+        }
+    }
+
+    var metricTitle: String {
+        switch self {
+        case .promptTesting:
+            return "Variants"
+        case .structuredOutput:
+            return "Schemas"
+        case .benchmarkRuns:
+            return "Suites"
+        case .capabilityMatrix:
+            return "Axes"
+        }
+    }
+
+    var metricValue: String {
+        switch self {
+        case .promptTesting:
+            return "4"
+        case .structuredOutput:
+            return "8"
+        case .benchmarkRuns:
+            return "3"
+        case .capabilityMatrix:
+            return "6"
+        }
+    }
+
+    var checkpoints: [String] {
+        switch self {
+        case .promptTesting:
+            return [
+                "Prompt set editor",
+                "Generation options matrix",
+                "Side-by-side run history"
+            ]
+        case .structuredOutput:
+            return [
+                "Schema picker",
+                "Validation failures",
+                "Repair prompt tracking"
+            ]
+        case .benchmarkRuns:
+            return [
+                "Dataset import",
+                "Repeatable run config",
+                "Latency and token timeline"
+            ]
+        case .capabilityMatrix:
+            return [
+                "Use-case profiles",
+                "Language coverage",
+                "Tool-call reliability"
+            ]
+        }
+    }
+}
+
+struct StudioRunSummary: Identifiable {
+    let id = UUID()
+    let name: String
+    let score: String
+    let detail: String
+
+    static let samples = [
+        StudioRunSummary(
+            name: "Recipe JSON schema",
+            score: "92%",
+            detail: "Valid structure across short and detailed prompts"
+        ),
+        StudioRunSummary(
+            name: "Travel assistant tone",
+            score: "A-",
+            detail: "Best result used concise role instructions"
+        ),
+        StudioRunSummary(
+            name: "Tool routing smoke test",
+            score: "18 ms",
+            detail: "Median setup overhead before generation"
+        )
+    ]
+}

--- a/Foundation Lab/Models/TabSelection.swift
+++ b/Foundation Lab/Models/TabSelection.swift
@@ -10,6 +10,7 @@ import Foundation
 enum TabSelection: String, CaseIterable, Hashable {
   case home
   case session
+  case lab
   case studio
   case insights
 
@@ -19,6 +20,8 @@ enum TabSelection: String, CaseIterable, Hashable {
       return "Home"
     case .session:
       return "Session"
+    case .lab:
+      return "Lab"
     case .studio:
       return "Studio"
     case .insights:

--- a/Foundation Lab/Views/AdaptiveNavigationView.swift
+++ b/Foundation Lab/Views/AdaptiveNavigationView.swift
@@ -52,6 +52,12 @@ struct AdaptiveNavigationView: View {
                 }
             }
 
+            Tab(TabSelection.lab.displayName, systemImage: "flask.fill", value: .lab) {
+                NavigationStack(path: $navigationCoordinator.labPath) {
+                    LabView()
+                }
+            }
+
             Tab(TabSelection.studio.displayName, systemImage: "slider.horizontal.3", value: .studio) {
                 NavigationStack(path: $navigationCoordinator.studioPath) {
                     StudioView()
@@ -105,6 +111,10 @@ struct AdaptiveNavigationView: View {
         case .session:
             NavigationStack {
                 ChatView(title: "Session", showsDoneButton: false, tearsDownOnDisappear: false)
+            }
+        case .lab:
+            NavigationStack(path: $navigationCoordinator.labPath) {
+                LabView()
             }
         case .studio:
             NavigationStack(path: $navigationCoordinator.studioPath) {

--- a/Foundation Lab/Views/Chat/ChatInstructionsView.swift
+++ b/Foundation Lab/Views/Chat/ChatInstructionsView.swift
@@ -147,8 +147,11 @@ struct ChatInstructionsView: View {
             }
         }
         .padding(Spacing.medium)
-        .glassEffect(.regular.interactive(true), in: .rect(cornerRadius: 12))
-        .glassEffectID("sampling-strategy", in: glassNamespace)
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.small)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 
     private var samplingConfigurationView: some View {

--- a/Foundation Lab/Views/Chat/ChatInstructionsView.swift
+++ b/Foundation Lab/Views/Chat/ChatInstructionsView.swift
@@ -20,8 +20,6 @@ struct ChatInstructionsView: View {
     let onApply: () -> Void
     @Environment(\.dismiss) private var dismiss
 
-    @Namespace private var glassNamespace
-
     private var clampedTopKSamplingValue: Binding<Int> {
         Binding(
             get: { viewModel.topKSamplingValue },
@@ -147,9 +145,9 @@ struct ChatInstructionsView: View {
             }
         }
         .padding(Spacing.medium)
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
         .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.small)
+            RoundedRectangle(cornerRadius: CornerRadius.large)
                 .stroke(.quaternary, lineWidth: 1)
         }
     }

--- a/Foundation Lab/Views/Components/GenericCardView.swift
+++ b/Foundation Lab/Views/Components/GenericCardView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import LiquidGlasKit
 
 /// Generic card view used across example and tool lists
 struct GenericCardView: View {
@@ -40,9 +39,11 @@ struct GenericCardView: View {
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
-#if os(iOS) || os(macOS)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 12))
-#endif
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.small)
+                .stroke(.quaternary, lineWidth: 1)
+        }
         .accessibilityElement(children: .combine)
     }
 }

--- a/Foundation Lab/Views/Components/GenericCardView.swift
+++ b/Foundation Lab/Views/Components/GenericCardView.swift
@@ -39,9 +39,9 @@ struct GenericCardView: View {
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
         .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.small)
+            RoundedRectangle(cornerRadius: CornerRadius.large)
                 .stroke(.quaternary, lineWidth: 1)
         }
         .accessibilityElement(children: .combine)

--- a/Foundation Lab/Views/Examples/ExampleType+Destination.swift
+++ b/Foundation Lab/Views/Examples/ExampleType+Destination.swift
@@ -40,7 +40,7 @@ extension ExampleType {
     var preferredTab: TabSelection {
         switch self {
         case .structuredData, .generationGuides, .generationOptions:
-            return .studio
+            return .lab
         case .health, .rag:
             return .insights
         case .chat:

--- a/Foundation Lab/Views/Examples/ModelAvailabilityView.swift
+++ b/Foundation Lab/Views/Examples/ModelAvailabilityView.swift
@@ -40,8 +40,8 @@ struct ModelAvailabilityView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, Spacing.xxLarge)
-        .background(Color.secondaryBackgroundColor)
-        .cornerRadius(CornerRadius.medium)
+        .background(Color.tertiaryBackgroundColor)
+        .cornerRadius(CornerRadius.large)
 
         // Info Section
         VStack(alignment: .leading, spacing: 12) {
@@ -69,8 +69,8 @@ struct ModelAvailabilityView: View {
           }
         }
         .padding()
-        .background(Color.secondaryBackgroundColor)
-        .cornerRadius(8)
+        .background(Color.tertiaryBackgroundColor)
+        .cornerRadius(CornerRadius.large)
       }
     }
   }

--- a/Foundation Lab/Views/Examples/StreamingResponseView.swift
+++ b/Foundation Lab/Views/Examples/StreamingResponseView.swift
@@ -38,7 +38,7 @@ struct StreamingResponseView: View {
                 }
                 .padding()
                 .background(Color.green.opacity(0.1))
-                .cornerRadius(8)
+                .cornerRadius(CornerRadius.large)
 
                 // Prompt Suggestions
                 PromptSuggestions(
@@ -77,8 +77,8 @@ struct StreamingResponseView: View {
                                     .textSelection(.enabled)
                                     .padding()
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                    .background(Color.secondaryBackgroundColor)
-                                    .cornerRadius(8)
+                                    .background(Color.tertiaryBackgroundColor)
+                                    .cornerRadius(CornerRadius.large)
                                     .id("streamingText")
                                     .drawingGroup()
                             }

--- a/Foundation Lab/Views/GenerationOptionsHelpers.swift
+++ b/Foundation Lab/Views/GenerationOptionsHelpers.swift
@@ -77,7 +77,11 @@ extension GenerationOptionsView {
                 .foregroundStyle(.secondary)
         }
         .padding()
-        .background(.thinMaterial, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 
     @ViewBuilder
@@ -103,6 +107,10 @@ extension GenerationOptionsView {
                 .foregroundStyle(.secondary)
         }
         .padding()
-        .background(.thinMaterial, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 }

--- a/Foundation Lab/Views/GenerationOptionsView.swift
+++ b/Foundation Lab/Views/GenerationOptionsView.swift
@@ -23,7 +23,6 @@ struct GenerationOptionsView: View {
     @State private var lastTokenCount: Int?
     @State private var contextSize: Int = AppConfiguration.TokenManagement.defaultMaxTokens
 
-    @Namespace private var glassNamespace
     private let generateTextUseCase = GenerateTextUseCase()
 
     var body: some View {
@@ -137,7 +136,11 @@ struct GenerationOptionsView: View {
             }
         }
         .padding()
-        .background(.thinMaterial, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 
     private var generateSection: some View {

--- a/Foundation Lab/Views/HomeView.swift
+++ b/Foundation Lab/Views/HomeView.swift
@@ -63,11 +63,11 @@ struct HomeView: View {
             Spacer(minLength: 0)
         }
         .padding()
-#if os(iOS) || os(macOS)
-        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.large))
-#else
-        .background(Color.gray.opacity(0.1), in: .rect(cornerRadius: CornerRadius.large))
-#endif
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.small)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 
     private var modelStatusIcon: String {

--- a/Foundation Lab/Views/HomeView.swift
+++ b/Foundation Lab/Views/HomeView.swift
@@ -63,9 +63,9 @@ struct HomeView: View {
             Spacer(minLength: 0)
         }
         .padding()
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
         .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.small)
+            RoundedRectangle(cornerRadius: CornerRadius.large)
                 .stroke(.quaternary, lineWidth: 1)
         }
     }

--- a/Foundation Lab/Views/Integrations/LanguagesIntegrationsView.swift
+++ b/Foundation Lab/Views/Integrations/LanguagesIntegrationsView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import FoundationModels
 
 struct LanguagesIntegrationsView: View {
-    @Namespace private var glassNamespace
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Spacing.large) {

--- a/Foundation Lab/Views/LabView.swift
+++ b/Foundation Lab/Views/LabView.swift
@@ -1,0 +1,199 @@
+//
+//  LabView.swift
+//  FoundationLab
+//
+//  Created by Codex on 5/23/26.
+//
+
+import SwiftUI
+
+struct LabView: View {
+    @State private var searchText = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.xLarge) {
+                labHeader
+
+                if hasResults {
+                    examplesSection
+                    toolsSection
+                    schemasSection
+                    languagesSection
+                } else {
+                    ContentUnavailableView.search(text: searchText)
+                }
+            }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+        }
+        .navigationTitle("Lab")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+#endif
+        .searchable(text: $searchText, prompt: "Search Lab")
+        .navigationDestination(for: ExampleType.self) { exampleType in
+            exampleType.destination
+        }
+        .navigationDestination(for: ToolExample.self) { tool in
+            tool.destination
+        }
+        .navigationDestination(for: DynamicSchemaExampleType.self) { example in
+            example.destination
+        }
+        .navigationDestination(for: LanguageExample.self) { languageExample in
+            languageExample.destination
+        }
+    }
+
+    private var labHeader: some View {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            Text("Lab")
+                .font(.largeTitle.bold())
+
+            Text("Foundation Models examples, tools, dynamic schemas, and language demos.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var examplesSection: some View {
+        LabSection(
+            title: "Model Controls",
+            subtitle: "Generation options, guides, and structured output."
+        ) {
+            ForEach(filteredStudioExamples) { exampleType in
+                NavigationLink(value: exampleType) {
+                    GenericCardView(
+                        icon: exampleType.icon,
+                        title: exampleType.title,
+                        subtitle: exampleType.subtitle
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var toolsSection: some View {
+        LabSection(
+            title: "Tools",
+            subtitle: "System capabilities the model can call."
+        ) {
+            ForEach(filteredTools, id: \.self) { tool in
+                NavigationLink(value: tool) {
+                    GenericCardView(
+                        icon: tool.icon,
+                        title: tool.displayName,
+                        subtitle: tool.shortDescription
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var schemasSection: some View {
+        LabSection(
+            title: "Dynamic Schemas",
+            subtitle: "Build and validate generation schemas."
+        ) {
+            ForEach(filteredSchemas) { example in
+                NavigationLink(value: example) {
+                    GenericCardView(
+                        icon: example.icon,
+                        title: example.title,
+                        subtitle: example.subtitle
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var languagesSection: some View {
+        LabSection(
+            title: "Languages",
+            subtitle: "Detect, select, and manage multilingual sessions."
+        ) {
+            ForEach(filteredLanguages) { languageExample in
+                NavigationLink(value: languageExample) {
+                    GenericCardView(
+                        icon: languageExample.icon,
+                        title: languageExample.title,
+                        subtitle: languageExample.subtitle
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var filteredStudioExamples: [ExampleType] {
+        ExampleType.studioExamples.filter { matches($0.title, $0.subtitle) }
+    }
+
+    private var filteredTools: [ToolExample] {
+        ToolExample.allCases.filter { matches($0.displayName, $0.shortDescription) }
+    }
+
+    private var filteredSchemas: [DynamicSchemaExampleType] {
+        DynamicSchemaExampleType.allCases.filter { matches($0.title, $0.subtitle) }
+    }
+
+    private var filteredLanguages: [LanguageExample] {
+        LanguageExample.allCases.filter { matches($0.title, $0.subtitle) }
+    }
+
+    private var hasResults: Bool {
+        !filteredStudioExamples.isEmpty ||
+        !filteredTools.isEmpty ||
+        !filteredSchemas.isEmpty ||
+        !filteredLanguages.isEmpty
+    }
+
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func matches(_ title: String, _ subtitle: String) -> Bool {
+        let query = trimmedSearchText
+        guard !query.isEmpty else { return true }
+
+        return title.localizedStandardContains(query) ||
+        subtitle.localizedStandardContains(query)
+    }
+}
+
+private struct LabSection<Content: View>: View {
+    let title: String
+    let subtitle: String
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            SectionHeader(title: title, subtitle: subtitle)
+
+            LazyVGrid(columns: adaptiveGridColumns, spacing: Spacing.large) {
+                content
+            }
+        }
+    }
+
+    private var adaptiveGridColumns: [GridItem] {
+#if os(iOS)
+        [
+            GridItem(.flexible(minimum: 140), spacing: Spacing.large),
+            GridItem(.flexible(minimum: 140), spacing: Spacing.large)
+        ]
+#else
+        [GridItem(.adaptive(minimum: 240), spacing: Spacing.large)]
+#endif
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LabView()
+    }
+}

--- a/Foundation Lab/Views/LabView.swift
+++ b/Foundation Lab/Views/LabView.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 
 struct LabView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     @State private var searchText = ""
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Spacing.xLarge) {
-                labHeader
+                if horizontalSizeClass != .compact {
+                    labHeader
+                }
 
                 if hasResults {
                     examplesSection

--- a/Foundation Lab/Views/Languages/ProductionLanguageExampleView.swift
+++ b/Foundation Lab/Views/Languages/ProductionLanguageExampleView.swift
@@ -185,9 +185,9 @@ struct ProductionLanguageExampleView: View {
                         Text(result.insights)
                             .font(.body)
                             .padding()
-                            .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+                            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
                             .overlay {
-                                RoundedRectangle(cornerRadius: CornerRadius.small)
+                                RoundedRectangle(cornerRadius: CornerRadius.large)
                                     .stroke(.quaternary, lineWidth: 1)
                             }
                     }
@@ -249,9 +249,9 @@ struct NutritionCard: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
         .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.small)
+            RoundedRectangle(cornerRadius: CornerRadius.large)
                 .stroke(.quaternary, lineWidth: 1)
         }
     }

--- a/Foundation Lab/Views/Languages/ProductionLanguageExampleView.swift
+++ b/Foundation Lab/Views/Languages/ProductionLanguageExampleView.swift
@@ -185,7 +185,11 @@ struct ProductionLanguageExampleView: View {
                         Text(result.insights)
                             .font(.body)
                             .padding()
-                            .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 12))
+                            .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: CornerRadius.small)
+                                    .stroke(.quaternary, lineWidth: 1)
+                            }
                     }
                 }
             }
@@ -245,7 +249,11 @@ struct NutritionCard: View {
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 12))
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.small)
+                .stroke(.quaternary, lineWidth: 1)
+        }
     }
 }
 

--- a/Foundation Lab/Views/SettingsView.swift
+++ b/Foundation Lab/Views/SettingsView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import LiquidGlasKit
 
 struct SettingsView: View {
     var body: some View {
@@ -45,7 +44,11 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
             }
             .padding()
-            .glassCard()
+            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+            .overlay {
+                RoundedRectangle(cornerRadius: CornerRadius.large)
+                    .stroke(.quaternary, lineWidth: 1)
+            }
             .padding([.horizontal, .top])
         }
 #if os(macOS)

--- a/Foundation Lab/Views/SidebarView.swift
+++ b/Foundation Lab/Views/SidebarView.swift
@@ -35,6 +35,8 @@ extension TabSelection {
             return "house.fill"
         case .session:
             return "bubble.left.and.bubble.right.fill"
+        case .lab:
+            return "flask.fill"
         case .studio:
             return "slider.horizontal.3"
         case .insights:
@@ -47,8 +49,9 @@ extension TabSelection {
         switch self {
         case .home: return "1"
         case .session: return "2"
-        case .studio: return "3"
-        case .insights: return "4"
+        case .lab: return "3"
+        case .studio: return "4"
+        case .insights: return "5"
         }
     }
 #endif

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -35,12 +35,14 @@ struct StudioView: View {
         .navigationBarTitleDisplayMode(.inline)
 #endif
         .toolbar {
+#if os(iOS)
             ToolbarItem(placement: .primaryAction) {
                 Button(action: runPromptTests) {
                     Label("Run", systemImage: isRunningPromptTests ? "hourglass" : "play.fill")
                 }
                 .disabled(isRunningPromptTests || !canRunPromptTests)
             }
+#endif
         }
     }
 
@@ -73,13 +75,13 @@ struct StudioView: View {
 
     private var compactLayout: some View {
         VStack(spacing: 0) {
-            stageBar
+            compactStageBar
             Divider()
 
             ScrollView {
                 VStack(alignment: .leading, spacing: Spacing.large) {
                     compactWorkspacePicker
-                    stageContent
+                    compactStageContent
                     activityInspectorContent
                 }
                 .padding()
@@ -184,6 +186,7 @@ struct StudioView: View {
 
     private var stageBar: some View {
         HStack(spacing: Spacing.large) {
+#if os(macOS)
             Button(action: runPromptTests) {
                 Image(systemName: isRunningPromptTests ? "hourglass" : "play.fill")
                     .font(.title3)
@@ -192,6 +195,7 @@ struct StudioView: View {
             .buttonStyle(.borderless)
             .disabled(isRunningPromptTests || !canRunPromptTests)
             .help("Run selected prompt variants")
+#endif
 
             Picker("Stage", selection: $selectedStage) {
                 ForEach(StudioPipelineStage.allCases) { stage in
@@ -205,6 +209,31 @@ struct StudioView: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, Spacing.xLarge)
+        .padding(.vertical, Spacing.small)
+        .background(.bar)
+    }
+
+    private var compactStageBar: some View {
+        HStack(spacing: Spacing.xSmall) {
+            ForEach(StudioPipelineStage.allCases) { stage in
+                Button {
+                    selectedStage = stage
+                } label: {
+                    Text(stage.title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+                        .frame(maxWidth: .infinity, minHeight: 32)
+                        .foregroundStyle(selectedStage == stage ? .white : .primary)
+                        .background(
+                            selectedStage == stage ? Color.accentColor : Color.secondaryBackgroundColor,
+                            in: .capsule
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, Spacing.medium)
         .padding(.vertical, Spacing.small)
         .background(.bar)
     }
@@ -238,6 +267,22 @@ struct StudioView: View {
         switch selectedStage {
         case .settings:
             promptSettingsContent
+        case .runs:
+            runsContent
+        case .evaluation:
+            evaluationContent
+        case .preview:
+            previewContent
+        case .output:
+            outputContent
+        }
+    }
+
+    @ViewBuilder
+    private var compactStageContent: some View {
+        switch selectedStage {
+        case .settings:
+            compactPromptSettingsContent
         case .runs:
             runsContent
         case .evaluation:
@@ -303,6 +348,88 @@ struct StudioView: View {
                     .foregroundStyle(.red)
             }
         }
+    }
+
+    private var compactPromptSettingsContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            compactPanel(title: "Base Prompt", systemImage: "text.quote") {
+                TextEditor(text: $promptText)
+                    .font(.body)
+                    .frame(minHeight: 180)
+                    .scrollContentBackground(.hidden)
+                    .padding(Spacing.small)
+                    .background(.background, in: .rect(cornerRadius: CornerRadius.small))
+            }
+
+            compactPanel(title: "Variants", systemImage: "square.stack.3d.up") {
+                VStack(spacing: 0) {
+                    ForEach(StudioPromptVariant.allCases) { variant in
+                        Toggle(isOn: variantBinding(for: variant)) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(variant.title)
+                                    .font(.callout.weight(.semibold))
+
+                                Text(variant.subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                        .padding(.vertical, Spacing.medium)
+
+                        if variant != StudioPromptVariant.allCases.last {
+                            Divider()
+                        }
+                    }
+                }
+            }
+
+            compactPanel(title: "Run Configuration", systemImage: "slider.horizontal.3") {
+                VStack(spacing: 0) {
+                    compactParameterRow(title: "Execution", value: "Sequential")
+                    compactParameterRow(title: "Variants", value: "\(selectedPromptVariants.count)")
+                    compactParameterRow(title: "Prompt", value: "\(promptText.count) characters")
+                    compactParameterRow(title: "Capture", value: "Output, latency, tokens")
+                }
+            }
+
+            if let promptTestError {
+                Label(promptTestError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func compactPanel<Content: View>(
+        title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+
+            content()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.medium))
+    }
+
+    private func compactParameterRow(title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.callout.weight(.medium))
+
+            Spacer(minLength: Spacing.medium)
+
+            Text(value)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.vertical, Spacing.small)
     }
 
     private func settingsPanel<Content: View>(
@@ -562,13 +689,24 @@ struct StudioView: View {
     }
 
     private var compactWorkspacePicker: some View {
-        Picker("Workspace", selection: $selectedWorkspace) {
-            ForEach(StudioWorkspace.allCases) { workspace in
-                Label(workspace.title, systemImage: workspace.icon)
-                    .tag(workspace)
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            Text("Workspace")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Picker("Workspace", selection: $selectedWorkspace) {
+                ForEach(StudioWorkspace.allCases) { workspace in
+                    Label(workspace.title, systemImage: workspace.icon)
+                        .tag(workspace)
+                }
             }
+            .pickerStyle(.menu)
+
+            Text(selectedWorkspace.subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
         }
-        .pickerStyle(.menu)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var statusBar: some View {

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -9,15 +9,18 @@ import SwiftUI
 
 struct StudioView: View {
     @State private var searchText = ""
+    @State private var selectedWorkspace: StudioWorkspace = .promptTesting
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Spacing.xLarge) {
+                studioHeader
+                workspaceOverview
+                selectedWorkspacePanel
+                recentRunsSection
+
                 if hasResults {
-                    examplesSection
-                    toolsSection
-                    schemasSection
-                    languagesSection
+                    referenceLibrarySection
                 } else {
                     ContentUnavailableView.search(text: searchText)
                 }
@@ -41,6 +44,150 @@ struct StudioView: View {
         }
         .navigationDestination(for: LanguageExample.self) { languageExample in
             languageExample.destination
+        }
+    }
+
+    private var studioHeader: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            HStack(alignment: .top, spacing: Spacing.medium) {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                    .frame(width: 44, height: 44)
+#if os(iOS) || os(macOS)
+                    .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.medium))
+#else
+                    .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.medium))
+#endif
+
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Studio")
+                        .font(.largeTitle.bold())
+
+                    Text("Prompt tests, structured output validation, benchmark runs, and model capability maps for local Foundation Models.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: Spacing.small) {
+                StudioPill(icon: "iphone.and.arrow.forward", title: "iPhone")
+                StudioPill(icon: "macbook", title: "Mac")
+                StudioPill(icon: "lock.shield", title: "On-device")
+            }
+        }
+        .padding()
+#if os(iOS) || os(macOS)
+        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.xLarge))
+#else
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.xLarge))
+#endif
+        .accessibilityElement(children: .combine)
+    }
+
+    private var workspaceOverview: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            SectionHeader(
+                title: "Workspaces",
+                subtitle: "The Studio surface stays inside Foundation Lab."
+            )
+
+            LazyVGrid(columns: workspaceGridColumns, spacing: Spacing.large) {
+                ForEach(StudioWorkspace.allCases) { workspace in
+                    Button {
+                        selectedWorkspace = workspace
+                    } label: {
+                        StudioWorkspaceCard(
+                            workspace: workspace,
+                            isSelected: selectedWorkspace == workspace
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var selectedWorkspacePanel: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            HStack(alignment: .center, spacing: Spacing.medium) {
+                Label(selectedWorkspace.title, systemImage: selectedWorkspace.icon)
+                    .font(.title3.bold())
+
+                Spacer(minLength: 0)
+
+                Text(selectedWorkspace.status)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, Spacing.medium)
+                    .padding(.vertical, Spacing.small)
+                    .background(Color.secondaryBackgroundColor, in: .capsule)
+            }
+
+            Text(selectedWorkspace.subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            LazyVGrid(columns: detailGridColumns, spacing: Spacing.large) {
+                StudioMetricBlock(
+                    title: selectedWorkspace.metricTitle,
+                    value: selectedWorkspace.metricValue,
+                    systemImage: "chart.bar.xaxis"
+                )
+
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    Text("Milestones")
+                        .font(.subheadline.weight(.semibold))
+
+                    ForEach(selectedWorkspace.checkpoints, id: \.self) { checkpoint in
+                        Label(checkpoint, systemImage: "circle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .labelStyle(.titleAndIcon)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding()
+#if os(iOS) || os(macOS)
+        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.large))
+#else
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+#endif
+    }
+
+    private var recentRunsSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            SectionHeader(
+                title: "Run Notes",
+                subtitle: "Seed rows for the first Studio data model."
+            )
+
+            LazyVGrid(columns: runGridColumns, spacing: Spacing.large) {
+                ForEach(StudioRunSummary.samples) { run in
+                    StudioRunCard(run: run)
+                }
+            }
+        }
+    }
+
+    private var referenceLibrarySection: some View {
+        VStack(alignment: .leading, spacing: Spacing.xLarge) {
+            SectionHeader(
+                title: "Reference Library",
+                subtitle: "Current Foundation Lab examples linked from Studio."
+            )
+
+            examplesSection
+            toolsSection
+            schemasSection
+            languagesSection
         }
     }
 
@@ -175,6 +322,173 @@ private struct StudioSection<Content: View>: View {
         ]
 #else
         [GridItem(.adaptive(minimum: 240), spacing: Spacing.large)]
+#endif
+    }
+}
+
+private struct StudioWorkspaceCard: View {
+    let workspace: StudioWorkspace
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            HStack(alignment: .center, spacing: Spacing.medium) {
+                Image(systemName: workspace.icon)
+                    .font(.title3)
+                    .foregroundStyle(.tint)
+                    .frame(width: 32, height: 32)
+
+                Spacer(minLength: 0)
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.body)
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text(workspace.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text(workspace.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: Spacing.small) {
+                Text(workspace.metricValue)
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+
+                Text(workspace.metricTitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
+        .contentShape(.rect)
+#if os(iOS) || os(macOS)
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: CornerRadius.large))
+#else
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+#endif
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.large)
+                .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct StudioMetricBlock: View {
+    let title: String
+    let value: String
+    let systemImage: String
+
+    var body: some View {
+        HStack(spacing: Spacing.medium) {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .foregroundStyle(.tint)
+                .frame(width: 34, height: 34)
+
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text(value)
+                    .font(.title2.bold())
+
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct StudioRunCard: View {
+    let run: StudioRunSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(run.name)
+                    .font(.headline)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+
+                Text(run.score)
+                    .font(.headline.monospacedDigit())
+                    .foregroundStyle(.tint)
+            }
+
+            Text(run.detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, minHeight: 110, alignment: .leading)
+#if os(iOS) || os(macOS)
+        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.large))
+#else
+        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
+#endif
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct StudioPill: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        Label(title, systemImage: icon)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.small)
+            .background(Color.secondaryBackgroundColor, in: .capsule)
+    }
+}
+
+private extension StudioView {
+    var workspaceGridColumns: [GridItem] {
+#if os(iOS)
+        [
+            GridItem(.flexible(minimum: 150), spacing: Spacing.large),
+            GridItem(.flexible(minimum: 150), spacing: Spacing.large)
+        ]
+#else
+        [GridItem(.adaptive(minimum: 220), spacing: Spacing.large)]
+#endif
+    }
+
+    var detailGridColumns: [GridItem] {
+#if os(iOS)
+        [GridItem(.flexible(minimum: 180), spacing: Spacing.large)]
+#else
+        [
+            GridItem(.fixed(180), spacing: Spacing.large),
+            GridItem(.flexible(minimum: 240), spacing: Spacing.large)
+        ]
+#endif
+    }
+
+    var runGridColumns: [GridItem] {
+#if os(iOS)
+        [GridItem(.flexible(minimum: 220), spacing: Spacing.large)]
+#else
+        [GridItem(.adaptive(minimum: 260), spacing: Spacing.large)]
 #endif
     }
 }

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -16,6 +16,7 @@ struct StudioView: View {
     @State private var promptText = "Summarize what makes Apple Foundation Models useful for an offline journaling app."
     @State private var selectedPromptVariants: Set<StudioPromptVariant> = Set(StudioPromptVariant.allCases)
     @State private var promptRuns: [StudioPromptRun] = []
+    @State private var selectedPromptRun: StudioPromptRun?
     @State private var isRunningPromptTests = false
     @State private var promptTestError: String?
     @State private var studioCreatedAt = Date.now
@@ -48,6 +49,23 @@ struct StudioView: View {
 
     private var workbenchLayout: some View {
         VStack(spacing: 0) {
+#if os(macOS)
+            GeometryReader { proxy in
+                if proxy.size.width < 920 {
+                    narrowWorkbenchLayout
+                } else {
+                    HSplitView {
+                        primaryWorkbenchColumn
+                            .frame(minWidth: 0, idealWidth: 820, maxWidth: .infinity, maxHeight: .infinity)
+                            .layoutPriority(1)
+
+                        activityInspector
+                            .frame(minWidth: 240, idealWidth: 300, maxWidth: 320)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+#else
             HStack(spacing: 0) {
                 studioSourceList
                     .frame(width: 250)
@@ -66,11 +84,35 @@ struct StudioView: View {
                 activityInspector
                     .frame(width: 280)
             }
+#endif
 
             Divider()
             statusBar
         }
         .background(Color.secondaryBackgroundColor.opacity(0.28))
+    }
+
+    private var primaryWorkbenchColumn: some View {
+        VStack(spacing: 0) {
+            stageBar
+            Divider()
+            mainWorkspace
+        }
+    }
+
+    private var narrowWorkbenchLayout: some View {
+        VStack(spacing: 0) {
+            stageBar
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.large) {
+                    workspaceHeader
+                    compactStageContent
+                }
+                .padding()
+            }
+        }
     }
 
     private var compactLayout: some View {
@@ -305,7 +347,7 @@ struct StudioView: View {
                             .frame(minHeight: 140)
                             .scrollContentBackground(.hidden)
                             .padding(Spacing.small)
-                            .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+                            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
                     }
 
                     promptDataSlot(
@@ -411,7 +453,7 @@ struct StudioView: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.medium))
+        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
     }
 
     private func compactParameterRow(title: String, value: String) -> some View {
@@ -460,7 +502,7 @@ struct StudioView: View {
             }
             .padding(.horizontal, Spacing.medium)
             .padding(.vertical, Spacing.small)
-            .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
 
             content()
 
@@ -469,7 +511,7 @@ struct StudioView: View {
         .padding()
         .frame(maxWidth: .infinity, minHeight: 260, alignment: .topLeading)
         .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.small)
+            RoundedRectangle(cornerRadius: CornerRadius.large)
                 .stroke(.quaternary, lineWidth: 1)
         }
     }
@@ -534,32 +576,103 @@ struct StudioView: View {
     }
 
     private func runRow(_ run: StudioPromptRun) -> some View {
-        HStack(alignment: .top, spacing: Spacing.large) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(run.variant.title)
-                    .font(.headline)
-                Text(run.finishedAt, style: .time)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        Button {
+            selectedPromptRun = run
+        } label: {
+            HStack(alignment: .top, spacing: Spacing.large) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(run.variant.title)
+                        .font(.headline)
+                    Text(run.finishedAt, style: .time)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(width: 150, alignment: .leading)
+
+                Text(run.output)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text(run.durationLabel)
+                        .font(.headline.monospacedDigit())
+                    Text(run.tokenLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(width: 100, alignment: .trailing)
             }
-            .frame(width: 150, alignment: .leading)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, Spacing.small)
+        .help("Show full prompt run")
+        .popover(
+            isPresented: Binding(
+                get: { selectedPromptRun?.id == run.id },
+                set: { isPresented in
+                    if !isPresented, selectedPromptRun?.id == run.id {
+                        selectedPromptRun = nil
+                    }
+                }
+            ),
+            arrowEdge: .trailing
+        ) {
+            runDetailPopover(run)
+                .presentationCompactAdaptation(.popover)
+        }
+    }
 
-            Text(run.output)
-                .font(.callout)
-                .lineLimit(4)
-                .textSelection(.enabled)
+    private func runDetailPopover(_ run: StudioPromptRun) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(run.variant.title)
+                        .font(.headline)
+                    Text(run.finishedAt, style: .time)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
-            Spacer(minLength: 0)
+                Spacer()
 
-            VStack(alignment: .trailing, spacing: 3) {
-                Text(run.durationLabel)
-                    .font(.headline.monospacedDigit())
-                Text(run.tokenLabel)
-                    .font(.caption)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(run.durationLabel)
+                        .font(.headline.monospacedDigit())
+                    Text(run.tokenLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text("Prompt")
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
+                Text(run.prompt)
+                    .font(.callout)
+                    .textSelection(.enabled)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text("Output")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ScrollView {
+                    Text(run.output)
+                        .font(.body)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 260)
             }
         }
-        .padding(.vertical, Spacing.small)
+        .padding()
+        .frame(width: 420)
     }
 
     private var evaluationContent: some View {

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -656,6 +656,10 @@ struct StudioView: View {
     }
 
     private func runPromptTests() {
+        guard canRunPromptTests, !isRunningPromptTests else { return }
+
+        isRunningPromptTests = true
+
         Task {
             await performPromptTests()
         }
@@ -664,11 +668,14 @@ struct StudioView: View {
     @MainActor
     private func performPromptTests() async {
         let trimmedPrompt = promptText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedPrompt.isEmpty, !selectedPromptVariants.isEmpty else { return }
+        guard !trimmedPrompt.isEmpty, !selectedPromptVariants.isEmpty else {
+            isRunningPromptTests = false
+            return
+        }
 
-        isRunningPromptTests = true
         promptTestError = nil
         selectedStage = .runs
+        defer { isRunningPromptTests = false }
 
         var newRuns: [StudioPromptRun] = []
         let variants = StudioPromptVariant.allCases.filter { selectedPromptVariants.contains($0) }
@@ -702,11 +709,13 @@ struct StudioView: View {
 
             promptRuns = newRuns + promptRuns
         } catch {
-            promptTestError = error.localizedDescription
-            selectedStage = .settings
-        }
+            if !newRuns.isEmpty {
+                promptRuns = newRuns + promptRuns
+            }
 
-        isRunningPromptTests = false
+            promptTestError = error.localizedDescription
+            selectedStage = newRuns.isEmpty ? .settings : .runs
+        }
     }
 }
 

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -86,9 +86,6 @@ struct StudioView: View {
                 }
                 .padding()
             }
-
-            Divider()
-            statusBar
         }
     }
 
@@ -689,22 +686,36 @@ struct StudioView: View {
     }
 
     private var compactWorkspacePicker: some View {
-        VStack(alignment: .leading, spacing: Spacing.small) {
-            Text("Workspace")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Workspace")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
 
-            Picker("Workspace", selection: $selectedWorkspace) {
-                ForEach(StudioWorkspace.allCases) { workspace in
-                    Label(workspace.title, systemImage: workspace.icon)
-                        .tag(workspace)
+                Spacer(minLength: Spacing.medium)
+
+                Menu {
+                    Picker("Workspace", selection: $selectedWorkspace) {
+                        ForEach(StudioWorkspace.allCases) { workspace in
+                            Label(workspace.title, systemImage: workspace.icon)
+                                .tag(workspace)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: Spacing.xSmall) {
+                        Text(selectedWorkspace.title)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .font(.callout.weight(.medium))
                 }
+                .buttonStyle(.plain)
             }
-            .pickerStyle(.menu)
 
             Text(selectedWorkspace.subtitle)
-                .font(.callout)
+                .font(.caption)
                 .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -6,490 +6,707 @@
 //
 
 import SwiftUI
+import FoundationLabCore
 
 struct StudioView: View {
-    @State private var searchText = ""
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     @State private var selectedWorkspace: StudioWorkspace = .promptTesting
+    @State private var selectedStage: StudioPipelineStage = .settings
+    @State private var promptText = "Summarize what makes Apple Foundation Models useful for an offline journaling app."
+    @State private var selectedPromptVariants: Set<StudioPromptVariant> = Set(StudioPromptVariant.allCases)
+    @State private var promptRuns: [StudioPromptRun] = []
+    @State private var isRunningPromptTests = false
+    @State private var promptTestError: String?
+
+    private let generateTextUseCase = GenerateTextUseCase()
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.xLarge) {
-                studioHeader
-                workspaceOverview
-                selectedWorkspacePanel
-                recentRunsSection
-
-                if hasResults {
-                    referenceLibrarySection
-                } else {
-                    ContentUnavailableView.search(text: searchText)
-                }
+        Group {
+            if horizontalSizeClass == .compact {
+                compactLayout
+            } else {
+                workbenchLayout
             }
-            .padding(.horizontal, Spacing.medium)
-            .padding(.vertical, Spacing.large)
         }
         .navigationTitle("Studio")
 #if os(iOS)
-        .navigationBarTitleDisplayMode(.large)
+        .navigationBarTitleDisplayMode(.inline)
 #endif
-        .searchable(text: $searchText, prompt: "Search Studio")
-        .navigationDestination(for: ExampleType.self) { exampleType in
-            exampleType.destination
-        }
-        .navigationDestination(for: ToolExample.self) { tool in
-            tool.destination
-        }
-        .navigationDestination(for: DynamicSchemaExampleType.self) { example in
-            example.destination
-        }
-        .navigationDestination(for: LanguageExample.self) { languageExample in
-            languageExample.destination
-        }
-    }
-
-    private var studioHeader: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            HStack(alignment: .top, spacing: Spacing.medium) {
-                Image(systemName: "slider.horizontal.3")
-                    .font(.title2)
-                    .foregroundStyle(.tint)
-                    .frame(width: 44, height: 44)
-#if os(iOS) || os(macOS)
-                    .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.medium))
-#else
-                    .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.medium))
-#endif
-
-                VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                    Text("Studio")
-                        .font(.largeTitle.bold())
-
-                    Text("Prompt tests, structured output validation, benchmark runs, and model capability maps for local Foundation Models.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: runPromptTests) {
+                    Label("Run", systemImage: isRunningPromptTests ? "hourglass" : "play.fill")
                 }
-
-                Spacer(minLength: 0)
-            }
-
-            HStack(spacing: Spacing.small) {
-                StudioPill(icon: "iphone.and.arrow.forward", title: "iPhone")
-                StudioPill(icon: "macbook", title: "Mac")
-                StudioPill(icon: "lock.shield", title: "On-device")
+                .disabled(isRunningPromptTests || !canRunPromptTests)
             }
         }
-        .padding()
-#if os(iOS) || os(macOS)
-        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.xLarge))
-#else
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.xLarge))
-#endif
-        .accessibilityElement(children: .combine)
     }
 
-    private var workspaceOverview: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            SectionHeader(
-                title: "Workspaces",
-                subtitle: "The Studio surface stays inside Foundation Lab."
-            )
+    private var workbenchLayout: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                studioSourceList
+                    .frame(width: 250)
 
-            LazyVGrid(columns: workspaceGridColumns, spacing: Spacing.large) {
-                ForEach(StudioWorkspace.allCases) { workspace in
-                    Button {
-                        selectedWorkspace = workspace
-                    } label: {
-                        StudioWorkspaceCard(
-                            workspace: workspace,
-                            isSelected: selectedWorkspace == workspace
-                        )
-                    }
-                    .buttonStyle(.plain)
+                Divider()
+
+                VStack(spacing: 0) {
+                    stageBar
+                    Divider()
+                    mainWorkspace
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                Divider()
+
+                activityInspector
+                    .frame(width: 280)
             }
-        }
-    }
-
-    private var selectedWorkspacePanel: some View {
-        VStack(alignment: .leading, spacing: Spacing.large) {
-            HStack(alignment: .center, spacing: Spacing.medium) {
-                Label(selectedWorkspace.title, systemImage: selectedWorkspace.icon)
-                    .font(.title3.bold())
-
-                Spacer(minLength: 0)
-
-                Text(selectedWorkspace.status)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, Spacing.medium)
-                    .padding(.vertical, Spacing.small)
-                    .background(Color.secondaryBackgroundColor, in: .capsule)
-            }
-
-            Text(selectedWorkspace.subtitle)
-                .font(.callout)
-                .foregroundStyle(.secondary)
 
             Divider()
+            statusBar
+        }
+        .background(Color.secondaryBackgroundColor.opacity(0.28))
+    }
 
-            LazyVGrid(columns: detailGridColumns, spacing: Spacing.large) {
-                StudioMetricBlock(
-                    title: selectedWorkspace.metricTitle,
-                    value: selectedWorkspace.metricValue,
-                    systemImage: "chart.bar.xaxis"
-                )
+    private var compactLayout: some View {
+        VStack(spacing: 0) {
+            stageBar
+            Divider()
 
-                VStack(alignment: .leading, spacing: Spacing.small) {
-                    Text("Milestones")
-                        .font(.subheadline.weight(.semibold))
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.large) {
+                    compactWorkspacePicker
+                    stageContent
+                    activityInspectorContent
+                }
+                .padding()
+            }
 
-                    ForEach(selectedWorkspace.checkpoints, id: \.self) { checkpoint in
-                        Label(checkpoint, systemImage: "circle")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .labelStyle(.titleAndIcon)
+            Divider()
+            statusBar
+        }
+    }
+
+    private var studioSourceList: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text("Foundation Lab")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+
+                Label("Local Evaluation Studio", systemImage: "doc.text.magnifyingglass")
+                    .font(.headline)
+            }
+
+            sourceSection("Workspaces") {
+                ForEach(StudioWorkspace.allCases) { workspace in
+                    sourceRow(
+                        title: workspace.title,
+                        subtitle: workspace.status,
+                        systemImage: workspace.icon,
+                        isSelected: selectedWorkspace == workspace
+                    ) {
+                        selectedWorkspace = workspace
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
             }
-        }
-        .padding()
-#if os(iOS) || os(macOS)
-        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.large))
-#else
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
-#endif
-    }
 
-    private var recentRunsSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            SectionHeader(
-                title: "Run Notes",
-                subtitle: "Seed rows for the first Studio data model."
-            )
-
-            LazyVGrid(columns: runGridColumns, spacing: Spacing.large) {
-                ForEach(StudioRunSummary.samples) { run in
-                    StudioRunCard(run: run)
+            sourceSection("Prompt Sources") {
+                ForEach(StudioPromptVariant.allCases) { variant in
+                    sourceRow(
+                        title: variant.title,
+                        subtitle: selectedPromptVariants.contains(variant) ? "Included" : "Excluded",
+                        systemImage: selectedPromptVariants.contains(variant) ? "checkmark.square.fill" : "square",
+                        isSelected: selectedPromptVariants.contains(variant)
+                    ) {
+                        togglePromptVariant(variant)
+                    }
                 }
-            }
-        }
-    }
-
-    private var referenceLibrarySection: some View {
-        VStack(alignment: .leading, spacing: Spacing.xLarge) {
-            SectionHeader(
-                title: "Reference Library",
-                subtitle: "Current Foundation Lab examples linked from Studio."
-            )
-
-            examplesSection
-            toolsSection
-            schemasSection
-            languagesSection
-        }
-    }
-
-    private var examplesSection: some View {
-        StudioSection(
-            title: "Model Controls",
-            subtitle: "Generation options, guides, and structured output."
-        ) {
-            ForEach(filteredStudioExamples) { exampleType in
-                NavigationLink(value: exampleType) {
-                    GenericCardView(
-                        icon: exampleType.icon,
-                        title: exampleType.title,
-                        subtitle: exampleType.subtitle
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private var toolsSection: some View {
-        StudioSection(
-            title: "Tools",
-            subtitle: "System capabilities the model can call."
-        ) {
-            ForEach(filteredTools, id: \.self) { tool in
-                NavigationLink(value: tool) {
-                    GenericCardView(
-                        icon: tool.icon,
-                        title: tool.displayName,
-                        subtitle: tool.shortDescription
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private var schemasSection: some View {
-        StudioSection(
-            title: "Dynamic Schemas",
-            subtitle: "Build and validate generation schemas."
-        ) {
-            ForEach(filteredSchemas) { example in
-                NavigationLink(value: example) {
-                    GenericCardView(
-                        icon: example.icon,
-                        title: example.title,
-                        subtitle: example.subtitle
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private var languagesSection: some View {
-        StudioSection(
-            title: "Languages",
-            subtitle: "Detect, select, and manage multilingual sessions."
-        ) {
-            ForEach(filteredLanguages) { languageExample in
-                NavigationLink(value: languageExample) {
-                    GenericCardView(
-                        icon: languageExample.icon,
-                        title: languageExample.title,
-                        subtitle: languageExample.subtitle
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private var filteredStudioExamples: [ExampleType] {
-        ExampleType.studioExamples.filter { matches($0.title, $0.subtitle) }
-    }
-
-    private var filteredTools: [ToolExample] {
-        ToolExample.allCases.filter { matches($0.displayName, $0.shortDescription) }
-    }
-
-    private var filteredSchemas: [DynamicSchemaExampleType] {
-        DynamicSchemaExampleType.allCases.filter { matches($0.title, $0.subtitle) }
-    }
-
-    private var filteredLanguages: [LanguageExample] {
-        LanguageExample.allCases.filter { matches($0.title, $0.subtitle) }
-    }
-
-    private var hasResults: Bool {
-        !filteredStudioExamples.isEmpty ||
-        !filteredTools.isEmpty ||
-        !filteredSchemas.isEmpty ||
-        !filteredLanguages.isEmpty
-    }
-
-    private var trimmedSearchText: String {
-        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func matches(_ title: String, _ subtitle: String) -> Bool {
-        let query = trimmedSearchText
-        guard !query.isEmpty else { return true }
-
-        return title.localizedStandardContains(query) ||
-        subtitle.localizedStandardContains(query)
-    }
-}
-
-private struct StudioSection<Content: View>: View {
-    let title: String
-    let subtitle: String
-    @ViewBuilder var content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            SectionHeader(title: title, subtitle: subtitle)
-
-            LazyVGrid(columns: adaptiveGridColumns, spacing: Spacing.large) {
-                content
-            }
-        }
-    }
-
-    private var adaptiveGridColumns: [GridItem] {
-#if os(iOS)
-        [
-            GridItem(.flexible(minimum: 140), spacing: Spacing.large),
-            GridItem(.flexible(minimum: 140), spacing: Spacing.large)
-        ]
-#else
-        [GridItem(.adaptive(minimum: 240), spacing: Spacing.large)]
-#endif
-    }
-}
-
-private struct StudioWorkspaceCard: View {
-    let workspace: StudioWorkspace
-    let isSelected: Bool
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            HStack(alignment: .center, spacing: Spacing.medium) {
-                Image(systemName: workspace.icon)
-                    .font(.title3)
-                    .foregroundStyle(.tint)
-                    .frame(width: 32, height: 32)
-
-                Spacer(minLength: 0)
-
-                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                    .font(.body)
-                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text(workspace.title)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-
-                Text(workspace.subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            HStack(spacing: Spacing.small) {
-                Text(workspace.metricValue)
-                    .font(.title3.bold())
-                    .foregroundStyle(.primary)
-
-                Text(workspace.metricTitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Spacer(minLength: 0)
-            }
-        }
-        .padding()
-        .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
-        .contentShape(.rect)
-#if os(iOS) || os(macOS)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: CornerRadius.large))
-#else
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
-#endif
-        .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.large)
-                .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
-        }
-        .accessibilityElement(children: .combine)
-    }
-}
-
-private struct StudioMetricBlock: View {
-    let title: String
-    let value: String
-    let systemImage: String
-
-    var body: some View {
-        HStack(spacing: Spacing.medium) {
-            Image(systemName: systemImage)
-                .font(.title3)
-                .foregroundStyle(.tint)
-                .frame(width: 34, height: 34)
-
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text(value)
-                    .font(.title2.bold())
-
-                Text(title)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
 
             Spacer(minLength: 0)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.large)
+        .background(.regularMaterial)
     }
-}
 
-private struct StudioRunCard: View {
-    let run: StudioRunSummary
+    private func sourceSection<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(run.name)
-                    .font(.headline)
+            VStack(spacing: Spacing.xSmall) {
+                content()
+            }
+        }
+    }
+
+    private func sourceRow(
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.small) {
+                Image(systemName: systemImage)
+                    .font(.body)
+                    .frame(width: 20)
+
+                Text(title)
                     .lineLimit(1)
 
                 Spacer(minLength: 0)
 
-                Text(run.score)
-                    .font(.headline.monospacedDigit())
-                    .foregroundStyle(.tint)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(isSelected ? .white.opacity(0.86) : .secondary)
+                    .lineLimit(1)
             }
-
-            Text(run.detail)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding()
-        .frame(maxWidth: .infinity, minHeight: 110, alignment: .leading)
-#if os(iOS) || os(macOS)
-        .glassEffect(.regular, in: .rect(cornerRadius: CornerRadius.large))
-#else
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
-#endif
-        .accessibilityElement(children: .combine)
-    }
-}
-
-private struct StudioPill: View {
-    let icon: String
-    let title: String
-
-    var body: some View {
-        Label(title, systemImage: icon)
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(.secondary)
+            .font(.callout)
+            .foregroundStyle(isSelected ? .white : .primary)
             .padding(.horizontal, Spacing.medium)
             .padding(.vertical, Spacing.small)
-            .background(Color.secondaryBackgroundColor, in: .capsule)
-    }
-}
-
-private extension StudioView {
-    var workspaceGridColumns: [GridItem] {
-#if os(iOS)
-        [
-            GridItem(.flexible(minimum: 150), spacing: Spacing.large),
-            GridItem(.flexible(minimum: 150), spacing: Spacing.large)
-        ]
-#else
-        [GridItem(.adaptive(minimum: 220), spacing: Spacing.large)]
-#endif
+            .background(isSelected ? Color.accentColor : Color.clear, in: .rect(cornerRadius: CornerRadius.small))
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
     }
 
-    var detailGridColumns: [GridItem] {
-#if os(iOS)
-        [GridItem(.flexible(minimum: 180), spacing: Spacing.large)]
-#else
-        [
-            GridItem(.fixed(180), spacing: Spacing.large),
-            GridItem(.flexible(minimum: 240), spacing: Spacing.large)
-        ]
-#endif
+    private var stageBar: some View {
+        HStack(spacing: Spacing.large) {
+            Button(action: runPromptTests) {
+                Image(systemName: isRunningPromptTests ? "hourglass" : "play.fill")
+                    .font(.title3)
+                    .frame(width: 34, height: 34)
+            }
+            .buttonStyle(.borderless)
+            .disabled(isRunningPromptTests || !canRunPromptTests)
+            .help("Run selected prompt variants")
+
+            Picker("Stage", selection: $selectedStage) {
+                ForEach(StudioPipelineStage.allCases) { stage in
+                    Label(stage.title, systemImage: stage.systemImage)
+                        .tag(stage)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 560)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.xLarge)
+        .padding(.vertical, Spacing.small)
+        .background(.bar)
     }
 
-    var runGridColumns: [GridItem] {
-#if os(iOS)
-        [GridItem(.flexible(minimum: 220), spacing: Spacing.large)]
-#else
-        [GridItem(.adaptive(minimum: 260), spacing: Spacing.large)]
-#endif
+    private var mainWorkspace: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.xLarge) {
+                workspaceHeader
+                stageContent
+            }
+            .padding(.horizontal, 34)
+            .padding(.vertical, Spacing.xLarge)
+            .frame(maxWidth: 960, alignment: .leading)
+        }
+        .background(.background)
+    }
+
+    private var workspaceHeader: some View {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            Text(selectedWorkspace.title)
+                .font(.title.bold())
+
+            Text(selectedWorkspace.subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var stageContent: some View {
+        switch selectedStage {
+        case .settings:
+            promptSettingsContent
+        case .runs:
+            runsContent
+        case .evaluation:
+            evaluationContent
+        case .preview:
+            previewContent
+        case .output:
+            outputContent
+        }
+    }
+
+    private var promptSettingsContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.xLarge) {
+            settingsPanel(title: "Data") {
+                HStack(alignment: .top, spacing: Spacing.large) {
+                    promptDataSlot(
+                        title: "Base Prompt",
+                        systemImage: "text.quote",
+                        isEnabled: true
+                    ) {
+                        TextEditor(text: $promptText)
+                            .font(.body)
+                            .frame(minHeight: 140)
+                            .scrollContentBackground(.hidden)
+                            .padding(Spacing.small)
+                            .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+                    }
+
+                    promptDataSlot(
+                        title: "Variants",
+                        systemImage: "square.stack.3d.up",
+                        isEnabled: !selectedPromptVariants.isEmpty
+                    ) {
+                        VStack(alignment: .leading, spacing: Spacing.small) {
+                            ForEach(StudioPromptVariant.allCases) { variant in
+                                Toggle(isOn: variantBinding(for: variant)) {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(variant.title)
+                                            .font(.callout)
+                                        Text(variant.subtitle)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            settingsPanel(title: "Parameters") {
+                VStack(spacing: 0) {
+                    parameterRow(title: "Execution", value: "Sequential local runs")
+                    parameterRow(title: "Selected Variants", value: "\(selectedPromptVariants.count)")
+                    parameterRow(title: "Prompt Characters", value: "\(promptText.count)")
+                    parameterRow(title: "Result Capture", value: "Output, latency, token count")
+                }
+            }
+
+            if let promptTestError {
+                Label(promptTestError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func settingsPanel<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            Text(title)
+                .font(.title3.bold())
+
+            content()
+        }
+    }
+
+    private func promptDataSlot<Content: View>(
+        title: String,
+        systemImage: String,
+        isEnabled: Bool,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            HStack {
+                Label(title, systemImage: systemImage)
+                    .font(.headline)
+                    .foregroundStyle(isEnabled ? .primary : .secondary)
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "questionmark.circle")
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.small)
+            .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+
+            content()
+
+            Spacer(minLength: 0)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, minHeight: 260, alignment: .topLeading)
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.small)
+                .stroke(.quaternary, lineWidth: 1)
+        }
+    }
+
+    private func parameterRow(title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.callout.weight(.medium))
+                .frame(width: 170, alignment: .trailing)
+
+            Text(value)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.large)
+        .padding(.vertical, Spacing.medium)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    private var runsContent: some View {
+        Group {
+            if promptRuns.isEmpty {
+                unavailableState(
+                    title: "Prompt runs unavailable",
+                    subtitle: "Set up the prompt source and run selected variants to view run progress."
+                )
+            } else {
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    ForEach(promptRuns) { run in
+                        runRow(run)
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    private func runRow(_ run: StudioPromptRun) -> some View {
+        HStack(alignment: .top, spacing: Spacing.large) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(run.variant.title)
+                    .font(.headline)
+                Text(run.finishedAt, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 150, alignment: .leading)
+
+            Text(run.output)
+                .font(.callout)
+                .lineLimit(4)
+                .textSelection(.enabled)
+
+            Spacer(minLength: 0)
+
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(run.durationLabel)
+                    .font(.headline.monospacedDigit())
+                Text(run.tokenLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, Spacing.small)
+    }
+
+    private var evaluationContent: some View {
+        Group {
+            if promptRuns.isEmpty {
+                unavailableState(
+                    title: "Evaluation unavailable",
+                    subtitle: "Run at least one variant to compare latency, tokens, and answer shape."
+                )
+            } else {
+                VStack(alignment: .leading, spacing: Spacing.large) {
+                    settingsPanel(title: "Comparison") {
+                        VStack(spacing: 0) {
+                            ForEach(promptRuns) { run in
+                                parameterRow(title: run.variant.title, value: "\(run.durationLabel) • \(run.tokenLabel)")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var previewContent: some View {
+        Group {
+            if let latestRun = promptRuns.first {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
+                    Text(latestRun.variant.title)
+                        .font(.title3.bold())
+                    Text(latestRun.output)
+                        .font(.body)
+                        .textSelection(.enabled)
+                }
+            } else {
+                unavailableState(
+                    title: "Preview unavailable",
+                    subtitle: "Run a prompt variant to preview the most recent generated output."
+                )
+            }
+        }
+    }
+
+    private var outputContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            settingsPanel(title: "Run Artifact") {
+                VStack(spacing: 0) {
+                    parameterRow(title: "Format", value: "Studio run summary")
+                    parameterRow(title: "Runs", value: "\(promptRuns.count)")
+                    parameterRow(title: "Status", value: promptRuns.isEmpty ? "No exportable runs" : "Ready")
+                }
+            }
+
+            Button {
+                selectedStage = .runs
+            } label: {
+                Label("Review Runs", systemImage: "doc.text.magnifyingglass")
+            }
+            .disabled(promptRuns.isEmpty)
+        }
+    }
+
+    private func unavailableState(title: String, subtitle: String) -> some View {
+        VStack(spacing: Spacing.medium) {
+            Spacer(minLength: 120)
+
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            Text(subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Spacer(minLength: 120)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var activityInspector: some View {
+        VStack(spacing: 0) {
+            activityInspectorContent
+            Spacer(minLength: 0)
+        }
+        .background(Color.secondaryBackgroundColor.opacity(0.45))
+    }
+
+    private var activityInspectorContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            inspectorMetrics
+
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                HStack {
+                    Text("Activity")
+                        .font(.headline)
+                    Spacer()
+                    Text(Date.now, style: .date)
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+
+                ForEach(activityEvents) { event in
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text(event.title)
+                                .font(.callout)
+                            Spacer()
+                            Text(event.date, style: .time)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text(event.detail)
+                            .font(.callout.weight(.semibold))
+                    }
+                    .padding(.vertical, Spacing.small)
+
+                    Divider()
+                }
+            }
+        }
+        .padding(Spacing.large)
+    }
+
+    private var inspectorMetrics: some View {
+        HStack(spacing: 0) {
+            inspectorMetric(value: "\(promptRuns.count)", title: "Runs")
+            Divider()
+            inspectorMetric(value: averageDurationLabel, title: "Average")
+            Divider()
+            inspectorMetric(value: "\(selectedPromptVariants.count)", title: "Variants")
+        }
+        .frame(height: 52)
+    }
+
+    private func inspectorMetric(value: String, title: String) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.headline.monospacedDigit())
+                .lineLimit(1)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var compactWorkspacePicker: some View {
+        Picker("Workspace", selection: $selectedWorkspace) {
+            ForEach(StudioWorkspace.allCases) { workspace in
+                Label(workspace.title, systemImage: workspace.icon)
+                    .tag(workspace)
+            }
+        }
+        .pickerStyle(.menu)
+    }
+
+    private var statusBar: some View {
+        HStack(spacing: Spacing.small) {
+            Image(systemName: statusIcon)
+                .foregroundStyle(statusColor)
+
+            Text(statusText)
+                .font(.callout.weight(.medium))
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.medium)
+        .padding(.vertical, Spacing.xSmall)
+        .background(.bar)
+    }
+
+    private var canRunPromptTests: Bool {
+        selectedWorkspace == .promptTesting &&
+        !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !selectedPromptVariants.isEmpty
+    }
+
+    private var averageDurationLabel: String {
+        guard !promptRuns.isEmpty else { return "--" }
+        let totalDuration = promptRuns.reduce(0) { $0 + $1.duration }
+        return (totalDuration / Double(promptRuns.count)).formatted(.number.precision(.fractionLength(2))) + "s"
+    }
+
+    private var activityEvents: [StudioActivityEvent] {
+        if promptRuns.isEmpty {
+            return [
+                StudioActivityEvent(
+                    title: "Studio Created",
+                    detail: "Local Evaluation Studio",
+                    date: Date.now
+                )
+            ]
+        }
+
+        return promptRuns.prefix(6).map {
+            StudioActivityEvent(
+                title: "Prompt Variant Completed",
+                detail: $0.variant.title,
+                date: $0.finishedAt
+            )
+        }
+    }
+
+    private var statusIcon: String {
+        if isRunningPromptTests { return "hourglass" }
+        if promptRuns.isEmpty { return "info.circle.fill" }
+        return "checkmark.circle.fill"
+    }
+
+    private var statusColor: Color {
+        if isRunningPromptTests { return .orange }
+        if promptRuns.isEmpty { return .secondary }
+        return .green
+    }
+
+    private var statusText: String {
+        if isRunningPromptTests { return "Running selected prompt variants" }
+        if promptRuns.isEmpty { return "Prompt run required" }
+        return "\(promptRuns.count) prompt runs completed"
+    }
+
+    private func variantBinding(for variant: StudioPromptVariant) -> Binding<Bool> {
+        Binding {
+            selectedPromptVariants.contains(variant)
+        } set: { isSelected in
+            if isSelected {
+                selectedPromptVariants.insert(variant)
+            } else {
+                selectedPromptVariants.remove(variant)
+            }
+        }
+    }
+
+    private func togglePromptVariant(_ variant: StudioPromptVariant) {
+        if selectedPromptVariants.contains(variant) {
+            selectedPromptVariants.remove(variant)
+        } else {
+            selectedPromptVariants.insert(variant)
+        }
+    }
+
+    private func runPromptTests() {
+        Task {
+            await performPromptTests()
+        }
+    }
+
+    @MainActor
+    private func performPromptTests() async {
+        let trimmedPrompt = promptText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty, !selectedPromptVariants.isEmpty else { return }
+
+        isRunningPromptTests = true
+        promptTestError = nil
+        selectedStage = .runs
+
+        var newRuns: [StudioPromptRun] = []
+        let variants = StudioPromptVariant.allCases.filter { selectedPromptVariants.contains($0) }
+
+        do {
+            for variant in variants {
+                let startedAt = Date()
+                let result = try await generateTextUseCase.execute(
+                    TextGenerationRequest(
+                        prompt: trimmedPrompt,
+                        systemPrompt: variant.systemPrompt,
+                        generationOptions: variant.generationOptions,
+                        context: CapabilityInvocationContext(
+                            source: .app,
+                            localeIdentifier: Locale.current.identifier
+                        )
+                    )
+                )
+
+                newRuns.append(
+                    StudioPromptRun(
+                        variant: variant,
+                        prompt: trimmedPrompt,
+                        output: result.content,
+                        duration: Date().timeIntervalSince(startedAt),
+                        tokenCount: result.metadata.tokenCount,
+                        finishedAt: Date()
+                    )
+                )
+            }
+
+            promptRuns = newRuns + promptRuns
+        } catch {
+            promptTestError = error.localizedDescription
+            selectedStage = .settings
+        }
+
+        isRunningPromptTests = false
     }
 }
 

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -18,6 +18,7 @@ struct StudioView: View {
     @State private var promptRuns: [StudioPromptRun] = []
     @State private var isRunningPromptTests = false
     @State private var promptTestError: String?
+    @State private var studioCreatedAt = Date.now
 
     private let generateTextUseCase = GenerateTextUseCase()
 
@@ -438,7 +439,7 @@ struct StudioView: View {
 
     private var previewContent: some View {
         Group {
-            if let latestRun = promptRuns.first {
+            if let latestRun = latestFinishedRun {
                 VStack(alignment: .leading, spacing: Spacing.medium) {
                     Text(latestRun.variant.title)
                         .font(.title3.bold())
@@ -597,19 +598,25 @@ struct StudioView: View {
         return (totalDuration / Double(promptRuns.count)).formatted(.number.precision(.fractionLength(2))) + "s"
     }
 
+    private var latestFinishedRun: StudioPromptRun? {
+        promptRuns.max { $0.finishedAt < $1.finishedAt }
+    }
+
     private var activityEvents: [StudioActivityEvent] {
         if promptRuns.isEmpty {
             return [
                 StudioActivityEvent(
+                    id: "studio-created",
                     title: "Studio Created",
                     detail: "Local Evaluation Studio",
-                    date: Date.now
+                    date: studioCreatedAt
                 )
             ]
         }
 
         return promptRuns.prefix(6).map {
             StudioActivityEvent(
+                id: $0.id.uuidString,
                 title: "Prompt Variant Completed",
                 detail: $0.variant.title,
                 date: $0.finishedAt

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -495,7 +495,9 @@ struct StudioView: View {
 
     private var runsContent: some View {
         Group {
-            if promptRuns.isEmpty {
+            if promptRuns.isEmpty, isRunningPromptTests {
+                runningPromptState
+            } else if promptRuns.isEmpty {
                 unavailableState(
                     title: "Prompt runs unavailable",
                     subtitle: "Set up the prompt source and run selected variants to view run progress."
@@ -509,6 +511,26 @@ struct StudioView: View {
                 }
             }
         }
+    }
+
+    private var runningPromptState: some View {
+        VStack(spacing: Spacing.medium) {
+            Spacer(minLength: 120)
+
+            ProgressView()
+                .controlSize(.large)
+
+            Text("Running selected variants")
+                .font(.headline)
+
+            Text("Results will appear here as soon as the first prompt run finishes.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Spacer(minLength: 120)
+        }
+        .frame(maxWidth: .infinity)
     }
 
     private func runRow(_ run: StudioPromptRun) -> some View {

--- a/Foundation Lab/Views/Tools/ToolsView.swift
+++ b/Foundation Lab/Views/Tools/ToolsView.swift
@@ -111,9 +111,9 @@ struct ToolButton: View {
     .padding()
     .frame(maxWidth: .infinity, minHeight: 140)
     .contentShape(.rect)
-    .background(isSelected ? Color.main : Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+    .background(isSelected ? Color.main : Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
     .overlay {
-      RoundedRectangle(cornerRadius: CornerRadius.small)
+      RoundedRectangle(cornerRadius: CornerRadius.large)
         .stroke(isSelected ? Color.clear : Color.secondary.opacity(0.2), lineWidth: 1)
     }
     .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isSelected)

--- a/Foundation Lab/Views/Tools/ToolsView.swift
+++ b/Foundation Lab/Views/Tools/ToolsView.swift
@@ -13,8 +13,6 @@ import SwiftUI
 #endif
 
 struct ToolsView: View {
-  @Namespace private var glassNamespace
-
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 20) {
@@ -29,39 +27,19 @@ struct ToolsView: View {
   }
 
   private var toolButtonsView: some View {
-    #if os(iOS) || os(macOS)
-      GlassEffectContainer(spacing: gridSpacing) {
-        LazyVGrid(columns: adaptiveGridColumns, spacing: gridSpacing) {
-          ForEach(ToolExample.allCases, id: \.self) { tool in
-            NavigationLink(value: tool) {
-              ToolButton(
-                tool: tool,
-                isSelected: false,
-                isRunning: false,
-                namespace: glassNamespace
-              )
-            }
-            .buttonStyle(PlainButtonStyle())
-          }
+    LazyVGrid(columns: adaptiveGridColumns, spacing: gridSpacing) {
+      ForEach(ToolExample.allCases, id: \.self) { tool in
+        NavigationLink(value: tool) {
+          ToolButton(
+            tool: tool,
+            isSelected: false,
+            isRunning: false
+          )
         }
+        .buttonStyle(PlainButtonStyle())
       }
-      .padding(.horizontal)
-    #else
-      LazyVGrid(columns: adaptiveGridColumns, spacing: gridSpacing) {
-        ForEach(ToolExample.allCases, id: \.self) { tool in
-          NavigationLink(value: tool) {
-            ToolButton(
-              tool: tool,
-              isSelected: false,
-              isRunning: false,
-              namespace: glassNamespace
-            )
-          }
-          .buttonStyle(PlainButtonStyle())
-        }
-      }
-      .padding(.horizontal)
-    #endif
+    }
+    .padding(.horizontal)
   }
 
   private var adaptiveGridColumns: [GridItem] {
@@ -100,7 +78,6 @@ struct ToolButton: View {
   let tool: ToolExample
   let isSelected: Bool
   let isRunning: Bool
-  let namespace: Namespace.ID
 
   var body: some View {
     VStack(spacing: 12) {
@@ -134,13 +111,11 @@ struct ToolButton: View {
     .padding()
     .frame(maxWidth: .infinity, minHeight: 140)
     .contentShape(.rect)
-    #if os(iOS) || os(macOS)
-      .glassEffect(
-        isSelected ? .regular.tint(.main).interactive(true) : .regular.interactive(true),
-        in: .rect(cornerRadius: 12)
-      )
-      .glassEffectID("tool-\(tool.rawValue)", in: namespace)
-    #endif
+    .background(isSelected ? Color.main : Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
+    .overlay {
+      RoundedRectangle(cornerRadius: CornerRadius.small)
+        .stroke(isSelected ? Color.clear : Color.secondary.opacity(0.2), lineWidth: 1)
+    }
     .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isSelected)
     .animation(.spring(response: 0.3, dampingFraction: 0.9), value: isRunning)
     .accessibilityElement(children: .combine)


### PR DESCRIPTION
## Summary
- Keeps the product/app name as `Foundation Lab` and treats `Studio` as the dedicated workspace tab.
- Reframes the existing Studio tab from a catalog-only page into a first product-direction slice for prompt testing, structured-output validation, benchmark runs, and capability comparison.
- Preserves existing Studio navigation to examples, tools, dynamic schemas, and languages through a Reference Library section.

## Verification
- `swift test` in `FoundationLabCore` passed: 26 XCTest tests + 4 Swift Testing tests.
- `xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=macOS" build` succeeded.
- `xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5" build` succeeded.
- Naming scan found no `Foundation Studio` / `FoundationStudio` strings; app naming remains `Foundation Lab`.

## Notes
This is intentionally a brainstorm/product-shape PR, not the full eval engine yet. The next real slice should wire the Prompt Testing workspace to an executable local run model.