### PR TITLE
Add Xcode 27 Foundation Models examples

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -17,6 +17,14 @@ enum ExampleType: String, CaseIterable, Identifiable {
     case modelAvailability = "model_availability"
     case generationGuides = "generation_guides"
     case generationOptions = "generation_options"
+    case modelRuntime = "model_runtime"
+    case contextWindowInspector = "context_window_inspector"
+    case privateCloudCompute = "private_cloud_compute"
+    case imageInputPlayground = "image_input_playground"
+    case toolCallingModeLab = "tool_calling_mode_lab"
+    case dynamicProfileBuilder = "dynamic_profile_builder"
+    case reasoningLevelComparison = "reasoning_level_comparison"
+    case transcriptExplorer = "transcript_explorer"
     case health = "health"
     case rag = "rag"
     case chat = "chat"
@@ -41,6 +49,22 @@ enum ExampleType: String, CaseIterable, Identifiable {
             return "Generation Guides"
         case .generationOptions:
             return "Generation Options"
+        case .modelRuntime:
+            return "Model Runtime"
+        case .contextWindowInspector:
+            return "Context Window"
+        case .privateCloudCompute:
+            return "Private Cloud"
+        case .imageInputPlayground:
+            return "Image Input"
+        case .toolCallingModeLab:
+            return "Tool Modes"
+        case .dynamicProfileBuilder:
+            return "Dynamic Profile"
+        case .reasoningLevelComparison:
+            return "Reasoning Levels"
+        case .transcriptExplorer:
+            return "Transcript Explorer"
         case .health:
             return "Health Dashboard"
         case .rag:
@@ -68,6 +92,22 @@ enum ExampleType: String, CaseIterable, Identifiable {
             return "Guided generation with constraints"
         case .generationOptions:
             return "Experiment with model parameters"
+        case .modelRuntime:
+            return "Compare system and cloud model surfaces"
+        case .contextWindowInspector:
+            return "Inspect context size and token budget"
+        case .privateCloudCompute:
+            return "Probe PCC availability, quota, and context size"
+        case .imageInputPlayground:
+            return "Explore image attachments and references"
+        case .toolCallingModeLab:
+            return "Compare allowed, required, and disallowed tools"
+        case .dynamicProfileBuilder:
+            return "Compose Xcode 27 session profiles"
+        case .reasoningLevelComparison:
+            return "Compare light, moderate, and deep reasoning"
+        case .transcriptExplorer:
+            return "Browse reasoning, attachments, and custom segments"
         case .health:
             return "AI-powered health insights and tracking"
         case .rag:
@@ -95,6 +135,22 @@ enum ExampleType: String, CaseIterable, Identifiable {
             return "slider.horizontal.3"
         case .generationOptions:
             return "tuningfork"
+        case .modelRuntime:
+            return "cpu"
+        case .contextWindowInspector:
+            return "text.page.badge.magnifyingglass"
+        case .privateCloudCompute:
+            return "icloud.and.arrow.up"
+        case .imageInputPlayground:
+            return "photo.on.rectangle.angled"
+        case .toolCallingModeLab:
+            return "hammer"
+        case .dynamicProfileBuilder:
+            return "slider.horizontal.below.rectangle"
+        case .reasoningLevelComparison:
+            return "brain.head.profile"
+        case .transcriptExplorer:
+            return "list.bullet.rectangle.portrait"
         case .health:
             return "heart.fill"
         case .rag:

--- a/Foundation Lab/Views/Examples/ExampleType+Destination.swift
+++ b/Foundation Lab/Views/Examples/ExampleType+Destination.swift
@@ -28,6 +28,22 @@ extension ExampleType {
             ModelAvailabilityView()
         case .generationOptions:
             GenerationOptionsView()
+        case .modelRuntime:
+            ModelRuntimeView()
+        case .contextWindowInspector:
+            ContextWindowInspectorView()
+        case .privateCloudCompute:
+            PrivateCloudComputeView()
+        case .imageInputPlayground:
+            ImageInputPlaygroundView()
+        case .toolCallingModeLab:
+            ToolCallingModeLabView()
+        case .dynamicProfileBuilder:
+            DynamicProfileBuilderView()
+        case .reasoningLevelComparison:
+            ReasoningLevelComparisonView()
+        case .transcriptExplorer:
+            TranscriptExplorerView()
         case .health:
             HealthExampleView()
         case .rag:
@@ -39,7 +55,10 @@ extension ExampleType {
 
     var preferredTab: TabSelection {
         switch self {
-        case .structuredData, .generationGuides, .generationOptions:
+        case .structuredData, .generationGuides, .generationOptions, .modelRuntime,
+             .contextWindowInspector, .privateCloudCompute, .imageInputPlayground,
+             .toolCallingModeLab, .dynamicProfileBuilder, .reasoningLevelComparison,
+             .transcriptExplorer:
             return .lab
         case .health, .rag:
             return .insights
@@ -55,7 +74,19 @@ extension ExampleType {
     }
 
     static var studioExamples: [ExampleType] {
-        [.structuredData, .generationGuides, .generationOptions]
+        [
+            .structuredData,
+            .generationGuides,
+            .generationOptions,
+            .modelRuntime,
+            .contextWindowInspector,
+            .privateCloudCompute,
+            .imageInputPlayground,
+            .toolCallingModeLab,
+            .dynamicProfileBuilder,
+            .reasoningLevelComparison,
+            .transcriptExplorer
+        ]
     }
 
     static var insightExamples: [ExampleType] {

--- a/Foundation Lab/Views/Examples/Xcode27/ContextWindowInspectorView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextWindowInspectorView.swift
@@ -1,0 +1,151 @@
+//
+//  ContextWindowInspectorView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import FoundationModels
+import SwiftUI
+
+struct ContextWindowInspectorView: View {
+    @State private var currentPrompt = """
+    You are a helpful assistant. Explain Foundation Models, then call tools if needed.
+    """
+    @State private var instructionsTokens = 180
+    @State private var promptTokens = 120
+    @State private var schemaTokens = 520
+    @State private var toolTokens = 740
+    @State private var historyTokens = 1_240
+    @State private var responseReserveTokens = 600
+
+    private var maxContextSize: Int {
+        SystemLanguageModel.default.contextSize
+    }
+
+    private var totalTokens: Int {
+        instructionsTokens + promptTokens + schemaTokens + toolTokens + historyTokens + responseReserveTokens
+    }
+
+    private var usageFraction: Double {
+        min(Double(totalTokens) / Double(maxContextSize), 1)
+    }
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Context Window",
+            description: "Inspect the pieces that consume a session budget",
+            defaultPrompt: "Inspect the context window.",
+            currentPrompt: $currentPrompt,
+            codeExample: codeExample,
+            onRun: rebalance,
+            onReset: reset
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Xcode27StatusCard(
+                    title: "Current Budget",
+                    value: "\(totalTokens) / \(maxContextSize) tokens",
+                    systemImage: "chart.bar.xaxis",
+                    tint: usageFraction > 0.9 ? .red : usageFraction > 0.75 ? .orange : .green
+                )
+
+                TokenUsageBar(
+                    currentTokenCount: totalTokens,
+                    maxContextSize: maxContextSize,
+                    tokenUsageFraction: usageFraction
+                )
+
+                Xcode27Section("Token Sources", systemImage: "list.bullet.rectangle") {
+                    VStack(spacing: 14) {
+                        tokenStepper("Instructions", value: $instructionsTokens, icon: "text.quote")
+                        tokenStepper("Prompt", value: $promptTokens, icon: "text.cursor")
+                        tokenStepper("Schemas", value: $schemaTokens, icon: "curlybraces")
+                        tokenStepper("Tools", value: $toolTokens, icon: "hammer")
+                        tokenStepper("History", value: $historyTokens, icon: "clock.arrow.circlepath")
+                        tokenStepper("Response reserve", value: $responseReserveTokens, icon: "arrow.down.doc")
+                    }
+                }
+
+                Xcode27Section("Compaction Trigger", systemImage: "arrow.triangle.2.circlepath") {
+                    Text(compactionAdvice)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var compactionAdvice: String {
+        switch usageFraction {
+        case ..<0.65:
+            return "The session has plenty of room. Keep the transcript intact."
+        case ..<0.85:
+            return "The session is getting warm. Consider summarizing older turns before adding large schemas or tool output."
+        default:
+            return "The session is close to the context limit. Compact history or start a fresh session before asking for a long response."
+        }
+    }
+
+    private func tokenStepper(
+        _ title: String,
+        value: Binding<Int>,
+        icon: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label(title, systemImage: icon)
+                    .font(.subheadline.weight(.medium))
+
+                Spacer()
+
+                Text("\(value.wrappedValue) tokens")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(value.wrappedValue) },
+                    set: { value.wrappedValue = Int($0) }
+                ),
+                in: 0...2_000,
+                step: 20
+            )
+            .accessibilityLabel(title)
+        }
+    }
+
+    private func rebalance() {
+        let promptEstimate = max(40, currentPrompt.split(separator: " ").count * 2)
+        promptTokens = promptEstimate
+    }
+
+    private func reset() {
+        currentPrompt = ""
+        instructionsTokens = 180
+        promptTokens = 120
+        schemaTokens = 520
+        toolTokens = 740
+        historyTokens = 1_240
+        responseReserveTokens = 600
+    }
+
+    private var codeExample: String {
+        """
+        let model = SystemLanguageModel.default
+        let maxContextSize = model.contextSize
+        let tokenCount = try await model.tokenCount(for: transcriptEntries)
+
+        if Double(tokenCount) / Double(maxContextSize) > 0.85 {
+            // Summarize older entries or start a fresh session.
+        }
+        """
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ContextWindowInspectorView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/DynamicProfileBuilderView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/DynamicProfileBuilderView.swift
@@ -1,0 +1,145 @@
+//
+//  DynamicProfileBuilderView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import SwiftUI
+
+struct DynamicProfileBuilderView: View {
+    @State private var currentPrompt = "Summarize this release note for developers."
+    @State private var temperature = 0.4
+    @State private var maxTokens = 240.0
+    @State private var reasoningLevel = ReasoningLevelChoice.moderate
+    @State private var toolMode = DynamicToolMode.allowed
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Dynamic Profile",
+            description: "Compose Xcode 27 session profile options",
+            defaultPrompt: "Summarize this release note for developers.",
+            currentPrompt: $currentPrompt,
+            codeExample: codeExample,
+            onRun: {},
+            onReset: reset
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Xcode27Section("Profile Controls", systemImage: "slider.horizontal.3") {
+                    VStack(spacing: 16) {
+                        labeledSlider("Temperature", value: $temperature, range: 0...1)
+                        labeledSlider("Maximum tokens", value: $maxTokens, range: 64...1_000)
+
+                        Picker("Reasoning", selection: $reasoningLevel) {
+                            ForEach(ReasoningLevelChoice.allCases) { level in
+                                Text(level.title).tag(level)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+
+                        Picker("Tools", selection: $toolMode) {
+                            ForEach(DynamicToolMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                }
+
+                Xcode27Section("Generated Recipe", systemImage: "curlybraces") {
+                    Text(recipePreview)
+                        .font(.body.monospaced())
+                        .textSelection(.enabled)
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.gray.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+        }
+    }
+
+    private func labeledSlider(
+        _ title: String,
+        value: Binding<Double>,
+        range: ClosedRange<Double>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                Spacer()
+                Text(title == "Maximum tokens" ? "\(Int(value.wrappedValue))" : value.wrappedValue.formatted(.number.precision(.fractionLength(2))))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Slider(value: value, in: range)
+                .accessibilityLabel(title)
+        }
+    }
+
+    private var recipePreview: String {
+        """
+        temperature: \(temperature.formatted(.number.precision(.fractionLength(2))))
+        maximumResponseTokens: \(Int(maxTokens))
+        reasoningLevel: .\(reasoningLevel.rawValue)
+        toolCallingMode: .\(toolMode.rawValue)
+        """
+    }
+
+    private var codeExample: String {
+        """
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let profile = LanguageModelSession.Profile {
+                DynamicInstructions("Be concise and developer-focused.")
+            }
+            .temperature(\(temperature.formatted(.number.precision(.fractionLength(2)))))
+            .maximumResponseTokens(\(Int(maxTokens)))
+            .reasoningLevel(.\(reasoningLevel.rawValue))
+            .toolCallingMode(.\(toolMode.rawValue))
+
+            let session = LanguageModelSession(profile: profile)
+        }
+        """
+    }
+
+    private func reset() {
+        currentPrompt = ""
+        temperature = 0.4
+        maxTokens = 240
+        reasoningLevel = .moderate
+        toolMode = .allowed
+    }
+}
+
+private enum ReasoningLevelChoice: String, CaseIterable, Identifiable {
+    case light
+    case moderate
+    case deep
+
+    var id: String { rawValue }
+
+    var title: String {
+        rawValue.capitalized
+    }
+}
+
+private enum DynamicToolMode: String, CaseIterable, Identifiable {
+    case allowed
+    case required
+    case disallowed
+
+    var id: String { rawValue }
+
+    var title: String {
+        rawValue.capitalized
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DynamicProfileBuilderView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
@@ -1,0 +1,134 @@
+//
+//  ImageInputPlaygroundView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import SwiftUI
+
+struct ImageInputPlaygroundView: View {
+    @State private var currentPrompt = "Turn this screenshot into a concise bug report."
+    @State private var selectedRecipe = ImageInputRecipe.altText
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Image Input",
+            description: "Explore image attachments and generated image references",
+            defaultPrompt: "Turn this screenshot into a concise bug report.",
+            currentPrompt: $currentPrompt,
+            codeExample: selectedRecipe.code,
+            onRun: {},
+            onReset: { currentPrompt = "" }
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Xcode27Section("Attachment Flow", systemImage: "photo.on.rectangle.angled") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Xcode27InfoRow(
+                            title: "Attach an image",
+                            detail: "Create Attachment<ImageAttachmentContent> from a CGImage, CIImage, pixel buffer, image URL, UIImage, or NSImage depending on platform.",
+                            systemImage: "1.circle"
+                        )
+
+                        Xcode27InfoRow(
+                            title: "Label it",
+                            detail: "Use a short label so generated ImageReference values can resolve back to the right transcript attachment.",
+                            systemImage: "2.circle"
+                        )
+
+                        Xcode27InfoRow(
+                            title: "Resolve references",
+                            detail: "Generated ImageReference can resolve in the transcript, which is useful for multimodal follow-ups.",
+                            systemImage: "3.circle"
+                        )
+                    }
+                }
+
+                Xcode27Section("Recipes", systemImage: "list.bullet.clipboard") {
+                    Picker("Recipe", selection: $selectedRecipe) {
+                        ForEach(ImageInputRecipe.allCases) { recipe in
+                            Text(recipe.title).tag(recipe)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    Text(selectedRecipe.prompt)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 8)
+                }
+
+                ResultDisplay(
+                    result: selectedRecipe.resultPreview,
+                    isSuccess: true
+                )
+            }
+        }
+    }
+}
+
+private enum ImageInputRecipe: String, CaseIterable, Identifiable {
+    case altText
+    case screenshotBug
+    case uiAudit
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .altText:
+            return "Alt Text"
+        case .screenshotBug:
+            return "Bug Report"
+        case .uiAudit:
+            return "UI Audit"
+        }
+    }
+
+    var prompt: String {
+        switch self {
+        case .altText:
+            return "Generate concise alt text for this image."
+        case .screenshotBug:
+            return "Turn this screenshot into a concise bug report."
+        case .uiAudit:
+            return "Audit this UI screenshot for accessibility and layout issues."
+        }
+    }
+
+    var resultPreview: String {
+        switch self {
+        case .altText:
+            return "Example output: A compact description of the image suitable for accessibility labels and summaries."
+        case .screenshotBug:
+            return "Example output: Title, observed behavior, expected behavior, visible evidence, and repro hints."
+        case .uiAudit:
+            return "Example output: Layout, hierarchy, contrast, spacing, text clipping, and actionable fixes."
+        }
+    }
+
+    var code: String {
+        """
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let image = Attachment<ImageAttachmentContent>(imageURL: imageURL)
+                .label("screenshot")
+
+            let session = LanguageModelSession()
+            let response = try await session.respond(
+                to: Prompt("\(prompt)")
+                // Include image attachment with the prompt when using the Xcode 27 attachment API.
+            )
+
+            let reference = try response.content as ImageReference
+            let resolved = reference.resolve(in: session.transcript)
+        }
+        """
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ImageInputPlaygroundView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
@@ -1,0 +1,177 @@
+//
+//  ModelRuntimeView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import Foundation
+import FoundationModels
+import SwiftUI
+
+struct ModelRuntimeView: View {
+    @State private var currentPrompt = "Inspect the current Foundation Models runtime."
+    @State private var report = ModelRuntimeReport.placeholder
+    @State private var isInspecting = false
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Model Runtime",
+            description: "Compare the system model with Xcode 27 runtime capabilities",
+            defaultPrompt: "Inspect the current Foundation Models runtime.",
+            currentPrompt: $currentPrompt,
+            isRunning: isInspecting,
+            errorMessage: nil,
+            codeExample: codeExample,
+            onRun: inspectRuntime,
+            onReset: reset
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Xcode27StatusCard(
+                    title: "System Context",
+                    value: "\(report.systemContextSize) tokens",
+                    systemImage: "text.page"
+                )
+
+                Xcode27StatusCard(
+                    title: "System Availability",
+                    value: report.systemAvailability,
+                    systemImage: report.systemAvailable ? "checkmark.circle.fill" : "xmark.circle.fill",
+                    tint: report.systemAvailable ? .green : .orange
+                )
+
+                Xcode27Section("Capabilities", systemImage: "sparkles.rectangle.stack") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(report.capabilities, id: \.name) { capability in
+                            Xcode27InfoRow(
+                                title: capability.name,
+                                detail: capability.isSupported ? "Supported by this model surface." : "Not reported by this model surface.",
+                                systemImage: capability.isSupported ? "checkmark.circle" : "circle",
+                                tint: capability.isSupported ? .green : .secondary
+                            )
+                        }
+                    }
+                }
+
+                Xcode27Section("Runtime Note", systemImage: "info.circle") {
+                    Text(report.runtimeNote)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .task {
+                inspectRuntime()
+            }
+        }
+    }
+
+    private func inspectRuntime() {
+        isInspecting = true
+        defer { isInspecting = false }
+
+        let systemModel = SystemLanguageModel.default
+        let availability = systemModel.availability
+        let availabilityText: String
+        let isAvailable: Bool
+
+        switch availability {
+        case .available:
+            availabilityText = "Available"
+            isAvailable = true
+        case .unavailable(let reason):
+            availabilityText = unavailableReasonDescription(reason)
+            isAvailable = false
+        }
+
+        var capabilities = [
+            ModelCapabilityRow(name: "Vision", isSupported: false),
+            ModelCapabilityRow(name: "Guided generation", isSupported: false),
+            ModelCapabilityRow(name: "Reasoning", isSupported: false),
+            ModelCapabilityRow(name: "Tool calling", isSupported: false)
+        ]
+
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            let modelCapabilities = systemModel.capabilities
+            capabilities = [
+                ModelCapabilityRow(name: "Vision", isSupported: modelCapabilities.contains(.vision)),
+                ModelCapabilityRow(name: "Guided generation", isSupported: modelCapabilities.contains(.guidedGeneration)),
+                ModelCapabilityRow(name: "Reasoning", isSupported: modelCapabilities.contains(.reasoning)),
+                ModelCapabilityRow(name: "Tool calling", isSupported: modelCapabilities.contains(.toolCalling))
+            ]
+        }
+
+        report = ModelRuntimeReport(
+            systemContextSize: systemModel.contextSize,
+            systemAvailability: availabilityText,
+            systemAvailable: isAvailable,
+            capabilities: capabilities,
+            runtimeNote: "PrivateCloudComputeLanguageModel is inspected separately because its context size is async and may require macOS/iOS 27 runtime support plus service eligibility."
+        )
+    }
+
+    private func reset() {
+        currentPrompt = ""
+        report = .placeholder
+    }
+
+    private func unavailableReasonDescription(
+        _ reason: SystemLanguageModel.Availability.UnavailableReason
+    ) -> String {
+        switch reason {
+        case .deviceNotEligible:
+            return "Device not eligible"
+        case .appleIntelligenceNotEnabled:
+            return "Apple Intelligence not enabled"
+        case .modelNotReady:
+            return "Model not ready"
+        @unknown default:
+            return "Unavailable"
+        }
+    }
+
+    private var codeExample: String {
+        """
+        let systemModel = SystemLanguageModel.default
+        let contextSize = systemModel.contextSize
+
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            let capabilities = systemModel.capabilities
+            capabilities.contains(.toolCalling)
+            capabilities.contains(.vision)
+        }
+        """
+    }
+}
+
+private struct ModelRuntimeReport {
+    var systemContextSize: Int
+    var systemAvailability: String
+    var systemAvailable: Bool
+    var capabilities: [ModelCapabilityRow]
+    var runtimeNote: String
+
+    static let placeholder = ModelRuntimeReport(
+        systemContextSize: 4_096,
+        systemAvailability: "Not inspected yet",
+        systemAvailable: false,
+        capabilities: [
+            ModelCapabilityRow(name: "Vision", isSupported: false),
+            ModelCapabilityRow(name: "Guided generation", isSupported: false),
+            ModelCapabilityRow(name: "Reasoning", isSupported: false),
+            ModelCapabilityRow(name: "Tool calling", isSupported: false)
+        ],
+        runtimeNote: "Tap Run to inspect the local runtime."
+    )
+}
+
+private struct ModelCapabilityRow {
+    let name: String
+    let isSupported: Bool
+}
+
+#Preview {
+    NavigationStack {
+        ModelRuntimeView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/PrivateCloudComputeView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/PrivateCloudComputeView.swift
@@ -1,0 +1,198 @@
+//
+//  PrivateCloudComputeView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import Foundation
+import FoundationModels
+import SwiftUI
+
+struct PrivateCloudComputeView: View {
+    @State private var currentPrompt = "Inspect Private Cloud Compute availability."
+    @State private var report = PrivateCloudComputeReport.pending
+    @State private var isInspecting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Private Cloud",
+            description: "Probe PCC availability, quota, and context size",
+            defaultPrompt: "Inspect Private Cloud Compute availability.",
+            currentPrompt: $currentPrompt,
+            isRunning: isInspecting,
+            errorMessage: errorMessage,
+            codeExample: codeExample,
+            onRun: inspect,
+            onReset: reset
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Xcode27StatusCard(
+                    title: "Availability",
+                    value: report.availability,
+                    systemImage: report.isAvailable ? "checkmark.icloud.fill" : "icloud.slash",
+                    tint: report.isAvailable ? .green : .orange
+                )
+
+                Xcode27StatusCard(
+                    title: "Context Size",
+                    value: report.contextSize.map { "\($0) tokens" } ?? "Unknown",
+                    systemImage: "text.page.badge.magnifyingglass"
+                )
+
+                Xcode27StatusCard(
+                    title: "Quota",
+                    value: report.quota,
+                    systemImage: "gauge.with.dots.needle.67percent",
+                    tint: report.quotaLimitReached ? .red : .blue
+                )
+
+                Xcode27Section("Supported Languages", systemImage: "globe") {
+                    Text(report.supportedLanguages)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .task {
+                inspect()
+            }
+        }
+    }
+
+    private func inspect() {
+        Task {
+            isInspecting = true
+            errorMessage = nil
+            defer { isInspecting = false }
+
+            guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) else {
+                report = .unsupported
+                return
+            }
+
+            let model = PrivateCloudComputeLanguageModel()
+            let availabilityText: String
+
+            switch model.availability {
+            case .available:
+                availabilityText = "Available"
+            case .unavailable(let reason):
+                availabilityText = unavailableReasonDescription(reason)
+            }
+
+            let quotaUsage = model.quotaUsage
+            let quotaText = quotaDescription(quotaUsage)
+            let languages = model.supportedLanguages
+                .map { $0.minimalIdentifier }
+                .sorted()
+                .joined(separator: ", ")
+
+            do {
+                let contextSize = try await model.contextSize
+                report = PrivateCloudComputeReport(
+                    availability: availabilityText,
+                    isAvailable: model.isAvailable,
+                    contextSize: contextSize,
+                    quota: quotaText,
+                    quotaLimitReached: quotaUsage.isLimitReached,
+                    supportedLanguages: languages.isEmpty ? "No languages reported yet." : languages
+                )
+            } catch {
+                report = PrivateCloudComputeReport(
+                    availability: availabilityText,
+                    isAvailable: model.isAvailable,
+                    contextSize: nil,
+                    quota: quotaText,
+                    quotaLimitReached: quotaUsage.isLimitReached,
+                    supportedLanguages: languages.isEmpty ? "No languages reported yet." : languages
+                )
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func reset() {
+        currentPrompt = ""
+        report = .pending
+        errorMessage = nil
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    private func unavailableReasonDescription(
+        _ reason: PrivateCloudComputeLanguageModel.Availability.UnavailableReason
+    ) -> String {
+        switch reason {
+        case .deviceNotEligible:
+            return "Device not eligible"
+        case .systemNotReady:
+            return "System not ready"
+        @unknown default:
+            return "Unavailable"
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    private func quotaDescription(
+        _ quotaUsage: PrivateCloudComputeLanguageModel.QuotaUsage
+    ) -> String {
+        switch quotaUsage.status {
+        case .belowLimit(let belowLimit):
+            return belowLimit.isApproachingLimit ? "Below limit, approaching cap" : "Below limit"
+        case .limitReached:
+            if let resetDate = quotaUsage.resetDate {
+                return "Limit reached. Resets \(resetDate.formatted(.relative(presentation: .named)))"
+            }
+            return "Limit reached"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+
+    private var codeExample: String {
+        """
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let model = PrivateCloudComputeLanguageModel()
+
+            model.availability
+            model.quotaUsage
+            model.isAvailable
+            let contextSize = try await model.contextSize
+        }
+        """
+    }
+}
+
+private struct PrivateCloudComputeReport {
+    var availability: String
+    var isAvailable: Bool
+    var contextSize: Int?
+    var quota: String
+    var quotaLimitReached: Bool
+    var supportedLanguages: String
+
+    static let pending = PrivateCloudComputeReport(
+        availability: "Not inspected yet",
+        isAvailable: false,
+        contextSize: nil,
+        quota: "Not inspected yet",
+        quotaLimitReached: false,
+        supportedLanguages: "Tap Run to inspect PCC language support."
+    )
+
+    static let unsupported = PrivateCloudComputeReport(
+        availability: "Requires OS 27 runtime",
+        isAvailable: false,
+        contextSize: nil,
+        quota: "Requires OS 27 runtime",
+        quotaLimitReached: false,
+        supportedLanguages: "PrivateCloudComputeLanguageModel is gated to iOS, macOS, visionOS, and watchOS 27."
+    )
+}
+
+#Preview {
+    NavigationStack {
+        PrivateCloudComputeView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/PrivateCloudComputeView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/PrivateCloudComputeView.swift
@@ -13,6 +13,7 @@ struct PrivateCloudComputeView: View {
     @State private var currentPrompt = "Inspect Private Cloud Compute availability."
     @State private var report = PrivateCloudComputeReport.pending
     @State private var isInspecting = false
+    @State private var inspectionID = UUID()
     @State private var errorMessage: String?
 
     var body: some View {
@@ -61,12 +62,22 @@ struct PrivateCloudComputeView: View {
     }
 
     private func inspect() {
-        Task {
+        let id = UUID()
+        inspectionID = id
+        isInspecting = true
+        errorMessage = nil
+
+        Task { @MainActor in
+            defer {
+                if inspectionID == id {
+                    isInspecting = false
+                }
+            }
+
             isInspecting = true
-            errorMessage = nil
-            defer { isInspecting = false }
 
             guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) else {
+                guard inspectionID == id else { return }
                 report = .unsupported
                 return
             }
@@ -90,6 +101,7 @@ struct PrivateCloudComputeView: View {
 
             do {
                 let contextSize = try await model.contextSize
+                guard inspectionID == id else { return }
                 report = PrivateCloudComputeReport(
                     availability: availabilityText,
                     isAvailable: model.isAvailable,
@@ -99,6 +111,7 @@ struct PrivateCloudComputeView: View {
                     supportedLanguages: languages.isEmpty ? "No languages reported yet." : languages
                 )
             } catch {
+                guard inspectionID == id else { return }
                 report = PrivateCloudComputeReport(
                     availability: availabilityText,
                     isAvailable: model.isAvailable,
@@ -113,6 +126,8 @@ struct PrivateCloudComputeView: View {
     }
 
     private func reset() {
+        inspectionID = UUID()
+        isInspecting = false
         currentPrompt = ""
         report = .pending
         errorMessage = nil
@@ -195,4 +210,3 @@ private struct PrivateCloudComputeReport {
         PrivateCloudComputeView()
     }
 }
-

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonView.swift
@@ -1,0 +1,122 @@
+//
+//  ReasoningLevelComparisonView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import SwiftUI
+
+struct ReasoningLevelComparisonView: View {
+    @State private var currentPrompt = "Plan a migration from an Xcode 26 Foundation Models app to Xcode 27."
+    @State private var selectedLevel = ReasoningComparisonLevel.moderate
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Reasoning Levels",
+            description: "Compare light, moderate, and deep reasoning contexts",
+            defaultPrompt: "Plan a migration from an Xcode 26 Foundation Models app to Xcode 27.",
+            currentPrompt: $currentPrompt,
+            codeExample: selectedLevel.code,
+            onRun: {},
+            onReset: { currentPrompt = "" }
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Picker("Reasoning level", selection: $selectedLevel) {
+                    ForEach(ReasoningComparisonLevel.allCases) { level in
+                        Text(level.title).tag(level)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Xcode27Section(selectedLevel.title, systemImage: selectedLevel.icon) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(selectedLevel.detail)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+
+                        ResultDisplay(
+                            result: selectedLevel.expectedShape,
+                            isSuccess: true
+                        )
+                    }
+                }
+
+                Xcode27Section("ContextOptions", systemImage: "gearshape.2") {
+                    Text("Xcode 27 adds ContextOptions(reasoningLevel:) so examples can make reasoning depth an explicit runtime choice instead of burying it in prompt wording.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private enum ReasoningComparisonLevel: String, CaseIterable, Identifiable {
+    case light
+    case moderate
+    case deep
+
+    var id: String { rawValue }
+
+    var title: String {
+        rawValue.capitalized
+    }
+
+    var icon: String {
+        switch self {
+        case .light:
+            return "bolt"
+        case .moderate:
+            return "brain"
+        case .deep:
+            return "brain.head.profile"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .light:
+            return "Use light reasoning for fast rewrites, labels, small summaries, and simple classification."
+        case .moderate:
+            return "Use moderate reasoning for normal app flows where the response needs a little planning."
+        case .deep:
+            return "Use deep reasoning for migration plans, multi-step tradeoffs, and complex tool orchestration."
+        }
+    }
+
+    var expectedShape: String {
+        switch self {
+        case .light:
+            return "Expected output: short, direct, low-latency answer with minimal planning."
+        case .moderate:
+            return "Expected output: structured answer with a few explicit steps and tradeoffs."
+        case .deep:
+            return "Expected output: fuller plan with assumptions, risks, sequencing, and validation."
+        }
+    }
+
+    var code: String {
+        """
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let context = ContextOptions(
+                includeSchemaInPrompt: true,
+                reasoningLevel: .\(rawValue)
+            )
+
+            let session = LanguageModelSession()
+            let response = try await session.respond(
+                to: Prompt("Plan the migration."),
+                context: context
+            )
+        }
+        """
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ReasoningLevelComparisonView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabView.swift
@@ -1,0 +1,132 @@
+//
+//  ToolCallingModeLabView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import FoundationModels
+import SwiftUI
+
+struct ToolCallingModeLabView: View {
+    @State private var currentPrompt = "What is the weather in Cupertino?"
+    @State private var selectedMode = ToolModeExample.allowed
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Tool Modes",
+            description: "Compare allowed, required, and disallowed tool calling",
+            defaultPrompt: "What is the weather in Cupertino?",
+            currentPrompt: $currentPrompt,
+            codeExample: selectedMode.code,
+            onRun: {},
+            onReset: { currentPrompt = "" }
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Picker("Tool mode", selection: $selectedMode) {
+                    ForEach(ToolModeExample.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Xcode27Section(selectedMode.title, systemImage: selectedMode.icon) {
+                    Text(selectedMode.explanation)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
+                Xcode27Section("Behavior Matrix", systemImage: "tablecells") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        ForEach(ToolModeExample.allCases) { mode in
+                            Xcode27InfoRow(
+                                title: mode.title,
+                                detail: mode.shortDescription,
+                                systemImage: mode.icon,
+                                tint: mode == selectedMode ? .blue : .secondary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum ToolModeExample: String, CaseIterable, Identifiable {
+    case allowed
+    case required
+    case disallowed
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .allowed:
+            return "Allowed"
+        case .required:
+            return "Required"
+        case .disallowed:
+            return "Disallowed"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .allowed:
+            return "checkmark.circle"
+        case .required:
+            return "exclamationmark.circle"
+        case .disallowed:
+            return "nosign"
+        }
+    }
+
+    var shortDescription: String {
+        switch self {
+        case .allowed:
+            return "The model may call tools if they help."
+        case .required:
+            return "The model must call a tool before answering."
+        case .disallowed:
+            return "The model must answer without tool calls."
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .allowed:
+            return "Use this for normal agentic flows where a tool is available but not always necessary."
+        case .required:
+            return "Use this when the response must be grounded in a tool result, such as weather, calendar, or search."
+        case .disallowed:
+            return "Use this for pure language tasks, drafts, or contexts where external actions would be surprising."
+        }
+    }
+
+    var code: String {
+        """
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let options = GenerationOptions(
+                samplingMode: nil,
+                temperature: 0.2,
+                maximumResponseTokens: 200,
+                toolCallingMode: .\(rawValue)
+            )
+
+            let session = LanguageModelSession(tools: [weatherTool])
+            let response = try await session.respond(
+                to: Prompt("What is the weather in Cupertino?"),
+                options: options
+            )
+        }
+        """
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ToolCallingModeLabView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
@@ -67,17 +67,24 @@ struct TranscriptExplorerView: View {
 
     private var codeExample: String {
         """
-        switch segment {
-        case .text(let text):
-            render(text.content)
-        case .structure(let structured):
-            render(structured.schemaName)
-        case .attachment(let attachment):
-            render(attachment.label)
-        case .custom(let custom):
-            render(custom.description)
+        switch entry {
+        case .reasoning(let reasoning):
+            renderReasoning(reasoning)
+        case .segment(let segment):
+            switch segment {
+            case .text(let text):
+                render(text.content)
+            case .structure(let structured):
+                render(structured.schemaName)
+            case .attachment(let attachment):
+                render(attachment.label)
+            case .custom(let custom):
+                render(custom.description)
+            @unknown default:
+                render("Unknown segment")
+            }
         @unknown default:
-            render("Unknown segment")
+            render("Unknown entry")
         }
         """
     }
@@ -140,4 +147,3 @@ private enum TranscriptSegmentExample: String, CaseIterable, Identifiable {
         TranscriptExplorerView()
     }
 }
-

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
@@ -1,0 +1,143 @@
+//
+//  TranscriptExplorerView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import SwiftUI
+
+struct TranscriptExplorerView: View {
+    @State private var currentPrompt = "Browse the Xcode 27 transcript segment types."
+    @State private var selectedSegment = TranscriptSegmentExample.reasoning
+
+    var body: some View {
+        ExampleViewBase(
+            title: "Transcript Explorer",
+            description: "Browse new reasoning, attachment, and custom segment cases",
+            defaultPrompt: "Browse the Xcode 27 transcript segment types.",
+            currentPrompt: $currentPrompt,
+            codeExample: codeExample,
+            onRun: {},
+            onReset: { currentPrompt = "" }
+        ) {
+            VStack(spacing: Spacing.medium) {
+                Picker("Segment", selection: $selectedSegment) {
+                    ForEach(TranscriptSegmentExample.allCases) { segment in
+                        Label(segment.title, systemImage: segment.icon)
+                            .tag(segment)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Xcode27Section(selectedSegment.title, systemImage: selectedSegment.icon) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(selectedSegment.detail)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+
+                        Text(selectedSegment.sample)
+                            .font(.body.monospaced())
+                            .textSelection(.enabled)
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.gray.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                }
+
+                Xcode27Section("Why this matters", systemImage: "wrench.and.screwdriver") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Xcode27InfoRow(
+                            title: "Switches need new cases",
+                            detail: "Code that walked transcript entries or segments in Xcode 26 should explicitly handle the new Xcode 27 cases.",
+                            systemImage: "switch.2"
+                        )
+
+                        Xcode27InfoRow(
+                            title: "Debug views get richer",
+                            detail: "A transcript debugger can now show reasoning, image attachments, generated references, and app-defined custom content.",
+                            systemImage: "ladybug"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var codeExample: String {
+        """
+        switch segment {
+        case .text(let text):
+            render(text.content)
+        case .structure(let structured):
+            render(structured.schemaName)
+        case .attachment(let attachment):
+            render(attachment.label)
+        case .custom(let custom):
+            render(custom.description)
+        @unknown default:
+            render("Unknown segment")
+        }
+        """
+    }
+}
+
+private enum TranscriptSegmentExample: String, CaseIterable, Identifiable {
+    case reasoning
+    case attachment
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .reasoning:
+            return "Reasoning"
+        case .attachment:
+            return "Attachment"
+        case .custom:
+            return "Custom"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .reasoning:
+            return "brain"
+        case .attachment:
+            return "paperclip"
+        case .custom:
+            return "puzzlepiece.extension"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .reasoning:
+            return "Xcode 27 adds transcript reasoning entries so developer tools can separate reasoning from ordinary assistant text."
+        case .attachment:
+            return "Attachment segments let image inputs and generated image references travel through the transcript."
+        case .custom:
+            return "Custom segments give framework and app integrations room to preserve extra typed transcript content."
+        }
+    }
+
+    var sample: String {
+        switch self {
+        case .reasoning:
+            return "Transcript.Entry.reasoning(...)"
+        case .attachment:
+            return "Transcript.Segment.attachment(...)"
+        case .custom:
+            return "Transcript.Segment.custom(...)"
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TranscriptExplorerView()
+    }
+}
+

--- a/Foundation Lab/Views/Examples/Xcode27/Xcode27ExampleSupport.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/Xcode27ExampleSupport.swift
@@ -1,0 +1,88 @@
+//
+//  Xcode27ExampleSupport.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/8/26.
+//
+
+import SwiftUI
+
+struct Xcode27StatusCard: View {
+    let title: String
+    let value: String
+    let systemImage: String
+    var tint: Color = .blue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+                .foregroundStyle(tint)
+
+            Text(value)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color.tertiaryBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.large))
+    }
+}
+
+struct Xcode27InfoRow: View {
+    let title: String
+    let detail: String
+    let systemImage: String
+    var tint: Color = .blue
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: systemImage)
+                .foregroundStyle(tint)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct Xcode27Section<Content: View>: View {
+    let title: String
+    let systemImage: String
+    let content: Content
+
+    init(
+        _ title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color.tertiaryBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.large))
+    }
+}
+


### PR DESCRIPTION
## Summary
- add eight Xcode 27 Foundation Models example views covering model runtime, context windows, Private Cloud Compute, image input, tool modes, dynamic profiles, reasoning levels, and transcripts
- wire the new examples into `ExampleType`, destinations, and the Studio examples list
- share reusable Xcode 27 example UI support components for compact status/section layouts

## Verification
- `DEVELOPER_DIR=/Users/rudrank/Downloads/Xcode-beta.app/Contents/Developer xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath ./build-xcode27-examples build`

## Notes
- Private Cloud Compute probing remains OS/service gated in-app and reports unsupported states instead of assuming availability.