### PR TITLE
Update Foundation Models docs for Xcode 27

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-Foundation Lab is an iOS/macOS app demonstrating Apple's Foundation Models framework (iOS 26.0+/macOS 26.0+). It accompanies the "Exploring Foundation Models" book and showcases:
+Foundation Lab is an iOS/macOS app demonstrating Apple's Foundation Models framework (iOS 26.0+/macOS 26.0+). Xcode 27 adds new Foundation Models APIs for Private Cloud Compute, image attachments, shared `LanguageModel` execution, and explicit tool-calling control. It accompanies the "Exploring Foundation Models" book and showcases:
 - Multi-turn chat with streaming responses using `LanguageModelSession`
 - 9 system integration tools (Weather, Web Search, Contacts, Calendar, Reminders, Location, Health, Music, Web Metadata)
 - Voice interface with speech-to-text (`SpeechRecognitionStateMachine`) and text-to-speech
@@ -26,7 +26,7 @@ xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destinatio
 xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath ./build test
 ```
 
-**Requirements:** Xcode 26.0+, iOS 26.0+/macOS 26.0+, Apple Silicon device with Apple Intelligence.
+**Requirements:** Xcode 27 beta, iOS 26.0+/macOS 26.0+, Apple Silicon device with Apple Intelligence. Xcode 27 is required for `PrivateCloudComputeLanguageModel`, image attachments, `GenerationOptions.toolCallingMode`, and the `samplingMode` spelling.
 
 **Dependencies (SPM):**
 - `HighlightSwift` - Syntax highlighting

--- a/BookPlaygrounds/03_GenerationOptionsAndSamplingControl/05_SamplingStrategies.swift
+++ b/BookPlaygrounds/03_GenerationOptionsAndSamplingControl/05_SamplingStrategies.swift
@@ -8,7 +8,7 @@ import Playgrounds
     // Greedy sampling - always chooses most likely token
     debugPrint("Greedy Sampling (Deterministic)")
     let greedyOptions = GenerationOptions(
-        sampling: .greedy,
+        samplingMode: .greedy,
         temperature: nil // Temperature is ignored with greedy sampling
     )
     let greedyResponse = try await session.respond(to: prompt, options: greedyOptions)
@@ -17,7 +17,7 @@ import Playgrounds
     // Top-K sampling with smaller K (more deterministic)
     debugPrint("Top-K Sampling (K=30, More Focused)")
     let topKSmallOptions = GenerationOptions(
-        sampling: .random(top: 30, seed: nil),
+        samplingMode: .random(top: 30, seed: nil),
         temperature: 0.7
     )
     let topKSmallResponse = try await session.respond(to: prompt, options: topKSmallOptions)
@@ -26,7 +26,7 @@ import Playgrounds
     // Top-K sampling with larger K (more creative)
     debugPrint("Top-K Sampling (K=50, More Creative)")
     let topKLargeOptions = GenerationOptions(
-        sampling: .random(top: 50, seed: nil),
+        samplingMode: .random(top: 50, seed: nil),
         temperature: 0.7
     )
     let topKLargeResponse = try await session.respond(to: prompt, options: topKLargeOptions)
@@ -35,7 +35,7 @@ import Playgrounds
     // Top-P sampling with conservative threshold
     debugPrint("Top-P Sampling (P=0.8, Conservative)")
     let topPConservativeOptions = GenerationOptions(
-        sampling: .random(probabilityThreshold: 0.8, seed: nil),
+        samplingMode: .random(probabilityThreshold: 0.8, seed: nil),
         temperature: 0.6
     )
     let topPConservativeResponse = try await session.respond(to: prompt, options: topPConservativeOptions)
@@ -44,7 +44,7 @@ import Playgrounds
     // Top-P sampling with higher threshold
     debugPrint("Top-P Sampling (P=0.9, More Creative)")
     let topPCreativeOptions = GenerationOptions(
-        sampling: .random(probabilityThreshold: 0.9, seed: nil),
+        samplingMode: .random(probabilityThreshold: 0.9, seed: nil),
         temperature: 0.7
     )
     let topPCreativeResponse = try await session.respond(to: prompt, options: topPCreativeOptions)
@@ -53,7 +53,7 @@ import Playgrounds
     // Reproducible results with seed
     debugPrint("Reproducible Results (With Seed)")
     let seededOptions = GenerationOptions(
-        sampling: .random(top: 30, seed: 12345),
+        samplingMode: .random(top: 30, seed: 12345),
         temperature: 0.8
     )
     let seededResponse1 = try await session.respond(to: prompt, options: seededOptions)
@@ -65,7 +65,7 @@ import Playgrounds
     // System default (recommended)
     debugPrint("System Default (Recommended)")
     let systemDefaultOptions = GenerationOptions(
-        sampling: nil,
+        samplingMode: nil,
         temperature: nil
     )
     let systemDefaultResponse = try await session.respond(to: prompt, options: systemDefaultOptions)

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsConfigurationAdapters.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsConfigurationAdapters.swift
@@ -37,7 +37,7 @@ extension FoundationLabGenerationOptions.SamplingMode {
 extension FoundationLabGenerationOptions {
     var foundationModelsValue: GenerationOptions {
         GenerationOptions(
-            sampling: sampling?.foundationModelsValue,
+            samplingMode: sampling?.foundationModelsValue,
             temperature: temperature,
             maximumResponseTokens: maximumResponseTokens
         )

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsTranscriptTokenCounting.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsTranscriptTokenCounting.swift
@@ -17,6 +17,11 @@ extension Transcript.Entry {
             }
         case .toolOutput(let output):
             return output.segments.reduce(0) { $0 + $1.foundationLabEstimatedTokenCount } + 3
+        case .reasoning(let reasoning):
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                return reasoning.segments.reduce(0) { $0 + $1.foundationLabEstimatedTokenCount } + 3
+            }
+            return 0
         @unknown default:
             return 0
         }
@@ -43,6 +48,16 @@ extension Transcript.Segment {
             return foundationLabEstimateTokens(textSegment.content)
         case .structure(let structuredSegment):
             return foundationLabEstimateStructuredTokens(structuredSegment.content)
+        case .attachment(let attachmentSegment):
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                return foundationLabEstimateTokens(attachmentSegment.label ?? "image attachment") + 12
+            }
+            return 0
+        case .custom(let customSegment):
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                return foundationLabEstimateTokens(customSegment.description)
+            }
+            return 0
         @unknown default:
             return 0
         }

--- a/README.md
+++ b/README.md
@@ -38,10 +38,21 @@ It is part of the [Exploring Foundation Models](https://academy.rudrank.com/prod
 
 ## Requirements
 
-- iOS 26.0+ or macOS 26.0+ (Xcode 26.0+)
-- **Xcode 26 official is required**
+- iOS 26.0+ or macOS 26.0+
+- **Xcode 27 beta is required** for the latest Foundation Models APIs used in this repo
 - Apple Intelligence enabled
 - Compatible Apple device with Apple Silicon
+
+## Xcode 27 Foundation Models Notes
+
+Xcode 27 adds several Foundation Models surfaces that are not available in the Xcode 26 SDK:
+
+- `PrivateCloudComputeLanguageModel` for Private Cloud Compute-backed language model sessions, with availability, quota usage, context size, supported languages, and network/quota/service errors.
+- `LanguageModel` and executor APIs that abstract over `SystemLanguageModel` and `PrivateCloudComputeLanguageModel`.
+- Image attachments and references through `Attachment<ImageAttachmentContent>` and `ImageReference`, including UIKit convenience initializers through the new `_FoundationModels_UIKit` overlay.
+- `GenerationOptions.samplingMode`, replacing the deprecated `sampling` spelling.
+- `GenerationOptions.toolCallingMode` with `.allowed`, `.required`, and `.disallowed`.
+- Foundation Models types are now available to watchOS 27 for many prompting, schema, transcript, tool, and feedback surfaces, while tvOS remains unavailable.
 
 ## Try it on TestFlight
 

--- a/fmf.md
+++ b/fmf.md
@@ -1,3 +1,188 @@
+## Xcode 27 Foundation Models API Delta
+
+Source: `/Users/rudrank/Downloads/Xcode-beta.app` (`Xcode 27.0`, build `27A5194q`), iOS SDK interface:
+`Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/FoundationModels.framework/Modules/FoundationModels.swiftmodule/arm64e-apple-ios.swiftinterface`.
+
+This section records the new public API shape found in Xcode 27. The older commented reference below remains useful for the Xcode 26-era API documentation.
+
+### Private Cloud Compute model
+
+```swift
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+@available(tvOS, unavailable)
+final public class PrivateCloudComputeLanguageModel: Sendable, Observable, LanguageModel {
+    public convenience init()
+
+    public var availability: PrivateCloudComputeLanguageModel.Availability { get }
+    public var quotaUsage: PrivateCloudComputeLanguageModel.QuotaUsage { get }
+    public var isAvailable: Bool { get }
+    public var capabilities: LanguageModelCapabilities { get }
+    public var contextSize: Int { get async throws }
+    public var supportedLanguages: Set<Locale.Language> { get }
+
+    public func supportsLocale(_ locale: Locale = .current) -> Bool
+}
+```
+
+`PrivateCloudComputeLanguageModel.Availability.UnavailableReason` has `deviceNotEligible` and `systemNotReady`. `PrivateCloudComputeLanguageModel.Error` adds `networkFailure`, `quotaLimitReached`, and `serviceUnavailable`. Quota usage reports whether the limit is reached, when it resets, and may expose a `LimitIncreaseSuggestion.show()` action.
+
+### Shared language model execution
+
+```swift
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+extension SystemLanguageModel: LanguageModel {
+    public var capabilities: LanguageModelCapabilities { get }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+@available(tvOS, unavailable)
+public protocol LanguageModel: Sendable {
+    var capabilities: LanguageModelCapabilities { get }
+}
+```
+
+`LanguageModelCapabilities` includes `.vision`, `.guidedGeneration`, `.reasoning`, and `.toolCalling`.
+
+### Dynamic instructions and profiles
+
+Xcode 27 adds a richer session configuration DSL:
+
+```swift
+public protocol DynamicInstructions { associatedtype Body: DynamicInstructions }
+public struct AnyDynamicInstructions: DynamicInstructions
+public struct DynamicInstructionsBuilder
+
+extension LanguageModelSession {
+    public struct Profile
+    public protocol DynamicProfile
+
+    public convenience init(profile: LanguageModelSession.Profile, history: Transcript = Transcript())
+    public convenience init(
+        model: some LanguageModel,
+        dynamicInstructions: some DynamicInstructions,
+        history: Transcript = Transcript()
+    )
+}
+```
+
+Dynamic profile modifiers include model selection, temperature, `samplingMode`, `maximumResponseTokens`, `reasoningLevel`, `toolCallingMode`, history transforms, and lifecycle hooks such as prompt, response, tool-call, and tool-output handlers.
+
+### Image attachments and generated image references
+
+```swift
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+@available(tvOS, unavailable)
+public struct Attachment<Content> where Content: AttachmentContent {
+    public func label(_ label: String) -> Attachment<Content>
+}
+
+public struct ImageAttachmentContent: AttachmentContent, Sendable, Equatable {}
+
+extension Attachment where Content == ImageAttachmentContent {
+    public init(_ cgImage: CGImage, orientation: CGImagePropertyOrientation? = nil)
+    public init(_ ciImage: CIImage, orientation: CGImagePropertyOrientation? = nil)
+    public init(_ pixelBuffer: CVPixelBuffer, orientation: CGImagePropertyOrientation? = nil)
+    public init(imageURL: URL, orientation: CGImagePropertyOrientation? = nil)
+}
+
+public struct ImageReference: Sendable, Equatable, Generable {
+    public let attachmentLabel: String
+    public func resolve(in transcript: Transcript) -> Transcript.ImageAttachment?
+}
+```
+
+The `_FoundationModels_UIKit` overlay also adds:
+
+```swift
+extension Attachment where Content == ImageAttachmentContent {
+    public init(_ uiImage: UIImage, orientation: UIImage.Orientation? = nil)
+}
+```
+
+### Generation options
+
+```swift
+public struct GenerationOptions: Sendable, Equatable {
+    @available(*, deprecated, renamed: "samplingMode")
+    public var sampling: GenerationOptions.SamplingMode?
+
+    public var samplingMode: GenerationOptions.SamplingMode?
+    public var temperature: Double?
+    public var maximumResponseTokens: Int?
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    public var toolCallingMode: GenerationOptions.ToolCallingMode?
+}
+
+extension GenerationOptions.ToolCallingMode {
+    public static let allowed: GenerationOptions.ToolCallingMode
+    public static let required: GenerationOptions.ToolCallingMode
+    public static let disallowed: GenerationOptions.ToolCallingMode
+}
+```
+
+The Xcode 26 `GenerationOptions(sampling:temperature:maximumResponseTokens:)` initializer is deprecated in favor of `GenerationOptions(samplingMode:temperature:maximumResponseTokens:)`.
+
+### Context options and reasoning
+
+```swift
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+public struct ContextOptions: Sendable, Equatable {
+    public enum ReasoningLevel: Sendable, Equatable {
+        case light
+        case moderate
+        case deep
+        case custom(String)
+    }
+
+    public var includeSchemaInPrompt: Bool?
+    public var reasoningLevel: ContextOptions.ReasoningLevel?
+}
+```
+
+Newer response and streaming overloads can carry context options and metadata, so schema inclusion and reasoning level are no longer only ad hoc overload arguments.
+
+### Transcript and response changes
+
+```swift
+extension Transcript.Entry {
+    case reasoning(Transcript.Reasoning)
+}
+
+extension Transcript.Segment {
+    case attachment(Transcript.AttachmentSegment)
+    case custom(any Transcript.CustomSegment)
+}
+
+extension LanguageModelSession.Response {
+    public let usage: LanguageModelSession.Usage
+}
+```
+
+`Transcript.StructuredSegment.source` is deprecated in favor of `schemaName`, with `init(id:schemaName:content:)` replacing `init(id:source:content:)` for Xcode 27 code. `Transcript` also gains mutable/range-replaceable collection behavior.
+
+`LanguageModelSession.GenerationError.concurrentRequests` is deprecated in favor of `LanguageModelSession.Error.concurrentRequests`.
+
+### Adapter migration
+
+`SystemLanguageModel.init(adapter:guardrails:)` is obsoleted for iOS, macOS, and visionOS 27. Keep adapter examples guarded for 26.x and prefer the new `LanguageModel` / `LanguageModelExecutor` direction for Xcode 27-era custom model behavior.
+
+### Related framework overlays
+
+Xcode 27 ships additional Foundation Models bridge frameworks:
+
+- `_FoundationModels_UIKit` adds `Attachment(UIImage, orientation:)`.
+- `_FoundationModels_AppKit` provides macOS image attachment bridging.
+- `_FoundationModels_SwiftUI` re-exports FoundationModels for SwiftUI integration.
+- `_Vision_FoundationModels` exposes vision-oriented tools such as OCR and barcode reading.
+- `_CoreSpotlight_FoundationModels` exposes Spotlight/file search tooling.
+
+### Platform availability
+
+Many Foundation Models prompting, schema, transcript, tool, feedback, and dynamic generation types now include `watchOS 27.0` availability. `tvOS` remains unavailable in the public API annotations even though Xcode 27 ships tvOS framework stubs.
+
 import BackgroundAssets
 import CoreGraphics
 import Foundation
@@ -4667,4 +4852,3 @@ extension Array : PromptRepresentable where Element : PromptRepresentable {
     /// An instance that represents a prompt.
     public var promptRepresentation: Prompt { get }
 }
-


### PR DESCRIPTION
## Summary
- document the Xcode 27 FoundationModels API delta in fmf.md, including PrivateCloudComputeLanguageModel, shared LanguageModel execution, dynamic profiles, image attachments, tool calling controls, and related overlays
- migrate GenerationOptions usage from sampling to samplingMode for the Xcode 27 SDK
- handle new transcript segment cases introduced by Xcode 27 and refresh README/Agents requirements notes

## Verification
- DEVELOPER_DIR=/Users/rudrank/Downloads/Xcode-beta.app/Contents/Developer swift build (in FoundationLabCore)
- DEVELOPER_DIR=/Users/rudrank/Downloads/Xcode-beta.app/Contents/Developer xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath ./build-xcode27 build