### PR TITLE
Rename project to Foundation Models Framework Lab

### DIFF
--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -6409,7 +6409,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Explore IA no dispositivo com o Foundation-Models-Framework-Example da Apple."
+            "value" : "Explore a IA no dispositivo com o framework Foundation Models da Apple."
           }
         },
         "zh-Hans" : {

--- a/Foundation Lab/Views/SettingsView.swift
+++ b/Foundation Lab/Views/SettingsView.swift
@@ -11,7 +11,7 @@ struct SettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                Link(destination: URL(string: "https://github.com/rudrankriyam/Foundation-Models-Framework-Example/issues")!) {
+                Link(destination: URL(string: "https://github.com/rudrankriyam/Foundation-Models-Framework-Lab/issues")!) {
                     HStack {
                         Text("Bug/Feature Request")
                         Spacer()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Foundation Models Framework Example
+# Foundation Models Framework Lab
 
 <div align="center">
   <table>
@@ -107,16 +107,16 @@ skills/
 Install it with the open skills CLI:
 
 ```bash
-npx skills add rudrankriyam/Foundation-Models-Framework-Example --skill foundation-models-app-builder
-npx skills add rudrankriyam/Foundation-Models-Framework-Example --skill foundation-models-os27-updater
+npx skills add rudrankriyam/Foundation-Models-Framework-Lab --skill foundation-models-app-builder
+npx skills add rudrankriyam/Foundation-Models-Framework-Lab --skill foundation-models-os27-updater
 ```
 
 To target a specific agent explicitly:
 
 ```bash
-npx skills add rudrankriyam/Foundation-Models-Framework-Example --skill foundation-models-app-builder --agent codex
-npx skills add rudrankriyam/Foundation-Models-Framework-Example --skill foundation-models-app-builder --agent claude-code
-npx skills add rudrankriyam/Foundation-Models-Framework-Example --skill foundation-models-os27-updater --agent codex
+npx skills add rudrankriyam/Foundation-Models-Framework-Lab --skill foundation-models-app-builder --agent codex
+npx skills add rudrankriyam/Foundation-Models-Framework-Lab --skill foundation-models-app-builder --agent claude-code
+npx skills add rudrankriyam/Foundation-Models-Framework-Lab --skill foundation-models-os27-updater --agent codex
 ```
 
 ## What's Inside
@@ -460,4 +460,4 @@ Contributions are welcome! Please feel free to submit a pull request.
 
 This project is licensed under the MIT License - see the LICENSE file for details.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rudrankriyam/Foundation-Models-Framework-Example&type=Date)](https://star-history.com/#rudrankriyam/Foundation-Models-Framework-Example&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=rudrankriyam/Foundation-Models-Framework-Lab&type=Date)](https://star-history.com/#rudrankriyam/Foundation-Models-Framework-Lab&Date)


### PR DESCRIPTION
## Summary
- rename the repository-facing project title to Foundation Models Framework Lab
- update skill installation commands, issue links, and the star-history URL for the new repository slug
- correct the stale Portuguese localization that contained the old repository name

## Validation
- `swift test --package-path FoundationLabCore` (30 tests passed)
- SwiftLint on `Foundation Lab/Views/SettingsView.swift` (0 violations)
- `Foundation Lab/Localizable.xcstrings` parsed as valid JSON
- verified no tracked references to the old repository name remain

The full repository lint still reports 50 pre-existing violations unrelated to this rename.