### PR TITLE
Fix transcript row identity warnings

### DIFF
--- a/Foundation Lab/Health/Views/Chat/HealthChatView.swift
+++ b/Foundation Lab/Health/Views/Chat/HealthChatView.swift
@@ -93,9 +93,9 @@ struct HealthChatView: View {
                             .id("welcome")
                     }
 
-                    ForEach(viewModel.session.transcript) { entry in
-                        HealthTranscriptEntryView(entry: entry)
-                            .id(entry.id)
+                    ForEach(transcriptDisplayEntries, id: \.id) { displayEntry in
+                        HealthTranscriptEntryView(entry: displayEntry.entry)
+                            .id(displayEntry.id)
                     }
 
                     if viewModel.isSummarizing {
@@ -124,9 +124,9 @@ struct HealthChatView: View {
             #endif
             .scrollPosition(id: $scrollID, anchor: .bottom)
             .onChange(of: viewModel.session.transcript.count) { _, _ in
-                if let lastEntry = viewModel.session.transcript.last {
+                if let lastEntryID = transcriptDisplayEntries.last?.id {
                     withAnimation(.easeOut(duration: 0.3)) {
-                        proxy.scrollTo(lastEntry.id, anchor: .bottom)
+                        proxy.scrollTo(lastEntryID, anchor: .bottom)
                     }
                 }
             }
@@ -139,6 +139,12 @@ struct HealthChatView: View {
             }
         }
         .defaultScrollAnchor(.bottom)
+    }
+
+    private var transcriptDisplayEntries: [(id: String, entry: Transcript.Entry)] {
+        viewModel.session.transcript.enumerated().map { index, entry in
+            ("\(index)-\(entry.id)", entry)
+        }
     }
 }
 

--- a/Foundation Lab/Views/Chat/ChatView.swift
+++ b/Foundation Lab/Views/Chat/ChatView.swift
@@ -141,9 +141,9 @@ struct ChatView: View {
                             .padding(.bottom, 48)
                     }
 
-                    ForEach(viewModel.session.transcript) { entry in
-                        TranscriptEntryView(entry: entry)
-                            .id(entry.id)
+                    ForEach(transcriptDisplayEntries, id: \.id) { displayEntry in
+                        TranscriptEntryView(entry: displayEntry.entry)
+                            .id(displayEntry.id)
                     }
 
                     if viewModel.isSummarizing {
@@ -185,9 +185,9 @@ struct ChatView: View {
 #endif
             .scrollPosition(id: $scrollID, anchor: .bottom)
             .onChange(of: viewModel.session.transcript.count) { _, _ in
-                if let lastEntry = viewModel.session.transcript.last {
+                if let lastEntryID = transcriptDisplayEntries.last?.id {
                     withAnimation(.easeOut(duration: 0.3)) {
-                        proxy.scrollTo(lastEntry.id, anchor: .bottom)
+                        proxy.scrollTo(lastEntryID, anchor: .bottom)
                     }
                 }
             }
@@ -228,6 +228,12 @@ struct ChatView: View {
             Label(viewModel.selectedModelRuntime.shortName, systemImage: viewModel.selectedModelRuntime.systemImage)
         }
         .help(viewModel.modelRuntimeStatus)
+    }
+
+    private var transcriptDisplayEntries: [(id: String, entry: Transcript.Entry)] {
+        viewModel.session.transcript.enumerated().map { index, entry in
+            ("\(index)-\(entry.id)", entry)
+        }
     }
 
     private var reasoningMenu: some View {

--- a/Foundation Lab/Views/Chat/TranscriptEntryView.swift
+++ b/Foundation Lab/Views/Chat/TranscriptEntryView.swift
@@ -41,13 +41,11 @@ struct TranscriptEntryView: View {
         case .prompt(let prompt):
             if let text = prompt.segments.textContentJoined() {
                 MessageBubbleView(message: ChatMessage(content: text, isFromUser: true))
-                    .id(entry.id)
             }
 
         case .response(let response):
             if let text = response.segments.textContentJoined() {
                 MessageBubbleView(message: ChatMessage(entryID: entry.id, content: text, isFromUser: false))
-                    .id(entry.id)
             }
 
         case .toolCalls(let toolCalls):
@@ -57,7 +55,6 @@ struct TranscriptEntryView: View {
                     content: "🔧 Calling tool: \(toolCall.toolName)",
                     isFromUser: false
                 ))
-                .id("\(entry.id)-tool-\(index)")
             }
 
         case .toolOutput(let toolOutput):
@@ -67,7 +64,6 @@ struct TranscriptEntryView: View {
                     content: "🔧 Tool result: \(text)",
                     isFromUser: false
                 ))
-                .id(entry.id)
             }
 
         #if compiler(>=6.4)
@@ -75,7 +71,6 @@ struct TranscriptEntryView: View {
             if chatViewModel.showsReasoningTrace {
                 if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
                     ReasoningTraceView(reasoning: reasoning)
-                        .id(entry.id)
                 }
             }
         #endif


### PR DESCRIPTION
## Summary
- render transcript rows with display-unique IDs derived from row index and transcript entry ID
- scroll to those display IDs instead of the raw Foundation Models transcript IDs
- remove redundant nested explicit IDs inside transcript entry content

## Testing
- Xcode 27 beta: `xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /tmp/FoundationLab-Xcode27-TranscriptIDs-Final build | rg "error:|warning:|BUILD SUCCEEDED|BUILD FAILED"` -> `BUILD SUCCEEDED`
- Xcode 26.5 beta: `xcodebuild -project FoundationLab.xcodeproj -scheme "Foundation Lab" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /tmp/FoundationLab-Xcode265-TranscriptIDs-Final build | rg "error:|warning:|BUILD SUCCEEDED|BUILD FAILED"` -> `BUILD SUCCEEDED`

## Notes
- Stacked on PR #135 so this PR only shows the transcript UI identity fix.