### PR TITLE
Clean Core and AFM CLI SwiftLint violations

### DIFF
--- a/.github/workflows/afm-cli.yml
+++ b/.github/workflows/afm-cli.yml
@@ -9,6 +9,7 @@ on:
       - 'Packages/FoundationModelsKit/**'
       - 'Package.swift'
       - 'Package.resolved'
+      - '.swiftlint-core-cli.yml'
       - '.github/workflows/afm-cli.yml'
   push:
     branches: [main]
@@ -18,6 +19,7 @@ on:
       - 'Packages/FoundationModelsKit/**'
       - 'Package.swift'
       - 'Package.resolved'
+      - '.swiftlint-core-cli.yml'
       - '.github/workflows/afm-cli.yml'
   workflow_dispatch:
 
@@ -39,6 +41,12 @@ jobs:
         run: |
           xcodebuild -version
           swift --version
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Lint Core and CLI
+        run: swiftlint lint --strict --config .swiftlint-core-cli.yml
 
       - name: Resolve package dependencies
         run: swift package resolve

--- a/.swiftlint-core-cli.yml
+++ b/.swiftlint-core-cli.yml
@@ -1,0 +1,44 @@
+included:
+  - FoundationLabCore
+  - Tools/AFMCLI
+
+excluded:
+  - .build
+  - build
+  - DerivedData
+
+line_length:
+  warning: 140
+  error: 140
+  ignores_comments: true
+  ignores_urls: true
+
+type_body_length:
+  warning: 200
+  error: 300
+
+file_length:
+  warning: 600
+  error: 800
+
+identifier_name:
+  min_length:
+    warning: 2
+    error: 1
+  max_length:
+    warning: 40
+    error: 50
+
+type_name:
+  max_length:
+    warning: 50
+    error: 60
+
+function_body_length:
+  warning: 60
+  error: 100
+
+nesting:
+  type_level:
+    warning: 3
+    error: 5

--- a/FoundationLabCore/Sources/FoundationLabCore/Capabilities/RunSchemaExampleUseCase.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Capabilities/RunSchemaExampleUseCase.swift
@@ -20,18 +20,18 @@ public struct RunSchemaExampleUseCase: CapabilityUseCase {
             throw FoundationLabCoreError.invalidRequest("Missing input")
         }
 
-        let (schema, prompt, formatter) = try makeExecutionPlan(for: request, input: trimmedInput)
+        let plan = try makeExecutionPlan(for: request, input: trimmedInput)
         let response = try await generator.execute(
             DynamicSchemaGenerationRequest(
-                prompt: prompt,
-                schema: schema,
+                prompt: plan.prompt,
+                schema: plan.schema,
                 generationOptions: request.generationOptions,
                 context: request.context
             )
         )
 
         return RunSchemaExampleResult(
-            content: formatter(response.output),
+            content: plan.formatter(response.output),
             metadata: response.metadata
         )
     }
@@ -40,10 +40,27 @@ public struct RunSchemaExampleUseCase: CapabilityUseCase {
 private extension RunSchemaExampleUseCase {
     typealias SchemaFormatter = @Sendable (GeneratedContent) -> String
 
+    struct SchemaExecutionPlan {
+        let schema: GenerationSchema
+        let prompt: String
+        let formatter: SchemaFormatter
+    }
+
+    struct NamedSchema {
+        let schema: GenerationSchema
+        let name: String
+    }
+
+    struct ClassificationData {
+        let classification: String
+        let confidence: Float?
+        let reasoning: String?
+    }
+
     func makeExecutionPlan(
         for request: RunSchemaExampleRequest,
         input: String
-    ) throws -> (GenerationSchema, String, SchemaFormatter) {
+    ) throws -> SchemaExecutionPlan {
         switch request.example {
         case .basicObject:
             return try basicObjectPlan(
@@ -69,75 +86,107 @@ private extension RunSchemaExampleUseCase {
     func basicObjectPlan(
         presetIndex: Int,
         input: String
-    ) throws -> (GenerationSchema, String, SchemaFormatter) {
-        let schema: GenerationSchema
-        let schemaName: String
-
-        switch presetIndex {
-        case 0:
-            let personSchema = DynamicGenerationSchema(
-                name: "Person",
-                description: "Information about a person",
-                properties: [
-                    .init(name: "name", description: "The person's full name", schema: .init(type: String.self)),
-                    .init(name: "age", description: "The person's age in years", schema: .init(type: Int.self)),
-                    .init(name: "occupation", description: "The person's job or profession", schema: .init(type: String.self)),
-                    .init(name: "hobbies", description: "List of hobbies or interests", schema: .init(arrayOf: .init(type: String.self)))
-                ]
-            )
-            schema = try GenerationSchema(root: personSchema, dependencies: [])
-            schemaName = "Person"
-        case 1:
-            let specsSchema = DynamicGenerationSchema(
-                name: "Specifications",
-                description: "Product specifications",
-                properties: [
-                    .init(name: "display_size", description: "Display size if mentioned", schema: .init(type: String.self), isOptional: true),
-                    .init(name: "other_specs", description: "Any other specifications", schema: .init(arrayOf: .init(type: String.self)), isOptional: true)
-                ]
-            )
-            let productSchema = DynamicGenerationSchema(
-                name: "Product",
-                description: "Information about a product",
-                properties: [
-                    .init(name: "name", description: "Product name", schema: .init(type: String.self)),
-                    .init(name: "price", description: "Price in USD", schema: .init(type: Double.self)),
-                    .init(name: "specifications", description: "Product specifications", schema: specsSchema)
-                ]
-            )
-            schema = try GenerationSchema(root: productSchema, dependencies: [specsSchema])
-            schemaName = "Product"
-        default:
-            let customSchema = DynamicGenerationSchema(
-                name: "CustomObject",
-                description: "Generic custom object",
-                properties: [
-                    .init(name: "field1", description: "A text field", schema: .init(type: String.self)),
-                    .init(name: "field2", description: "A number field", schema: .init(type: Int.self))
-                ]
-            )
-            schema = try GenerationSchema(root: customSchema, dependencies: [])
-            schemaName = "CustomObject"
-        }
-
+    ) throws -> SchemaExecutionPlan {
+        let namedSchema = try basicObjectSchema(presetIndex: presetIndex)
         let prompt = """
         Extract the following information from this text:
 
         \(input)
         """
 
-        return (schema, prompt, { content in
-            """
-            Input:
-            \(input)
+        return SchemaExecutionPlan(
+            schema: namedSchema.schema,
+            prompt: prompt,
+            formatter: { content in
+                """
+                Input:
+                \(input)
 
-            Extracted Data:
-            \(generatedContentJSONString(content))
+                Extracted Data:
+                \(generatedContentJSONString(content))
 
-            Schema Used:
-            \(schemaName)
-            """
-        })
+                Schema Used:
+                \(namedSchema.name)
+                """
+            }
+        )
+    }
+
+    func basicObjectSchema(presetIndex: Int) throws -> NamedSchema {
+        switch presetIndex {
+        case 0:
+            return try personSchema()
+        case 1:
+            return try productSchema()
+        default:
+            return try customObjectSchema()
+        }
+    }
+
+    func personSchema() throws -> NamedSchema {
+        let personSchema = DynamicGenerationSchema(
+            name: "Person",
+            description: "Information about a person",
+            properties: [
+                .init(name: "name", description: "The person's full name", schema: .init(type: String.self)),
+                .init(name: "age", description: "The person's age in years", schema: .init(type: Int.self)),
+                .init(name: "occupation", description: "The person's job or profession", schema: .init(type: String.self)),
+                .init(name: "hobbies", description: "List of hobbies or interests", schema: .init(arrayOf: .init(type: String.self)))
+            ]
+        )
+        return NamedSchema(
+            schema: try GenerationSchema(root: personSchema, dependencies: []),
+            name: "Person"
+        )
+    }
+
+    func productSchema() throws -> NamedSchema {
+        let specsSchema = DynamicGenerationSchema(
+            name: "Specifications",
+            description: "Product specifications",
+            properties: [
+                .init(
+                    name: "display_size",
+                    description: "Display size if mentioned",
+                    schema: .init(type: String.self),
+                    isOptional: true
+                ),
+                .init(
+                    name: "other_specs",
+                    description: "Any other specifications",
+                    schema: .init(arrayOf: .init(type: String.self)),
+                    isOptional: true
+                )
+            ]
+        )
+        let productSchema = DynamicGenerationSchema(
+            name: "Product",
+            description: "Information about a product",
+            properties: [
+                .init(name: "name", description: "Product name", schema: .init(type: String.self)),
+                .init(name: "price", description: "Price in USD", schema: .init(type: Double.self)),
+                .init(name: "specifications", description: "Product specifications", schema: specsSchema)
+            ]
+        )
+        return NamedSchema(
+            schema: try GenerationSchema(root: productSchema, dependencies: [specsSchema]),
+            name: "Product"
+        )
+    }
+
+    func customObjectSchema() throws -> NamedSchema {
+        let customSchema = DynamicGenerationSchema(
+            name: "CustomObject",
+            description: "Generic custom object",
+            properties: [
+                .init(name: "field1", description: "A text field", schema: .init(type: String.self)),
+                .init(name: "field2", description: "A number field", schema: .init(type: Int.self))
+            ]
+        )
+        return NamedSchema(
+            schema: try GenerationSchema(root: customSchema, dependencies: []),
+            name: "CustomObject"
+        )
     }
 
     func arraySchemaPlan(
@@ -145,13 +194,41 @@ private extension RunSchemaExampleUseCase {
         input: String,
         minimumElements: Int,
         maximumElements: Int
-    ) throws -> (GenerationSchema, String, SchemaFormatter) {
+    ) throws -> SchemaExecutionPlan {
         guard minimumElements <= maximumElements else {
             throw FoundationLabCoreError.invalidRequest("Minimum elements must be less than or equal to maximum elements")
         }
 
-        let schema: GenerationSchema
+        let schema = try arraySchema(
+            presetIndex: presetIndex,
+            minimumElements: minimumElements,
+            maximumElements: maximumElements
+        )
+        let prompt = """
+        Extract the items from this text. Return between \(minimumElements) and \(maximumElements) items.
 
+        Text: \(input)
+        """
+
+        return SchemaExecutionPlan(
+            schema: schema,
+            prompt: prompt,
+            formatter: { content in
+                formattedArrayOutput(
+                    from: content,
+                    input: input,
+                    minimumElements: minimumElements,
+                    maximumElements: maximumElements
+                )
+            }
+        )
+    }
+
+    func arraySchema(
+        presetIndex: Int,
+        minimumElements: Int,
+        maximumElements: Int
+    ) throws -> GenerationSchema {
         switch presetIndex {
         case 0:
             let todoItemSchema = DynamicGenerationSchema(
@@ -172,7 +249,7 @@ private extension RunSchemaExampleUseCase {
                 minimumElements: minimumElements,
                 maximumElements: maximumElements
             )
-            schema = try GenerationSchema(root: arraySchema, dependencies: [todoItemSchema])
+            return try GenerationSchema(root: arraySchema, dependencies: [todoItemSchema])
         case 1:
             let ingredientSchema = DynamicGenerationSchema(
                 name: "Ingredient",
@@ -187,7 +264,7 @@ private extension RunSchemaExampleUseCase {
                 minimumElements: minimumElements,
                 maximumElements: maximumElements
             )
-            schema = try GenerationSchema(root: arraySchema, dependencies: [ingredientSchema])
+            return try GenerationSchema(root: arraySchema, dependencies: [ingredientSchema])
         default:
             let stringSchema = DynamicGenerationSchema(type: String.self)
             let arraySchema = DynamicGenerationSchema(
@@ -195,30 +272,15 @@ private extension RunSchemaExampleUseCase {
                 minimumElements: minimumElements,
                 maximumElements: maximumElements
             )
-            schema = try GenerationSchema(root: arraySchema, dependencies: [])
+            return try GenerationSchema(root: arraySchema, dependencies: [])
         }
-
-        let prompt = """
-        Extract the items from this text. Return between \(minimumElements) and \(maximumElements) items.
-
-        Text: \(input)
-        """
-
-        return (schema, prompt, { content in
-            formattedArrayOutput(
-                from: content,
-                input: input,
-                minimumElements: minimumElements,
-                maximumElements: maximumElements
-            )
-        })
     }
 
     func enumSchemaPlan(
         presetIndex: Int,
         input: String,
         customChoices: [String]?
-    ) throws -> (GenerationSchema, String, SchemaFormatter) {
+    ) throws -> SchemaExecutionPlan {
         let choices: [String]
         let fieldName: String
         let description: String
@@ -273,7 +335,7 @@ private extension RunSchemaExampleUseCase {
         fieldName: String,
         description: String,
         choices: [String]
-    ) throws -> (GenerationSchema, String, SchemaFormatter) {
+    ) throws -> SchemaExecutionPlan {
         let enumSchema = DynamicGenerationSchema(
             name: "\(fieldName.capitalized)Type",
             description: description,
@@ -284,8 +346,18 @@ private extension RunSchemaExampleUseCase {
             description: "Classification result with optional confidence and reasoning",
             properties: [
                 .init(name: fieldName, description: description, schema: enumSchema),
-                .init(name: "confidence", description: "Confidence score between 0 and 1", schema: .init(type: Float.self), isOptional: true),
-                .init(name: "reasoning", description: "Brief explanation for the classification", schema: .init(type: String.self), isOptional: true)
+                .init(
+                    name: "confidence",
+                    description: "Confidence score between 0 and 1",
+                    schema: .init(type: Float.self),
+                    isOptional: true
+                ),
+                .init(
+                    name: "reasoning",
+                    description: "Brief explanation for the classification",
+                    schema: .init(type: String.self),
+                    isOptional: true
+                )
             ]
         )
 
@@ -295,17 +367,18 @@ private extension RunSchemaExampleUseCase {
         Text: \(input)
         """
 
-        return (
-            try GenerationSchema(root: resultSchema, dependencies: [enumSchema]),
-            prompt,
-            { content in
-            formattedEnumOutput(
-                from: content,
-                input: input,
-                fieldName: fieldName,
-                choices: choices
-            )
-        })
+        return SchemaExecutionPlan(
+            schema: try GenerationSchema(root: resultSchema, dependencies: [enumSchema]),
+            prompt: prompt,
+            formatter: { content in
+                formattedEnumOutput(
+                    from: content,
+                    input: input,
+                    fieldName: fieldName,
+                    choices: choices
+                )
+            }
+        )
     }
 
     func formattedArrayOutput(
@@ -396,12 +469,16 @@ private extension RunSchemaExampleUseCase {
     func classificationData(
         from content: GeneratedContent,
         fieldName: String
-    ) -> (classification: String, confidence: Float?, reasoning: String?) {
+    ) -> ClassificationData {
         guard case .structure(let properties, _) = content.kind else {
-            return ("unknown", nil, nil)
+            return ClassificationData(
+                classification: "unknown",
+                confidence: nil,
+                reasoning: nil
+            )
         }
 
-        return (
+        return ClassificationData(
             classification: extractedStringValue(from: properties[fieldName]) ?? "unknown",
             confidence: extractedFloatValue(from: properties["confidence"]),
             reasoning: extractedStringValue(from: properties["reasoning"])

--- a/FoundationLabCore/Sources/FoundationLabCore/Catalogs/FoundationLabExampleCatalog.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Catalogs/FoundationLabExampleCatalog.swift
@@ -48,7 +48,8 @@ public enum FoundationLabExampleDemo: String, CaseIterable, Sendable, Codable, I
             Mood: A bit anxious and overwhelmed by deadlines.
             Sleep: Restless, woke up twice.
             Quote: "Enjoy when you can, and endure when you must."
-            Entry: I tried to focus today but kept jumping between tasks and felt guilty about not finishing. I want a calmer rhythm tomorrow.
+            Entry: I tried to focus today but kept jumping between tasks and felt guilty about not finishing. \
+            I want a calmer rhythm tomorrow.
             """
         case .creativeWriting:
             return "Write a story outline about time travel."

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
@@ -71,7 +71,7 @@ public final class FoundationLabConversationEngine {
         self.model = model
         self.adapterURL = adapterURL
         self.maxContextSize = configuration.defaultMaxContextSize
-        self.session = Self.makeSession(
+        self.session = FoundationLabSessionFactory.makeSession(
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
@@ -225,7 +225,7 @@ private extension FoundationLabConversationEngine {
         currentTokenCount = 0
         isSummarizing = false
         isApplyingWindow = false
-        session = Self.makeSession(
+        session = FoundationLabSessionFactory.makeSession(
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
@@ -289,71 +289,93 @@ private extension FoundationLabConversationEngine {
                 throw CancellationError()
             }
 
-            var latest = ""
-            if let generationOptions {
-                #if compiler(>=6.4)
-                if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-                    if let contextOptions = self.contextOptions() {
-                        for try await snapshot in self.session.streamResponse(
-                            to: Prompt(prompt),
-                            options: generationOptions.foundationModelsValue,
-                            contextOptions: contextOptions
-                        ) {
-                            latest = snapshot.content
-                            onPartialResponse?(snapshot.content)
-                        }
-                    } else {
-                        for try await snapshot in self.session.streamResponse(
-                            to: Prompt(prompt),
-                            options: generationOptions.foundationModelsValue
-                        ) {
-                            latest = snapshot.content
-                            onPartialResponse?(snapshot.content)
-                        }
-                    }
-                    return latest.isEmpty ? self.latestResponseText() : latest
-                }
-                #endif
-
-                for try await snapshot in self.session.streamResponse(
-                    to: Prompt(prompt),
-                    options: generationOptions.foundationModelsValue
-                ) {
-                    latest = snapshot.content
-                    onPartialResponse?(snapshot.content)
-                }
-            } else {
-                #if compiler(>=6.4)
-                if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-                    if let contextOptions = self.contextOptions() {
-                        for try await snapshot in self.session.streamResponse(
-                            to: Prompt(prompt),
-                            contextOptions: contextOptions
-                        ) {
-                            latest = snapshot.content
-                            onPartialResponse?(snapshot.content)
-                        }
-                    } else {
-                        for try await snapshot in self.session.streamResponse(to: Prompt(prompt)) {
-                            latest = snapshot.content
-                            onPartialResponse?(snapshot.content)
-                        }
-                    }
-                    return latest.isEmpty ? self.latestResponseText() : latest
-                }
-                #endif
-
-                for try await snapshot in self.session.streamResponse(to: Prompt(prompt)) {
-                    latest = snapshot.content
-                    onPartialResponse?(snapshot.content)
-                }
-            }
+            let latest = try await self.performStreamingResponse(
+                to: prompt,
+                generationOptions: generationOptions,
+                onPartialResponse: onPartialResponse
+            )
             return latest.isEmpty ? self.latestResponseText() : latest
         }
 
         activeStreamingTask = task
         defer { activeStreamingTask = nil }
         return try await task.value
+    }
+
+    func performStreamingResponse(
+        to prompt: String,
+        generationOptions: FoundationLabGenerationOptions?,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        if let generationOptions {
+            return try await streamWithGenerationOptions(
+                prompt: prompt,
+                generationOptions: generationOptions,
+                onPartialResponse: onPartialResponse
+            )
+        }
+
+        return try await streamWithoutGenerationOptions(
+            prompt: prompt,
+            onPartialResponse: onPartialResponse
+        )
+    }
+
+    func streamWithGenerationOptions(
+        prompt: String,
+        generationOptions: FoundationLabGenerationOptions,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        var latest = ""
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *),
+           let contextOptions = contextOptions() {
+            for try await snapshot in session.streamResponse(
+                to: Prompt(prompt),
+                options: generationOptions.foundationModelsValue,
+                contextOptions: contextOptions
+            ) {
+                latest = snapshot.content
+                onPartialResponse?(snapshot.content)
+            }
+            return latest
+        }
+        #endif
+
+        for try await snapshot in session.streamResponse(
+            to: Prompt(prompt),
+            options: generationOptions.foundationModelsValue
+        ) {
+            latest = snapshot.content
+            onPartialResponse?(snapshot.content)
+        }
+        return latest
+    }
+
+    func streamWithoutGenerationOptions(
+        prompt: String,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        var latest = ""
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *),
+           let contextOptions = contextOptions() {
+            for try await snapshot in session.streamResponse(
+                to: Prompt(prompt),
+                contextOptions: contextOptions
+            ) {
+                latest = snapshot.content
+                onPartialResponse?(snapshot.content)
+            }
+            return latest
+        }
+        #endif
+
+        for try await snapshot in session.streamResponse(to: Prompt(prompt)) {
+            latest = snapshot.content
+            onPartialResponse?(snapshot.content)
+        }
+        return latest
     }
 
     func respond(
@@ -447,7 +469,7 @@ private extension FoundationLabConversationEngine {
     }
 
     func generateConversationSummary() async throws -> FoundationLabConversationSummary {
-        let summarySession = Self.makeSession(
+        let summarySession = FoundationLabSessionFactory.makeSession(
             runtime: .onDevice,
             model: model,
             tools: [],
@@ -480,7 +502,7 @@ private extension FoundationLabConversationEngine {
             continuationNote: configuration.continuationNote
         )
 
-        session = Self.makeSession(
+        session = FoundationLabSessionFactory.makeSession(
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
@@ -492,7 +514,7 @@ private extension FoundationLabConversationEngine {
     }
 
     func createFreshSessionAfterOverflow() {
-        session = Self.makeSession(
+        session = FoundationLabSessionFactory.makeSession(
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
@@ -526,89 +548,6 @@ private extension FoundationLabConversationEngine {
         }
         return ""
     }
-
-    static func makeSession(
-        model: SystemLanguageModel,
-        tools: [any Tool],
-        instructions: String
-    ) -> LanguageModelSession {
-        makeSession(
-            runtime: .onDevice,
-            model: model,
-            tools: tools,
-            instructions: instructions
-        )
-    }
-
-    static func makeSession(
-        runtime: FoundationLabModelRuntime,
-        model: SystemLanguageModel,
-        tools: [any Tool],
-        instructions: String
-    ) -> LanguageModelSession {
-        #if compiler(>=6.4)
-        if runtime == .privateCloudCompute {
-            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-                return makeSession(
-                    model: PrivateCloudComputeLanguageModel(),
-                    tools: tools,
-                    instructions: instructions
-                )
-            }
-        }
-        #endif
-
-        let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !tools.isEmpty {
-            if trimmedInstructions.isEmpty {
-                return LanguageModelSession(model: model, tools: tools)
-            }
-            return LanguageModelSession(
-                model: model,
-                tools: tools,
-                instructions: Instructions(trimmedInstructions)
-            )
-        }
-
-        if trimmedInstructions.isEmpty {
-            return LanguageModelSession(model: model)
-        }
-
-        return LanguageModelSession(
-            model: model,
-            instructions: Instructions(trimmedInstructions)
-        )
-    }
-
-    #if compiler(>=6.4)
-    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
-    static func makeSession(
-        model: PrivateCloudComputeLanguageModel,
-        tools: [any Tool],
-        instructions: String
-    ) -> LanguageModelSession {
-        let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !tools.isEmpty {
-            if trimmedInstructions.isEmpty {
-                return LanguageModelSession(model: model, tools: tools)
-            }
-            return LanguageModelSession(
-                model: model,
-                tools: tools,
-                instructions: Instructions(trimmedInstructions)
-            )
-        }
-
-        if trimmedInstructions.isEmpty {
-            return LanguageModelSession(model: model)
-        }
-
-        return LanguageModelSession(
-            model: model,
-            instructions: Instructions(trimmedInstructions)
-        )
-    }
-    #endif
 
     #if compiler(>=6.4)
     @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabSessionFactory.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabSessionFactory.swift
@@ -1,0 +1,85 @@
+import Foundation
+import FoundationModels
+
+enum FoundationLabSessionFactory {
+    static func makeSession(
+        runtime: FoundationLabModelRuntime,
+        model: SystemLanguageModel,
+        tools: [any Tool],
+        instructions: String
+    ) -> LanguageModelSession {
+        #if compiler(>=6.4)
+        if runtime == .privateCloudCompute {
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                return makePrivateCloudSession(
+                    tools: tools,
+                    instructions: instructions
+                )
+            }
+        }
+        #endif
+
+        return makeOnDeviceSession(
+            model: model,
+            tools: tools,
+            instructions: instructions
+        )
+    }
+
+    private static func makeOnDeviceSession(
+        model: SystemLanguageModel,
+        tools: [any Tool],
+        instructions: String
+    ) -> LanguageModelSession {
+        let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tools.isEmpty {
+            if trimmedInstructions.isEmpty {
+                return LanguageModelSession(model: model, tools: tools)
+            }
+            return LanguageModelSession(
+                model: model,
+                tools: tools,
+                instructions: Instructions(trimmedInstructions)
+            )
+        }
+
+        if trimmedInstructions.isEmpty {
+            return LanguageModelSession(model: model)
+        }
+
+        return LanguageModelSession(
+            model: model,
+            instructions: Instructions(trimmedInstructions)
+        )
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    private static func makePrivateCloudSession(
+        tools: [any Tool],
+        instructions: String
+    ) -> LanguageModelSession {
+        let model = PrivateCloudComputeLanguageModel()
+        let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tools.isEmpty {
+            if trimmedInstructions.isEmpty {
+                return LanguageModelSession(model: model, tools: tools)
+            }
+            return LanguageModelSession(
+                model: model,
+                tools: tools,
+                instructions: Instructions(trimmedInstructions)
+            )
+        }
+
+        if trimmedInstructions.isEmpty {
+            return LanguageModelSession(model: model)
+        }
+
+        return LanguageModelSession(
+            model: model,
+            instructions: Instructions(trimmedInstructions)
+        )
+    }
+    #endif
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsCalendarQuerier.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsCalendarQuerier.swift
@@ -16,10 +16,14 @@ public struct FoundationModelsCalendarQuerier: CalendarQuerying {
 
         let localeIdentifier = request.context.localeIdentifier ?? Locale.current.identifier
         let timeZone = FoundationModelsPromptSupport.resolvedTimeZone(identifier: request.timeZoneIdentifier)
+        let currentTimestamp = FoundationModelsPromptSupport.isoTimestamp(
+            request.referenceDate,
+            timeZoneIdentifier: request.timeZoneIdentifier
+        )
         let contextualInstructions = """
         The user's current time zone is \(timeZone.identifier).
         The user's current locale identifier is \(localeIdentifier).
-        The current local date and time is \(FoundationModelsPromptSupport.isoTimestamp(request.referenceDate, timeZoneIdentifier: request.timeZoneIdentifier)).
+        The current local date and time is \(currentTimestamp).
         Use this information when interpreting relative dates like "today" or "tomorrow".
         """
 

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsNutritionAnalyzer.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsNutritionAnalyzer.swift
@@ -109,6 +109,14 @@ private struct NutritionReference {
     let fat: Int
 }
 
+private struct NutritionSummaryValues {
+    let foodName: String
+    let calories: Int
+    let protein: Int
+    let carbs: Int
+    let fat: Int
+}
+
 private let nutritionReferences: [NutritionReference] = [
     .init(name: "egg", aliases: ["scrambled egg", "scrambled eggs", "egg", "eggs"], calories: 72, protein: 6, carbs: 1, fat: 5),
     .init(name: "toast", aliases: ["toast"], calories: 80, protein: 3, carbs: 15, fat: 1),
@@ -159,6 +167,13 @@ private func heuristicNutritionAnalysis(
         quantity > 1 ? "\(quantity)x \(reference.name)" : reference.name
     }
     .joined(separator: ", ")
+    let summaryValues = NutritionSummaryValues(
+        foodName: foodName,
+        calories: calories,
+        protein: protein,
+        carbs: carbs,
+        fat: fat
+    )
 
     return NutritionAnalysis(
         foodName: foodName,
@@ -167,11 +182,7 @@ private func heuristicNutritionAnalysis(
         carbsGrams: carbs,
         fatGrams: fat,
         insights: localizedNutritionSummary(
-            foodName: foodName,
-            calories: calories,
-            protein: protein,
-            carbs: carbs,
-            fat: fat,
+            summaryValues,
             responseLanguage: responseLanguage
         )
     )
@@ -192,32 +203,40 @@ private func inferredQuantity(for alias: String, in description: String) -> Int 
 }
 
 private func localizedNutritionSummary(
-    foodName: String,
-    calories: Int,
-    protein: Int,
-    carbs: Int,
-    fat: Int,
+    _ values: NutritionSummaryValues,
     responseLanguage: String
 ) -> String {
     let language = responseLanguage.lowercased()
 
     if language.contains("french") {
-        return "\(foodName) est estime a environ \(calories) calories, avec \(protein) g de proteines, \(carbs) g de glucides et \(fat) g de lipides. Il s'agit d'un resume factuel base sur des portions courantes."
+        return "\(values.foodName) est estime a environ \(values.calories) calories, " +
+            "avec \(values.protein) g de proteines, \(values.carbs) g de glucides et \(values.fat) g de lipides. " +
+            "Il s'agit d'un resume factuel base sur des portions courantes."
     }
     if language.contains("spanish") {
-        return "\(foodName) se estima en unas \(calories) calorias, con \(protein) g de proteina, \(carbs) g de carbohidratos y \(fat) g de grasa. Es un resumen factual basado en porciones comunes."
+        return "\(values.foodName) se estima en unas \(values.calories) calorias, " +
+            "con \(values.protein) g de proteina, \(values.carbs) g de carbohidratos y \(values.fat) g de grasa. " +
+            "Es un resumen factual basado en porciones comunes."
     }
     if language.contains("german") {
-        return "\(foodName) wird auf etwa \(calories) Kalorien mit \(protein) g Protein, \(carbs) g Kohlenhydraten und \(fat) g Fett geschatzt. Dies ist eine sachliche Schatzung auf Basis ublicher Portionen."
+        return "\(values.foodName) wird auf etwa \(values.calories) Kalorien mit \(values.protein) g Protein, " +
+            "\(values.carbs) g Kohlenhydraten und \(values.fat) g Fett geschatzt. " +
+            "Dies ist eine sachliche Schatzung auf Basis ublicher Portionen."
     }
     if language.contains("italian") {
-        return "\(foodName) e stimato a circa \(calories) calorie, con \(protein) g di proteine, \(carbs) g di carboidrati e \(fat) g di grassi. Si tratta di un riepilogo fattuale basato su porzioni comuni."
+        return "\(values.foodName) e stimato a circa \(values.calories) calorie, " +
+            "con \(values.protein) g di proteine, \(values.carbs) g di carboidrati e \(values.fat) g di grassi. " +
+            "Si tratta di un riepilogo fattuale basato su porzioni comuni."
     }
     if language.contains("portuguese") {
-        return "\(foodName) e estimado em cerca de \(calories) calorias, com \(protein) g de proteina, \(carbs) g de carboidratos e \(fat) g de gordura. Este e um resumo factual baseado em porcoes comuns."
+        return "\(values.foodName) e estimado em cerca de \(values.calories) calorias, " +
+            "com \(values.protein) g de proteina, \(values.carbs) g de carboidratos e \(values.fat) g de gordura. " +
+            "Este e um resumo factual baseado em porcoes comuns."
     }
 
-    return "\(foodName) is estimated at about \(calories) calories, with \(protein)g protein, \(carbs)g carbs, and \(fat)g fat. This is a factual estimate based on common serving sizes."
+    return "\(values.foodName) is estimated at about \(values.calories) calories, " +
+        "with \(values.protein)g protein, \(values.carbs)g carbs, and \(values.fat)g fat. " +
+        "This is a factual estimate based on common serving sizes."
 }
 
 private func nutritionPrompt(

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsReminderManager.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsReminderManager.swift
@@ -87,10 +87,14 @@ public struct FoundationModelsReminderManager: ReminderManaging {
         timeZone: TimeZone,
         localeIdentifier: String
     ) -> String {
-        """
+        let timeZoneName = timeZone.localizedName(
+            for: .standard,
+            locale: Locale(identifier: localeIdentifier)
+        ) ?? "Unknown"
+        return """
         You are a helpful assistant that can create reminders for users.
         Current date and time: \(formattedDate)
-        Time zone: \(timeZone.identifier) (\(timeZone.localizedName(for: .standard, locale: Locale(identifier: localeIdentifier)) ?? "Unknown"))
+        Time zone: \(timeZone.identifier) (\(timeZoneName))
         When creating reminders, consider the current date and time zone context.
         Always execute tool calls directly without asking for confirmation or permission from the user.
         If you need to create a reminder, call the RemindersTool immediately with the appropriate parameters.
@@ -105,10 +109,14 @@ public struct FoundationModelsReminderManager: ReminderManaging {
         timeZone: TimeZone,
         localeIdentifier: String
     ) -> String {
-        """
+        let timeZoneName = timeZone.localizedName(
+            for: .standard,
+            locale: Locale(identifier: localeIdentifier)
+        ) ?? "Unknown"
+        return """
         You are a helpful assistant that creates reminders based on structured input.
         Current date and time: \(formattedDate)
-        Time zone: \(timeZone.identifier) (\(timeZone.localizedName(for: .standard, locale: Locale(identifier: localeIdentifier)) ?? "Unknown"))
+        Time zone: \(timeZone.identifier) (\(timeZoneName))
         Always execute the RemindersTool directly with the provided information.
         Format due dates as 'yyyy-MM-dd HH:mm:ss' (24-hour format).
         """

--- a/FoundationLabCore/Sources/FoundationLabCore/Tools/Search1WebSearchTool.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Tools/Search1WebSearchTool.swift
@@ -65,7 +65,7 @@ extension Search1WebSearchTool {
         }
 
         guard (200...299).contains(httpResponse.statusCode) else {
-            let body = String(decoding: data, as: UTF8.self)
+            let body = String(data: data, encoding: .utf8) ?? ""
             throw Search1WebSearchError.httpStatus(code: httpResponse.statusCode, body: body)
         }
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CLIOptionPacks.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CLIOptionPacks.swift
@@ -26,12 +26,14 @@ struct PromptInputOptions: ParsableArguments {
 
     func resolve(required: Bool = true) throws -> ResolvedTextInput? {
         try resolveSingleInput(
-            inlineValue: prompt,
-            fileValue: promptFile,
-            stdin: stdin,
-            inlineOptionName: "--prompt",
-            fileOptionName: "--prompt-file",
-            requiredMessage: "Please provide --prompt, --prompt-file, or stdin."
+            SingleInputRequest(
+                inlineValue: prompt,
+                fileValue: promptFile,
+                stdin: stdin,
+                inlineOptionName: "--prompt",
+                fileOptionName: "--prompt-file",
+                requiredMessage: "Please provide --prompt, --prompt-file, or stdin."
+            )
         )
     }
 }
@@ -49,13 +51,15 @@ struct InputSourceOptions: ParsableArguments {
     func resolve(defaultValue: String? = nil) throws -> ResolvedTextInput {
         if input != nil || inputFile != nil || stdin {
             if let resolved = try resolveSingleInput(
-                inlineValue: input,
-                fileValue: inputFile,
-                stdin: stdin,
-                inlineOptionName: "--input",
-                fileOptionName: "--input-file",
-                requiredMessage: "Please provide --input, --input-file, or stdin.",
-                allowAutomaticStdin: false
+                SingleInputRequest(
+                    inlineValue: input,
+                    fileValue: inputFile,
+                    stdin: stdin,
+                    inlineOptionName: "--input",
+                    fileOptionName: "--input-file",
+                    requiredMessage: "Please provide --input, --input-file, or stdin.",
+                    allowAutomaticStdin: false
+                )
             ) {
                 return resolved
             }
@@ -76,7 +80,11 @@ struct InputSourceOptions: ParsableArguments {
 }
 
 struct SessionOptions: ParsableArguments {
-    @Option(name: .long, parsing: .upToNextOption, help: "Message(s) to send through one shared session. Repeat for multi-turn chat. Prefix values with @ to read from files.")
+    @Option(
+        name: .long,
+        parsing: .upToNextOption,
+        help: "Message(s) to send through one shared session. Repeat for multi-turn chat. Prefix values with @ to read from files."
+    )
     var message: [String] = []
 
     @Option(name: .customLong("message-file"), parsing: .upToNextOption, help: "Read one or more chat messages from files.")
@@ -145,7 +153,11 @@ struct SchemaSourceOptions: ParsableArguments {
 }
 
 struct ToolSourceOptions: ParsableArguments {
-    @Option(name: .long, parsing: .upToNextOption, help: "Tool identifier or file path. Searches --tool-dir for bare identifiers. Repeat to load multiple tools.")
+    @Option(
+        name: .long,
+        parsing: .upToNextOption,
+        help: "Tool identifier or file path. Searches --tool-dir for bare identifiers. Repeat to load multiple tools."
+    )
     var tool: [String] = []
 
     @Option(name: .customLong("tool-dir"), help: "Directory used to resolve bare tool identifiers.")
@@ -187,33 +199,40 @@ struct ResolvedArtifactReference: Sendable, Encodable {
     let directory: String
 }
 
-func resolveSingleInput(
-    inlineValue: String?,
-    fileValue: String?,
-    stdin: Bool,
-    inlineOptionName: String,
-    fileOptionName: String,
-    requiredMessage: String,
-    allowAutomaticStdin: Bool = true
-) throws -> ResolvedTextInput? {
+struct SingleInputRequest {
+    let inlineValue: String?
+    let fileValue: String?
+    let stdin: Bool
+    let inlineOptionName: String
+    let fileOptionName: String
+    let requiredMessage: String
+    var allowAutomaticStdin = true
+}
+
+func resolveSingleInput(_ request: SingleInputRequest) throws -> ResolvedTextInput? {
     var explicitSourceCount = 0
-    if inlineValue != nil { explicitSourceCount += 1 }
-    if fileValue != nil { explicitSourceCount += 1 }
-    if stdin { explicitSourceCount += 1 }
+    if request.inlineValue != nil { explicitSourceCount += 1 }
+    if request.fileValue != nil { explicitSourceCount += 1 }
+    if request.stdin { explicitSourceCount += 1 }
     if explicitSourceCount > 1 {
-        throw ValidationError("Use only one of \(inlineOptionName), \(fileOptionName), or --stdin.")
+        throw ValidationError(
+            "Use only one of \(request.inlineOptionName), \(request.fileOptionName), or --stdin."
+        )
     }
 
-    if let inlineValue {
-        return try resolveInlineValue(inlineValue, optionName: inlineOptionName)
+    if let inlineValue = request.inlineValue {
+        return try resolveInlineValue(inlineValue, optionName: request.inlineOptionName)
     }
 
-    if let fileValue {
-        return try readFileInput(path: fileValue, optionName: fileOptionName)
+    if let fileValue = request.fileValue {
+        return try readFileInput(path: fileValue, optionName: request.fileOptionName)
     }
 
-    if stdin || (allowAutomaticStdin && shouldAutomaticallyReadFromStdin()) {
-        return try readStandardInput(optionName: "--stdin", requiredMessage: requiredMessage)
+    if request.stdin || (request.allowAutomaticStdin && shouldAutomaticallyReadFromStdin()) {
+        return try readStandardInput(
+            optionName: "--stdin",
+            requiredMessage: request.requiredMessage
+        )
     }
 
     return nil

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
@@ -141,6 +141,21 @@ struct GenerationFlags: ParsableArguments {
     var guardrails: FoundationLabGuardrails = .default
 
     func validatedOptions() throws -> FoundationLabGenerationOptions? {
+        try validateOptionCombinations()
+        let resolvedSampling = resolvedSamplingMode()
+
+        guard resolvedSampling != nil || temperature != nil || maxTokens != nil else {
+            return nil
+        }
+
+        return FoundationLabGenerationOptions(
+            sampling: resolvedSampling,
+            temperature: temperature,
+            maximumResponseTokens: maxTokens
+        )
+    }
+
+    private func validateOptionCombinations() throws {
         if seed != nil && sampling != .topK && sampling != .nucleus {
             throw ValidationError("--seed is only valid with non-greedy sampling")
         }
@@ -162,27 +177,19 @@ struct GenerationFlags: ParsableArguments {
         if sampling != .nucleus, topP != nil {
             throw ValidationError("--top-p is only valid with --sampling nucleus")
         }
-        let resolvedSampling: FoundationLabGenerationOptions.SamplingMode?
+    }
+
+    private func resolvedSamplingMode() -> FoundationLabGenerationOptions.SamplingMode? {
         switch sampling {
         case .greedy:
-            resolvedSampling = .greedy
+            return .greedy
         case .topK:
-            resolvedSampling = .randomTop(topK ?? 50, seed: seed)
+            return .randomTop(topK ?? 50, seed: seed)
         case .nucleus:
-            resolvedSampling = .randomProbabilityThreshold(topP ?? 0.9, seed: seed)
+            return .randomProbabilityThreshold(topP ?? 0.9, seed: seed)
         case .none:
-            resolvedSampling = nil
-        }
-
-        guard resolvedSampling != nil || temperature != nil || maxTokens != nil else {
             return nil
         }
-
-        return FoundationLabGenerationOptions(
-            sampling: resolvedSampling,
-            temperature: temperature,
-            maximumResponseTokens: maxTokens
-        )
     }
 }
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelCommands.swift
@@ -153,7 +153,10 @@ struct ModelUseCasesCommand: AsyncParsableCommand {
         let payload = ModelUseCasesPayload(
             useCases: [
                 .init(id: FoundationLabModelUseCase.general.rawValue, summary: "General-purpose prompting and text generation."),
-                .init(id: FoundationLabModelUseCase.contentTagging.rawValue, summary: "Specialized tagging use case that returns categorizing tags.")
+                .init(
+                    id: FoundationLabModelUseCase.contentTagging.rawValue,
+                    summary: "Specialized tagging use case that returns categorizing tags."
+                )
             ]
         )
         let human = """
@@ -197,8 +200,14 @@ struct ModelGuardrailsCommand: AsyncParsableCommand {
 
         let payload = ModelGuardrailsPayload(
             guardrails: [
-                .init(id: FoundationLabGuardrails.default.afmArgumentValue, summary: "Default guardrails that block unsafe content in prompts and responses."),
-                .init(id: FoundationLabGuardrails.permissiveContentTransformations.afmArgumentValue, summary: "Permissive transformations for String generation while keeping structured generation strict.")
+                .init(
+                    id: FoundationLabGuardrails.default.afmArgumentValue,
+                    summary: "Default guardrails that block unsafe content in prompts and responses."
+                ),
+                .init(
+                    id: FoundationLabGuardrails.permissiveContentTransformations.afmArgumentValue,
+                    summary: "Permissive transformations for String generation while keeping structured generation strict."
+                )
             ]
         )
         let human = """

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaBuilders.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaBuilders.swift
@@ -1,0 +1,86 @@
+import ArgumentParser
+import FoundationModels
+
+func makeBasicObjectSchema(presetID: String) throws -> GenerationSchema {
+    let root: DynamicGenerationSchema
+    switch presetID {
+    case "person":
+        root = DynamicGenerationSchema(
+            name: "Person",
+            properties: [
+                .init(name: "name", schema: .init(type: String.self)),
+                .init(name: "age", schema: .init(type: Int.self)),
+                .init(name: "occupation", schema: .init(type: String.self))
+            ]
+        )
+    case "product":
+        root = DynamicGenerationSchema(
+            name: "Product",
+            properties: [
+                .init(name: "name", schema: .init(type: String.self)),
+                .init(name: "price", schema: .init(type: Double.self)),
+                .init(name: "feature", schema: .init(type: String.self))
+            ]
+        )
+    default:
+        throw ValidationError("Unknown preset '\(presetID)' for basic-object")
+    }
+    return try GenerationSchema(root: root, dependencies: [])
+}
+
+func makeArraySchema(
+    presetID: String,
+    minimumItems: Int,
+    maximumItems: Int
+) throws -> GenerationSchema {
+    guard minimumItems > 0 else {
+        throw ValidationError("--min-items must be greater than 0")
+    }
+    guard maximumItems >= minimumItems else {
+        throw ValidationError("--max-items must be greater than or equal to --min-items")
+    }
+
+    let itemName: String = switch presetID {
+    case "todo": "TodoItem"
+    default: throw ValidationError("Unknown preset '\(presetID)' for array-schema")
+    }
+
+    let itemSchema = DynamicGenerationSchema(
+        name: itemName,
+        properties: [
+            .init(name: "title", schema: .init(type: String.self)),
+            .init(name: "completed", schema: .init(type: Bool.self), isOptional: true)
+        ]
+    )
+    let root = DynamicGenerationSchema(
+        name: "TodoList",
+        properties: [
+            .init(
+                name: "items",
+                schema: .init(
+                    arrayOf: .init(referenceTo: itemName),
+                    minimumElements: minimumItems,
+                    maximumElements: maximumItems
+                )
+            )
+        ]
+    )
+    return try GenerationSchema(root: root, dependencies: [itemSchema])
+}
+
+func makeEnumSchema(
+    presetID: String,
+    customChoices: [String]
+) throws -> GenerationSchema {
+    let choices = customChoices.isEmpty
+        ? AFMSchemaCatalog.defaultChoices(for: presetID)
+        : customChoices
+    let root = DynamicGenerationSchema(
+        name: "Classification",
+        properties: [
+            .init(name: "label", schema: .init(name: "Label", anyOf: choices)),
+            .init(name: "reason", schema: .init(type: String.self), isOptional: true)
+        ]
+    )
+    return try GenerationSchema(root: root, dependencies: [])
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaCommands.swift
@@ -149,33 +149,13 @@ struct SchemaCustomCommand: AsyncParsableCommand {
                 context: afmContext()
             )
         )
-
-        let json = result.output.jsonString
-        let payload = DynamicSchemaPayload(
-            command: "schema run custom",
-            adapter: adapterPath,
-            preset: schemaReference.identifier,
-            useCase: useCaseFlags.useCase.rawValue,
-            guardrails: generation.guardrails.afmArgumentValue,
-            includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt,
-            input: resolvedInput.value,
-            json: json,
-            tokenCount: result.metadata.tokenCount,
-            schemaFile: schemaReference.filePath
+        try emitResult(
+            result,
+            schemaReference: schemaReference,
+            resolvedInput: resolvedInput,
+            adapterPath: adapterPath,
+            outputOptions: resolvedOutput
         )
-        let human = """
-        Custom Schema
-
-        Schema: \(schemaReference.filePath)
-        \(json)
-        """
-        let verboseHuman: String
-        if options.verbose, let tokenCount = result.metadata.tokenCount {
-            verboseHuman = "\(human)\n\nToken count: \(tokenCount)"
-        } else {
-            verboseHuman = human
-        }
-        try CLIOutput.emit(payload: payload, human: verboseHuman, options: resolvedOutput)
     }
 }
 
@@ -235,6 +215,60 @@ struct TypedPersonSchemaCommand: AsyncParsableCommand {
                 context: afmContext()
             )
         )
+        try emitResult(
+            result,
+            preset: preset,
+            resolvedInput: resolvedInput,
+            adapterPath: adapterPath,
+            outputOptions: resolvedOutput
+        )
+    }
+}
+
+private extension SchemaCustomCommand {
+    func emitResult(
+        _ result: DynamicSchemaGenerationResult,
+        schemaReference: ResolvedArtifactReference,
+        resolvedInput: ResolvedTextInput,
+        adapterPath: String?,
+        outputOptions: CLIOutputOptions
+    ) throws {
+        let json = result.output.jsonString
+        let payload = DynamicSchemaPayload(
+            command: "schema run custom",
+            adapter: adapterPath,
+            preset: schemaReference.identifier,
+            useCase: useCaseFlags.useCase.rawValue,
+            guardrails: generation.guardrails.afmArgumentValue,
+            includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt,
+            input: resolvedInput.value,
+            json: json,
+            tokenCount: result.metadata.tokenCount,
+            schemaFile: schemaReference.filePath
+        )
+        let human = """
+        Custom Schema
+
+        Schema: \(schemaReference.filePath)
+        \(json)
+        """
+        let renderedHuman = verboseHumanOutput(
+            human,
+            tokenCount: result.metadata.tokenCount,
+            verbose: options.verbose
+        )
+        try CLIOutput.emit(payload: payload, human: renderedHuman, options: outputOptions)
+    }
+}
+
+private extension TypedPersonSchemaCommand {
+    func emitResult(
+        _ result: StructuredGenerationResult<AFMGeneratedPerson>,
+        preset: AFMSchemaPreset,
+        resolvedInput: ResolvedTextInput,
+        adapterPath: String?,
+        outputOptions: CLIOutputOptions
+    ) throws {
         let payload = TypedSchemaPayload(
             command: "schema run typed-person",
             adapter: adapterPath,
@@ -253,14 +287,24 @@ struct TypedPersonSchemaCommand: AsyncParsableCommand {
         Age: \(result.output.age)
         Occupation: \(result.output.occupation)
         """
-        let verboseHuman: String
-        if options.verbose, let tokenCount = result.metadata.tokenCount {
-            verboseHuman = "\(human)\n\nToken count: \(tokenCount)"
-        } else {
-            verboseHuman = human
-        }
-        try CLIOutput.emit(payload: payload, human: verboseHuman, options: resolvedOutput)
+        let renderedHuman = verboseHumanOutput(
+            human,
+            tokenCount: result.metadata.tokenCount,
+            verbose: options.verbose
+        )
+        try CLIOutput.emit(payload: payload, human: renderedHuman, options: outputOptions)
     }
+}
+
+private func verboseHumanOutput(
+    _ human: String,
+    tokenCount: Int?,
+    verbose: Bool
+) -> String {
+    guard verbose, let tokenCount else {
+        return human
+    }
+    return "\(human)\n\nToken count: \(tokenCount)"
 }
 
 struct BasicObjectSchemaCommand: AsyncParsableCommand {
@@ -281,16 +325,18 @@ struct BasicObjectSchemaCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         try await runDynamicSchemaCommand(
-            command: "schema run basic-object",
-            exampleID: "basic-object",
-            presetID: preset,
-            inputSource: inputSource,
-            schemaBuilder: makeBasicObjectSchema,
-            options: options,
-            generation: generation,
-            adapterPath: try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails),
-            useCase: useCaseFlags.useCase,
-            includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt
+            DynamicSchemaCommandRequest(
+                command: "schema run basic-object",
+                exampleID: "basic-object",
+                presetID: preset,
+                inputSource: inputSource,
+                schemaBuilder: makeBasicObjectSchema,
+                options: options,
+                generation: generation,
+                adapterPath: try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails),
+                useCase: useCaseFlags.useCase,
+                includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt
+            )
         )
     }
 }
@@ -318,19 +364,27 @@ struct ArraySchemaCommand: AsyncParsableCommand {
     var maximumItems = 5
 
     mutating func run() async throws {
+        let resolvedMinimumItems = minimumItems
+        let resolvedMaximumItems = maximumItems
         try await runDynamicSchemaCommand(
-            command: "schema run array-schema",
-            exampleID: "array-schema",
-            presetID: preset,
-            inputSource: inputSource,
-            schemaBuilder: { presetID in
-                try makeArraySchema(presetID: presetID, minimumItems: minimumItems, maximumItems: maximumItems)
-            },
-            options: options,
-            generation: generation,
-            adapterPath: try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails),
-            useCase: useCaseFlags.useCase,
-            includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt
+            DynamicSchemaCommandRequest(
+                command: "schema run array-schema",
+                exampleID: "array-schema",
+                presetID: preset,
+                inputSource: inputSource,
+                schemaBuilder: { presetID in
+                    try makeArraySchema(
+                        presetID: presetID,
+                        minimumItems: resolvedMinimumItems,
+                        maximumItems: resolvedMaximumItems
+                    )
+                },
+                options: options,
+                generation: generation,
+                adapterPath: try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails),
+                useCase: useCaseFlags.useCase,
+                includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt
+            )
         )
     }
 }
@@ -355,90 +409,115 @@ struct EnumSchemaCommand: AsyncParsableCommand {
     var choice: [String] = []
 
     mutating func run() async throws {
+        let customChoices = choice
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
         try await runDynamicSchemaCommand(
-            command: "schema run enum-schema",
-            exampleID: "enum-schema",
-            presetID: preset,
-            inputSource: inputSource,
-            schemaBuilder: { presetID in
-                try makeEnumSchema(
-                    presetID: presetID,
-                    customChoices: choice.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
-                )
-            },
-            options: options,
-            generation: generation,
-            adapterPath: try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails),
-            useCase: useCaseFlags.useCase,
-            includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt
+            DynamicSchemaCommandRequest(
+                command: "schema run enum-schema",
+                exampleID: "enum-schema",
+                presetID: preset,
+                inputSource: inputSource,
+                schemaBuilder: { presetID in
+                    try makeEnumSchema(
+                        presetID: presetID,
+                        customChoices: customChoices
+                    )
+                },
+                options: options,
+                generation: generation,
+                adapterPath: try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails),
+                useCase: useCaseFlags.useCase,
+                includeSchemaInPrompt: schemaPromptFlags.includeSchemaInPrompt
+            )
         )
     }
 }
 
-private func runDynamicSchemaCommand(
-    command: String,
-    exampleID: String,
-    presetID: String,
-    inputSource: InputSourceOptions,
-    schemaBuilder: (String) throws -> GenerationSchema,
-    options: GlobalCommandOptions,
-    generation: GenerationFlags,
-    adapterPath: String?,
-    useCase: FoundationLabModelUseCase,
-    includeSchemaInPrompt: Bool
-) async throws {
-    let resolvedOutput = try options.resolvedOutput()
-    let generationOptions = try generation.validatedOptions()
-    guard let example = AFMSchemaCatalog.example(id: exampleID) else {
-        throw AFMRuntimeError.invalidRequest("Unknown schema example: \(exampleID)")
-    }
-    guard let preset = example.presets.first(where: { $0.id == presetID }) else {
-        throw ValidationError("Unknown preset '\(presetID)' for \(exampleID)")
-    }
-    let resolvedInput = try inputSource.resolve(defaultValue: preset.defaultInput)
+private struct DynamicSchemaCommandRequest {
+    let command: String
+    let exampleID: String
+    let presetID: String
+    let inputSource: InputSourceOptions
+    let schemaBuilder: (String) throws -> GenerationSchema
+    let options: GlobalCommandOptions
+    let generation: GenerationFlags
+    let adapterPath: String?
+    let useCase: FoundationLabModelUseCase
+    let includeSchemaInPrompt: Bool
+}
 
-    if options.dryRun {
+private func runDynamicSchemaCommand(
+    _ request: DynamicSchemaCommandRequest
+) async throws {
+    let resolvedOutput = try request.options.resolvedOutput()
+    let generationOptions = try request.generation.validatedOptions()
+    guard let example = AFMSchemaCatalog.example(id: request.exampleID) else {
+        throw AFMRuntimeError.invalidRequest("Unknown schema example: \(request.exampleID)")
+    }
+    guard let preset = example.presets.first(where: { $0.id == request.presetID }) else {
+        throw ValidationError("Unknown preset '\(request.presetID)' for \(request.exampleID)")
+    }
+    let resolvedInput = try request.inputSource.resolve(defaultValue: preset.defaultInput)
+
+    if request.options.dryRun {
         try CLIOutput.emit(
             payload: DryRunPayload(
-                command: command,
-                adapter: adapterPath,
-                preset: presetID,
+                command: request.command,
+                adapter: request.adapterPath,
+                preset: request.presetID,
                 input: resolvedInput.value,
                 inputFile: resolvedInput.file,
-                useCase: useCase.rawValue,
-                guardrails: generation.guardrails.afmArgumentValue,
-                includeSchemaInPrompt: includeSchemaInPrompt
+                useCase: request.useCase.rawValue,
+                guardrails: request.generation.guardrails.afmArgumentValue,
+                includeSchemaInPrompt: request.includeSchemaInPrompt
             ),
-            human: "[dry-run] afm \(command)\nPreset: \(presetID)\nInput: \(resolvedInput.value)",
+            human: "[dry-run] afm \(request.command)\nPreset: \(request.presetID)\nInput: \(resolvedInput.value)",
             options: resolvedOutput
         )
         return
     }
 
     _ = try requireFoundationModelsAvailability(
-        useCase: useCase,
-        adapterPath: adapterPath
+        useCase: request.useCase,
+        adapterPath: request.adapterPath
     )
     let result = try await GenerateDynamicSchemaContentUseCase().execute(
         DynamicSchemaGenerationRequest(
             prompt: resolvedInput.value,
-            schema: try schemaBuilder(presetID),
-            systemPrompt: generation.systemPrompt,
-            modelUseCase: useCase,
-            guardrails: generation.guardrails,
-            adapterURL: adapterURL(from: adapterPath),
+            schema: try request.schemaBuilder(request.presetID),
+            systemPrompt: request.generation.systemPrompt,
+            modelUseCase: request.useCase,
+            guardrails: request.generation.guardrails,
+            adapterURL: adapterURL(from: request.adapterPath),
             generationOptions: generationOptions,
-            includeSchemaInPrompt: includeSchemaInPrompt,
+            includeSchemaInPrompt: request.includeSchemaInPrompt,
             context: afmContext()
         )
     )
+    try emitDynamicSchemaResult(
+        result,
+        request: request,
+        example: example,
+        resolvedInput: resolvedInput,
+        outputOptions: resolvedOutput
+    )
+}
+
+private func emitDynamicSchemaResult(
+    _ result: DynamicSchemaGenerationResult,
+    request: DynamicSchemaCommandRequest,
+    example: AFMSchemaExampleDescriptor,
+    resolvedInput: ResolvedTextInput,
+    outputOptions: CLIOutputOptions
+) throws {
     let payload = DynamicSchemaPayload(
-        command: command,
-        adapter: adapterPath,
-        preset: presetID,
-        useCase: useCase.rawValue,
-        guardrails: generation.guardrails.afmArgumentValue,
-        includeSchemaInPrompt: includeSchemaInPrompt,
+        command: request.command,
+        adapter: request.adapterPath,
+        preset: request.presetID,
+        useCase: request.useCase.rawValue,
+        guardrails: request.generation.guardrails.afmArgumentValue,
+        includeSchemaInPrompt: request.includeSchemaInPrompt,
         input: resolvedInput.value,
         json: result.output.jsonString,
         tokenCount: result.metadata.tokenCount,
@@ -449,82 +528,10 @@ private func runDynamicSchemaCommand(
 
     \(result.output.jsonString)
     """
-    let verboseHuman: String
-    if options.verbose, let tokenCount = result.metadata.tokenCount {
-        verboseHuman = "\(human)\n\nToken count: \(tokenCount)"
-    } else {
-        verboseHuman = human
-    }
-    try CLIOutput.emit(payload: payload, human: verboseHuman, options: resolvedOutput)
-}
-
-private func makeBasicObjectSchema(presetID: String) throws -> GenerationSchema {
-    let root: DynamicGenerationSchema
-    switch presetID {
-    case "person":
-        root = DynamicGenerationSchema(
-            name: "Person",
-            properties: [
-                .init(name: "name", schema: .init(type: String.self)),
-                .init(name: "age", schema: .init(type: Int.self)),
-                .init(name: "occupation", schema: .init(type: String.self))
-            ]
-        )
-    case "product":
-        root = DynamicGenerationSchema(
-            name: "Product",
-            properties: [
-                .init(name: "name", schema: .init(type: String.self)),
-                .init(name: "price", schema: .init(type: Double.self)),
-                .init(name: "feature", schema: .init(type: String.self))
-            ]
-        )
-    default:
-        throw ValidationError("Unknown preset '\(presetID)' for basic-object")
-    }
-    return try GenerationSchema(root: root, dependencies: [])
-}
-
-private func makeArraySchema(presetID: String, minimumItems: Int, maximumItems: Int) throws -> GenerationSchema {
-    guard minimumItems > 0 else {
-        throw ValidationError("--min-items must be greater than 0")
-    }
-    guard maximumItems >= minimumItems else {
-        throw ValidationError("--max-items must be greater than or equal to --min-items")
-    }
-
-    let itemName: String = switch presetID {
-    case "todo": "TodoItem"
-    default: throw ValidationError("Unknown preset '\(presetID)' for array-schema")
-    }
-
-    let itemSchema = DynamicGenerationSchema(
-        name: itemName,
-        properties: [
-            .init(name: "title", schema: .init(type: String.self)),
-            .init(name: "completed", schema: .init(type: Bool.self), isOptional: true)
-        ]
+    let renderedHuman = verboseHumanOutput(
+        human,
+        tokenCount: result.metadata.tokenCount,
+        verbose: request.options.verbose
     )
-    let root = DynamicGenerationSchema(
-        name: "TodoList",
-        properties: [
-            .init(
-                name: "items",
-                schema: .init(arrayOf: .init(referenceTo: itemName), minimumElements: minimumItems, maximumElements: maximumItems)
-            )
-        ]
-    )
-    return try GenerationSchema(root: root, dependencies: [itemSchema])
-}
-
-private func makeEnumSchema(presetID: String, customChoices: [String]) throws -> GenerationSchema {
-    let choices = customChoices.isEmpty ? AFMSchemaCatalog.defaultChoices(for: presetID) : customChoices
-    let root = DynamicGenerationSchema(
-        name: "Classification",
-        properties: [
-            .init(name: "label", schema: .init(name: "Label", anyOf: choices)),
-            .init(name: "reason", schema: .init(type: String.self), isOptional: true)
-        ]
-    )
-    return try GenerationSchema(root: root, dependencies: [])
+    try CLIOutput.emit(payload: payload, human: renderedHuman, options: outputOptions)
 }

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommandSupport.swift
@@ -1,0 +1,372 @@
+import ArgumentParser
+import Foundation
+import FoundationLabCore
+import FoundationModels
+
+struct SessionStreamingEventPayload: Encodable {
+    let event: String
+    let command: String
+    let adapter: String?
+    let useCase: String?
+    let guardrails: String?
+    let messageIndex: Int?
+    let prompt: String?
+    let content: String?
+    let response: String?
+    let exchanges: [AFMConversationExchange]?
+    let sessionCount: Int?
+    let tokenCount: Int?
+    let transcript: [CLITranscriptEntry]?
+}
+
+struct SessionStreamingEventContent {
+    var messageIndex: Int?
+    var prompt: String?
+    var content: String?
+    var response: String?
+    var exchanges: [AFMConversationExchange]?
+    var sessionCount: Int?
+    var tokenCount: Int?
+    var transcript: [CLITranscriptEntry]?
+}
+
+struct SessionCommandContext {
+    let command: String
+    let adapterPath: String?
+    let useCase: String
+    let guardrails: String
+    let output: CLIOutputOptions
+    let verbose: Bool
+    let streamingEnabled: Bool
+
+    var streamsToConsole: Bool {
+        streamingEnabled && output.format == .text
+    }
+
+    var streamsToJSON: Bool {
+        streamingEnabled && output.format == .json
+    }
+
+    func validateStreamingOutput() throws {
+        if streamsToJSON && output.pretty {
+            throw ValidationError("--pretty is not supported with streaming JSON output")
+        }
+    }
+
+    func event(
+        _ name: String,
+        content: SessionStreamingEventContent = SessionStreamingEventContent()
+    ) -> SessionStreamingEventPayload {
+        SessionStreamingEventPayload(
+            event: name,
+            command: command,
+            adapter: adapterPath,
+            useCase: useCase,
+            guardrails: guardrails,
+            messageIndex: content.messageIndex,
+            prompt: content.prompt,
+            content: content.content,
+            response: content.response,
+            exchanges: content.exchanges,
+            sessionCount: content.sessionCount,
+            tokenCount: content.tokenCount,
+            transcript: content.transcript
+        )
+    }
+}
+
+struct SessionEngineRequest {
+    let systemPrompt: String?
+    let useCase: FoundationLabModelUseCase
+    let guardrails: FoundationLabGuardrails
+    let tools: [any Tool]
+    let adapterPath: String?
+}
+
+struct SessionMessageRequest {
+    let prompt: String
+    let messageIndex: Int?
+    let generationOptions: FoundationLabGenerationOptions?
+    let startedEvent: String?
+    let deltaEvent: String?
+    let completedEvent: String?
+}
+
+struct SessionChatRequest {
+    let messages: [String]
+    let generationOptions: FoundationLabGenerationOptions?
+}
+
+struct SessionSnapshot {
+    let transcript: [CLITranscriptEntry]?
+    let sessionCount: Int
+    let tokenCount: Int
+}
+
+struct ConversationRenderContext {
+    let exchanges: [AFMConversationExchange]
+    let transcript: [CLITranscriptEntry]?
+    let sessionCount: Int
+    let tokenCount: Int
+    let verbose: Bool
+    let streamed: Bool
+}
+
+@MainActor
+func makeSessionEngine(_ request: SessionEngineRequest) throws -> FoundationLabConversationEngine {
+    try makeConversationEngine(
+        configuration: defaultConversationConfiguration(
+            systemPrompt: request.systemPrompt,
+            useCase: request.useCase,
+            guardrails: request.guardrails,
+            tools: request.tools
+        ),
+        adapterPath: request.adapterPath
+    )
+}
+
+@MainActor
+func executeSessionMessage(
+    engine: FoundationLabConversationEngine,
+    request: SessionMessageRequest,
+    context: SessionCommandContext
+) async throws -> String {
+    beginStreamingMessage(request, context: context)
+
+    let response: String
+    if context.streamingEnabled {
+        var latestPrinted = ""
+        response = try await engine.sendStreamingMessage(
+            request.prompt,
+            generationOptions: request.generationOptions
+        ) { partial in
+            emitSessionPartial(
+                partial,
+                latestPrinted: &latestPrinted,
+                request: request,
+                context: context
+            )
+        }
+    } else {
+        response = try await engine.sendMessage(
+            request.prompt,
+            generationOptions: request.generationOptions
+        )
+    }
+
+    finishStreamingMessage(response, request: request, context: context)
+    return response
+}
+
+@MainActor
+func executeSessionChat(
+    engine: FoundationLabConversationEngine,
+    request: SessionChatRequest,
+    context: SessionCommandContext
+) async throws -> [AFMConversationExchange] {
+    var exchanges: [AFMConversationExchange] = []
+    for (index, prompt) in request.messages.enumerated() {
+        let response = try await executeSessionMessage(
+            engine: engine,
+            request: SessionMessageRequest(
+                prompt: prompt,
+                messageIndex: index,
+                generationOptions: request.generationOptions,
+                startedEvent: "message_started",
+                deltaEvent: "message_delta",
+                completedEvent: "message_completed"
+            ),
+            context: context
+        )
+        exchanges.append(AFMConversationExchange(prompt: prompt, response: response, isError: false))
+    }
+    return exchanges
+}
+
+@MainActor
+func captureSessionSnapshot(
+    engine: FoundationLabConversationEngine,
+    includeTranscript: Bool
+) -> SessionSnapshot {
+    SessionSnapshot(
+        transcript: includeTranscript ? transcriptPayload(engine.session.transcript) : nil,
+        sessionCount: engine.sessionCount,
+        tokenCount: engine.currentTokenCount
+    )
+}
+
+func humanReadableSessionResponse(
+    response: String,
+    transcript: [CLITranscriptEntry]?,
+    sessionCount: Int,
+    tokenCount: Int,
+    verbose: Bool
+) -> String {
+    var lines: [String] = []
+    if !response.isEmpty {
+        lines.append(response)
+    }
+    if let transcript, !transcript.isEmpty {
+        if !lines.isEmpty { lines.append("") }
+        lines.append("Transcript")
+        lines.append(
+            transcript.map { "\($0.role.capitalized): \($0.content)" }.joined(separator: "\n\n")
+        )
+    }
+    if verbose {
+        if !lines.isEmpty { lines.append("") }
+        lines.append("Sessions: \(sessionCount)")
+        lines.append("Token count: \(tokenCount)")
+    }
+    return lines.joined(separator: "\n")
+}
+
+func emitSessionStreamingEvent(_ payload: SessionStreamingEventPayload) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    guard let data = try? encoder.encode(payload),
+          let text = String(data: data, encoding: .utf8) else {
+        return
+    }
+
+    print(text)
+    fflush(stdout)
+}
+
+private func beginStreamingMessage(
+    _ request: SessionMessageRequest,
+    context: SessionCommandContext
+) {
+    if context.streamsToConsole {
+        if request.messageIndex != nil {
+            print("User: \(request.prompt)")
+        }
+        print("Assistant: ", terminator: "")
+        fflush(stdout)
+    }
+
+    if context.streamsToJSON, let event = request.startedEvent {
+        emitSessionStreamingEvent(
+            context.event(
+                event,
+                content: SessionStreamingEventContent(
+                    messageIndex: request.messageIndex,
+                    prompt: request.prompt
+                )
+            )
+        )
+    }
+}
+
+private func emitSessionPartial(
+    _ partial: String,
+    latestPrinted: inout String,
+    request: SessionMessageRequest,
+    context: SessionCommandContext
+) {
+    if context.streamsToConsole {
+        printStreamingText(partial, after: latestPrinted)
+        latestPrinted = partial
+        return
+    }
+
+    if context.streamsToJSON, let event = request.deltaEvent {
+        emitSessionStreamingEvent(
+            context.event(
+                event,
+                content: SessionStreamingEventContent(
+                    messageIndex: request.messageIndex,
+                    prompt: request.prompt,
+                    content: partial
+                )
+            )
+        )
+    }
+}
+
+private func printStreamingText(_ partial: String, after latestPrinted: String) {
+    if partial.hasPrefix(latestPrinted) {
+        let suffix = String(partial.dropFirst(latestPrinted.count))
+        guard !suffix.isEmpty else { return }
+        print(suffix, terminator: "")
+    } else {
+        print(partial, terminator: "")
+    }
+    fflush(stdout)
+}
+
+private func finishStreamingMessage(
+    _ response: String,
+    request: SessionMessageRequest,
+    context: SessionCommandContext
+) {
+    if context.streamsToConsole {
+        print("")
+    }
+
+    if context.streamsToJSON, let event = request.completedEvent {
+        emitSessionStreamingEvent(
+            context.event(
+                event,
+                content: SessionStreamingEventContent(
+                    messageIndex: request.messageIndex,
+                    prompt: request.prompt,
+                    response: response
+                )
+            )
+        )
+    }
+}
+
+func humanReadableConversation(_ context: ConversationRenderContext) -> String {
+    var lines: [String] = []
+    if !context.streamed {
+        for exchange in context.exchanges {
+            lines.append("User: \(exchange.prompt)")
+            lines.append("Assistant: \(exchange.response)")
+            lines.append("")
+        }
+        if !lines.isEmpty {
+            _ = lines.popLast()
+        }
+    }
+    if let transcript = context.transcript, !transcript.isEmpty {
+        if !lines.isEmpty { lines.append("") }
+        lines.append("Transcript")
+        lines.append(
+            transcript.map { "\($0.role.capitalized): \($0.content)" }.joined(separator: "\n\n")
+        )
+    }
+    if context.verbose {
+        if !lines.isEmpty { lines.append("") }
+        lines.append("Sessions: \(context.sessionCount)")
+        lines.append("Token count: \(context.tokenCount)")
+    }
+    return lines.joined(separator: "\n")
+}
+
+struct ResolvedToolSet {
+    let references: [ResolvedArtifactReference]
+    let tools: [any Tool]
+}
+
+func resolveToolManifests(_ toolSource: ToolSourceOptions) throws -> ResolvedToolSet {
+    let references = try toolSource.resolveTools()
+    if references.isEmpty {
+        return ResolvedToolSet(references: [], tools: [])
+    }
+
+    let manifests = try AFMArtifactRegistry.loadTools(from: references)
+    return ResolvedToolSet(
+        references: references,
+        tools: manifests.map { $0 as any Tool }
+    )
+}
+
+func requiredResolvedInput(_ input: ResolvedTextInput?) throws -> ResolvedTextInput {
+    guard let input else {
+        throw ValidationError("Please provide --prompt, --prompt-file, or stdin.")
+    }
+    return input
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommands.swift
@@ -30,22 +30,6 @@ struct SessionResponsePayload: Encodable {
     let transcript: [CLITranscriptEntry]?
 }
 
-private struct SessionStreamingEventPayload: Encodable {
-    let event: String
-    let command: String
-    let adapter: String?
-    let useCase: String?
-    let guardrails: String?
-    let messageIndex: Int?
-    let prompt: String?
-    let content: String?
-    let response: String?
-    let exchanges: [AFMConversationExchange]?
-    let sessionCount: Int?
-    let tokenCount: Int?
-    let transcript: [CLITranscriptEntry]?
-}
-
 struct SessionRespondCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "respond",
@@ -85,49 +69,40 @@ struct SessionRespondCommand: AsyncParsableCommand {
             return
         }
 
+        let context = SessionCommandContext(
+            command: "session respond",
+            adapterPath: adapterPath,
+            useCase: useCaseFlags.useCase.rawValue,
+            guardrails: generation.guardrails.afmArgumentValue,
+            output: resolvedOutput,
+            verbose: options.verbose,
+            streamingEnabled: false
+        )
         _ = try requireFoundationModelsAvailability(
             useCase: useCaseFlags.useCase,
             adapterPath: adapterPath
         )
         let engine = try await MainActor.run {
-            try makeConversationEngine(
-                configuration: defaultConversationConfiguration(
+            try makeSessionEngine(
+                SessionEngineRequest(
                     systemPrompt: generation.systemPrompt,
                     useCase: useCaseFlags.useCase,
                     guardrails: generation.guardrails,
-                    tools: toolResolution.tools
-                ),
-                adapterPath: adapterPath
+                    tools: toolResolution.tools,
+                    adapterPath: adapterPath
+                )
             )
         }
         let response = try await engine.sendMessage(resolvedPrompt.value, generationOptions: generationOptions)
-        let transcript = await MainActor.run {
-            transcriptFlags.transcript ? transcriptPayload(engine.session.transcript) : nil
+        let snapshot = await MainActor.run {
+            captureSessionSnapshot(engine: engine, includeTranscript: transcriptFlags.transcript)
         }
-        let sessionCount = await MainActor.run { engine.sessionCount }
-        let tokenCount = await MainActor.run { engine.currentTokenCount }
-
-        let payload = SessionResponsePayload(
-            command: "session respond",
-            adapter: adapterPath,
-            useCase: useCaseFlags.useCase.rawValue,
-            guardrails: generation.guardrails.afmArgumentValue,
+        try emitRespondResult(
+            response: response,
             prompt: resolvedPrompt.value,
-            messages: nil,
-            response: response,
-            exchanges: nil,
-            sessionCount: sessionCount,
-            tokenCount: tokenCount,
-            transcript: transcript
+            snapshot: snapshot,
+            context: context
         )
-        let human = humanReadableSessionResponse(
-            response: response,
-            transcript: transcript,
-            sessionCount: sessionCount,
-            tokenCount: tokenCount,
-            verbose: options.verbose
-        )
-        try CLIOutput.emit(payload: payload, human: human, options: resolvedOutput)
     }
 }
 
@@ -153,163 +128,61 @@ struct SessionStreamCommand: AsyncParsableCommand {
         let toolResolution = try resolveToolManifests(toolSource)
 
         if options.dryRun {
-            try CLIOutput.emit(
-                payload: DryRunPayload(
-                    command: "session stream",
-                    adapter: adapterPath,
-                    prompt: resolvedPrompt.value,
-                    promptFile: resolvedPrompt.file,
-                    useCase: useCaseFlags.useCase.rawValue,
-                    guardrails: generation.guardrails.afmArgumentValue,
-                    toolFiles: toolResolution.references.map { $0.filePath },
-                    toolDirectory: toolSource.tool.isEmpty ? nil : expandedPathString(toolSource.toolDir)
-                ),
-                human: "[dry-run] afm session stream\nPrompt: \(resolvedPrompt.value)",
-                options: resolvedOutput
+            try emitDryRun(
+                prompt: resolvedPrompt,
+                adapterPath: adapterPath,
+                tools: toolResolution,
+                output: resolvedOutput
             )
             return
         }
 
+        let context = SessionCommandContext(
+            command: "session stream",
+            adapterPath: adapterPath,
+            useCase: useCaseFlags.useCase.rawValue,
+            guardrails: generation.guardrails.afmArgumentValue,
+            output: resolvedOutput,
+            verbose: options.verbose,
+            streamingEnabled: true
+        )
+        try context.validateStreamingOutput()
         _ = try requireFoundationModelsAvailability(
             useCase: useCaseFlags.useCase,
             adapterPath: adapterPath
         )
         let engine = try await MainActor.run {
-            try makeConversationEngine(
-                configuration: defaultConversationConfiguration(
+            try makeSessionEngine(
+                SessionEngineRequest(
                     systemPrompt: generation.systemPrompt,
                     useCase: useCaseFlags.useCase,
                     guardrails: generation.guardrails,
-                    tools: toolResolution.tools
-                ),
-                adapterPath: adapterPath
-            )
-        }
-
-        let streamToConsole = resolvedOutput.format == .text
-        let streamToJSON = resolvedOutput.format == .json
-        let selectedUseCase = useCaseFlags.useCase.rawValue
-        let selectedGuardrails = generation.guardrails.afmArgumentValue
-        if streamToJSON && options.pretty {
-            throw ValidationError("--pretty is not supported with streaming JSON output")
-        }
-        var latestPrinted = ""
-        if streamToConsole {
-            print("Assistant: ", terminator: "")
-            fflush(stdout)
-        }
-        if streamToJSON {
-            emitSessionStreamingEvent(
-                .init(
-                    event: "started",
-                    command: "session stream",
-                    adapter: adapterPath,
-                    useCase: selectedUseCase,
-                    guardrails: selectedGuardrails,
-                    messageIndex: nil,
-                    prompt: resolvedPrompt.value,
-                    content: nil,
-                    response: nil,
-                    exchanges: nil,
-                    sessionCount: nil,
-                    tokenCount: nil,
-                    transcript: nil
+                    tools: toolResolution.tools,
+                    adapterPath: adapterPath
                 )
             )
         }
-
-        let response = try await engine.sendStreamingMessage(resolvedPrompt.value, generationOptions: generationOptions) { partial in
-            if streamToConsole {
-                if partial.hasPrefix(latestPrinted) {
-                    let suffix = String(partial.dropFirst(latestPrinted.count))
-                    guard !suffix.isEmpty else { return }
-                    print(suffix, terminator: "")
-                } else {
-                    print(partial, terminator: "")
-                }
-                fflush(stdout)
-                latestPrinted = partial
-                return
-            }
-            if streamToJSON {
-                emitSessionStreamingEvent(
-                    .init(
-                        event: "delta",
-                        command: "session stream",
-                        adapter: adapterPath,
-                        useCase: selectedUseCase,
-                        guardrails: selectedGuardrails,
-                        messageIndex: nil,
-                        prompt: resolvedPrompt.value,
-                        content: partial,
-                        response: nil,
-                        exchanges: nil,
-                        sessionCount: nil,
-                        tokenCount: nil,
-                        transcript: nil
-                    )
-                )
-            }
-        }
-
-        if streamToConsole {
-            print("")
-        }
-
-        let transcript = await MainActor.run {
-            transcriptFlags.transcript ? transcriptPayload(engine.session.transcript) : nil
-        }
-        let sessionCount = await MainActor.run { engine.sessionCount }
-        let tokenCount = await MainActor.run { engine.currentTokenCount }
-        let payload = SessionResponsePayload(
-            command: "session stream",
-            adapter: adapterPath,
-            useCase: selectedUseCase,
-            guardrails: selectedGuardrails,
-            prompt: resolvedPrompt.value,
-            messages: nil,
-            response: response,
-            exchanges: nil,
-            sessionCount: sessionCount,
-            tokenCount: tokenCount,
-            transcript: transcript
+        let response = try await executeSessionMessage(
+            engine: engine,
+            request: SessionMessageRequest(
+                prompt: resolvedPrompt.value,
+                messageIndex: nil,
+                generationOptions: generationOptions,
+                startedEvent: "started",
+                deltaEvent: "delta",
+                completedEvent: nil
+            ),
+            context: context
         )
-        if streamToJSON {
-            emitSessionStreamingEvent(
-                .init(
-                    event: "completed",
-                    command: "session stream",
-                    adapter: adapterPath,
-                    useCase: selectedUseCase,
-                    guardrails: selectedGuardrails,
-                    messageIndex: nil,
-                    prompt: resolvedPrompt.value,
-                    content: nil,
-                    response: response,
-                    exchanges: nil,
-                    sessionCount: sessionCount,
-                    tokenCount: tokenCount,
-                    transcript: transcript
-                )
-            )
-            return
+        let snapshot = await MainActor.run {
+            captureSessionSnapshot(engine: engine, includeTranscript: transcriptFlags.transcript)
         }
-        let human = resolvedOutput.format == .text
-            ? humanReadableSessionResponse(
-                response: "",
-                transcript: transcript,
-                sessionCount: sessionCount,
-                tokenCount: tokenCount,
-                verbose: options.verbose
-            )
-            : humanReadableSessionResponse(
-                response: response,
-                transcript: transcript,
-                sessionCount: sessionCount,
-                tokenCount: tokenCount,
-                verbose: options.verbose
-            )
-        try CLIOutput.emit(payload: payload, human: human, options: resolvedOutput)
+        try emitStreamResult(
+            response: response,
+            prompt: resolvedPrompt.value,
+            snapshot: snapshot,
+            context: context
+        )
     }
 }
 
@@ -337,282 +210,226 @@ struct SessionChatCommand: AsyncParsableCommand {
         let toolResolution = try resolveToolManifests(toolSource)
 
         if options.dryRun {
-            try CLIOutput.emit(
-                payload: DryRunPayload(
-                    command: "session chat",
-                    adapter: adapterPath,
-                    messages: validatedMessages,
-                    messageFiles: resolvedMessages.compactMap { $0.file },
-                    useCase: useCaseFlags.useCase.rawValue,
-                    guardrails: generation.guardrails.afmArgumentValue,
-                    toolFiles: toolResolution.references.map { $0.filePath },
-                    toolDirectory: toolSource.tool.isEmpty ? nil : expandedPathString(toolSource.toolDir)
-                ),
-                human: "[dry-run] afm session chat\nMessages: \(validatedMessages.count)",
-                options: resolvedOutput
+            try emitDryRun(
+                messages: resolvedMessages,
+                adapterPath: adapterPath,
+                tools: toolResolution,
+                output: resolvedOutput
             )
             return
         }
 
+        let context = SessionCommandContext(
+            command: "session chat",
+            adapterPath: adapterPath,
+            useCase: useCaseFlags.useCase.rawValue,
+            guardrails: generation.guardrails.afmArgumentValue,
+            output: resolvedOutput,
+            verbose: options.verbose,
+            streamingEnabled: streaming.stream
+        )
+        try context.validateStreamingOutput()
         _ = try requireFoundationModelsAvailability(
             useCase: useCaseFlags.useCase,
             adapterPath: adapterPath
         )
         let engine = try await MainActor.run {
-            try makeConversationEngine(
-                configuration: defaultConversationConfiguration(
+            try makeSessionEngine(
+                SessionEngineRequest(
                     systemPrompt: generation.systemPrompt,
                     useCase: useCaseFlags.useCase,
                     guardrails: generation.guardrails,
-                    tools: toolResolution.tools
-                ),
-                adapterPath: adapterPath
+                    tools: toolResolution.tools,
+                    adapterPath: adapterPath
+                )
             )
         }
-        var exchanges: [AFMConversationExchange] = []
-        let streamToConsole = streaming.stream && resolvedOutput.format == .text
-        let streamToJSON = streaming.stream && resolvedOutput.format == .json
-        let selectedUseCase = useCaseFlags.useCase.rawValue
-        let selectedGuardrails = generation.guardrails.afmArgumentValue
-        if streamToJSON && options.pretty {
-            throw ValidationError("--pretty is not supported with streaming JSON output")
+        let exchanges = try await executeSessionChat(
+            engine: engine,
+            request: SessionChatRequest(
+                messages: validatedMessages,
+                generationOptions: generationOptions
+            ),
+            context: context
+        )
+        let snapshot = await MainActor.run {
+            captureSessionSnapshot(engine: engine, includeTranscript: transcriptFlags.transcript)
         }
-
-        for (index, entry) in validatedMessages.enumerated() {
-            if streamToConsole {
-                print("User: \(entry)")
-                print("Assistant: ", terminator: "")
-                fflush(stdout)
-            }
-            if streamToJSON {
-                emitSessionStreamingEvent(
-                    .init(
-                        event: "message_started",
-                        command: "session chat",
-                        adapter: adapterPath,
-                        useCase: selectedUseCase,
-                        guardrails: selectedGuardrails,
-                        messageIndex: index,
-                        prompt: entry,
-                        content: nil,
-                        response: nil,
-                        exchanges: nil,
-                        sessionCount: nil,
-                        tokenCount: nil,
-                        transcript: nil
-                    )
-                )
-            }
-
-            var latestPrinted = ""
-            let response: String
-            if streamToConsole || streamToJSON {
-                response = try await engine.sendStreamingMessage(entry, generationOptions: generationOptions) { partial in
-                    if streamToConsole {
-                        if partial.hasPrefix(latestPrinted) {
-                            let suffix = String(partial.dropFirst(latestPrinted.count))
-                            guard !suffix.isEmpty else { return }
-                            print(suffix, terminator: "")
-                        } else {
-                            print(partial, terminator: "")
-                        }
-                        fflush(stdout)
-                        latestPrinted = partial
-                        return
-                    }
-                    if streamToJSON {
-                        emitSessionStreamingEvent(
-                            .init(
-                                event: "message_delta",
-                                command: "session chat",
-                                adapter: adapterPath,
-                                useCase: selectedUseCase,
-                                guardrails: selectedGuardrails,
-                                messageIndex: index,
-                                prompt: entry,
-                                content: partial,
-                                response: nil,
-                                exchanges: nil,
-                                sessionCount: nil,
-                                tokenCount: nil,
-                                transcript: nil
-                            )
-                        )
-                    }
-                }
-                if streamToConsole {
-                    print("")
-                }
-            } else {
-                response = try await engine.sendMessage(entry, generationOptions: generationOptions)
-            }
-
-            exchanges.append(AFMConversationExchange(prompt: entry, response: response, isError: false))
-            if streamToJSON {
-                emitSessionStreamingEvent(
-                    .init(
-                        event: "message_completed",
-                        command: "session chat",
-                        adapter: adapterPath,
-                        useCase: selectedUseCase,
-                        guardrails: selectedGuardrails,
-                        messageIndex: index,
-                        prompt: entry,
-                        content: nil,
-                        response: response,
-                        exchanges: nil,
-                        sessionCount: nil,
-                        tokenCount: nil,
-                        transcript: nil
-                    )
-                )
-            }
-        }
-
-        let transcript = await MainActor.run {
-            transcriptFlags.transcript ? transcriptPayload(engine.session.transcript) : nil
-        }
-        let sessionCount = await MainActor.run { engine.sessionCount }
-        let tokenCount = await MainActor.run { engine.currentTokenCount }
-        let payload = SessionResponsePayload(
-            command: "session chat",
-            adapter: adapterPath,
-            useCase: selectedUseCase,
-            guardrails: selectedGuardrails,
-            prompt: nil,
+        try emitChatResult(
             messages: validatedMessages,
-            response: nil,
             exchanges: exchanges,
-            sessionCount: sessionCount,
-            tokenCount: tokenCount,
-            transcript: transcript
+            snapshot: snapshot,
+            context: context
         )
-        if streamToJSON {
-            emitSessionStreamingEvent(
-                .init(
-                    event: "session_completed",
-                    command: "session chat",
-                    adapter: adapterPath,
-                    useCase: selectedUseCase,
-                    guardrails: selectedGuardrails,
-                    messageIndex: nil,
-                    prompt: nil,
-                    content: nil,
-                    response: nil,
-                    exchanges: exchanges,
-                    sessionCount: sessionCount,
-                    tokenCount: tokenCount,
-                    transcript: transcript
+    }
+}
+
+private extension SessionStreamCommand {
+    func emitDryRun(
+        prompt: ResolvedTextInput,
+        adapterPath: String?,
+        tools: ResolvedToolSet,
+        output: CLIOutputOptions
+    ) throws {
+        try CLIOutput.emit(
+            payload: DryRunPayload(
+                command: "session stream",
+                adapter: adapterPath,
+                prompt: prompt.value,
+                promptFile: prompt.file,
+                useCase: useCaseFlags.useCase.rawValue,
+                guardrails: generation.guardrails.afmArgumentValue,
+                toolFiles: tools.references.map { $0.filePath },
+                toolDirectory: toolSource.tool.isEmpty ? nil : expandedPathString(toolSource.toolDir)
+            ),
+            human: "[dry-run] afm session stream\nPrompt: \(prompt.value)",
+            options: output
+        )
+    }
+}
+
+private extension SessionChatCommand {
+    func emitDryRun(
+        messages: [ResolvedTextInput],
+        adapterPath: String?,
+        tools: ResolvedToolSet,
+        output: CLIOutputOptions
+    ) throws {
+        try CLIOutput.emit(
+            payload: DryRunPayload(
+                command: "session chat",
+                adapter: adapterPath,
+                messages: messages.map(\.value),
+                messageFiles: messages.compactMap(\.file),
+                useCase: useCaseFlags.useCase.rawValue,
+                guardrails: generation.guardrails.afmArgumentValue,
+                toolFiles: tools.references.map { $0.filePath },
+                toolDirectory: toolSource.tool.isEmpty ? nil : expandedPathString(toolSource.toolDir)
+            ),
+            human: "[dry-run] afm session chat\nMessages: \(messages.count)",
+            options: output
+        )
+    }
+}
+
+private func emitRespondResult(
+    response: String,
+    prompt: String,
+    snapshot: SessionSnapshot,
+    context: SessionCommandContext
+) throws {
+    let payload = SessionResponsePayload(
+        command: context.command,
+        adapter: context.adapterPath,
+        useCase: context.useCase,
+        guardrails: context.guardrails,
+        prompt: prompt,
+        messages: nil,
+        response: response,
+        exchanges: nil,
+        sessionCount: snapshot.sessionCount,
+        tokenCount: snapshot.tokenCount,
+        transcript: snapshot.transcript
+    )
+    let human = humanReadableSessionResponse(
+        response: response,
+        transcript: snapshot.transcript,
+        sessionCount: snapshot.sessionCount,
+        tokenCount: snapshot.tokenCount,
+        verbose: context.verbose
+    )
+    try CLIOutput.emit(payload: payload, human: human, options: context.output)
+}
+
+private func emitStreamResult(
+    response: String,
+    prompt: String,
+    snapshot: SessionSnapshot,
+    context: SessionCommandContext
+) throws {
+    let payload = SessionResponsePayload(
+        command: context.command,
+        adapter: context.adapterPath,
+        useCase: context.useCase,
+        guardrails: context.guardrails,
+        prompt: prompt,
+        messages: nil,
+        response: response,
+        exchanges: nil,
+        sessionCount: snapshot.sessionCount,
+        tokenCount: snapshot.tokenCount,
+        transcript: snapshot.transcript
+    )
+    if context.streamsToJSON {
+        emitSessionStreamingEvent(
+            context.event(
+                "completed",
+                content: SessionStreamingEventContent(
+                    prompt: prompt,
+                    response: response,
+                    sessionCount: snapshot.sessionCount,
+                    tokenCount: snapshot.tokenCount,
+                    transcript: snapshot.transcript
                 )
             )
-            return
-        }
-        let human = humanReadableConversation(
-            exchanges: exchanges,
-            transcript: transcript,
-            sessionCount: sessionCount,
-            tokenCount: tokenCount,
-            verbose: options.verbose,
-            streamed: streamToConsole
         )
-        try CLIOutput.emit(payload: payload, human: human, options: resolvedOutput)
-    }
-}
-
-private func humanReadableSessionResponse(
-    response: String,
-    transcript: [CLITranscriptEntry]?,
-    sessionCount: Int,
-    tokenCount: Int,
-    verbose: Bool
-) -> String {
-    var lines: [String] = []
-    if !response.isEmpty {
-        lines.append(response)
-    }
-    if let transcript, !transcript.isEmpty {
-        if !lines.isEmpty { lines.append("") }
-        lines.append("Transcript")
-        lines.append(
-            transcript.map { "\($0.role.capitalized): \($0.content)" }.joined(separator: "\n\n")
-        )
-    }
-    if verbose {
-        if !lines.isEmpty { lines.append("") }
-        lines.append("Sessions: \(sessionCount)")
-        lines.append("Token count: \(tokenCount)")
-    }
-    return lines.joined(separator: "\n")
-}
-
-private func emitSessionStreamingEvent(_ payload: SessionStreamingEventPayload) {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.sortedKeys]
-
-    guard let data = try? encoder.encode(payload),
-          let text = String(data: data, encoding: .utf8) else {
         return
     }
 
-    print(text)
-    fflush(stdout)
-}
-
-private func humanReadableConversation(
-    exchanges: [AFMConversationExchange],
-    transcript: [CLITranscriptEntry]?,
-    sessionCount: Int,
-    tokenCount: Int,
-    verbose: Bool,
-    streamed: Bool
-) -> String {
-    var lines: [String] = []
-    if !streamed {
-        for exchange in exchanges {
-            lines.append("User: \(exchange.prompt)")
-            lines.append("Assistant: \(exchange.response)")
-            lines.append("")
-        }
-        if !lines.isEmpty {
-            _ = lines.popLast()
-        }
-    }
-    if let transcript, !transcript.isEmpty {
-        if !lines.isEmpty { lines.append("") }
-        lines.append("Transcript")
-        lines.append(
-            transcript.map { "\($0.role.capitalized): \($0.content)" }.joined(separator: "\n\n")
-        )
-    }
-    if verbose {
-        if !lines.isEmpty { lines.append("") }
-        lines.append("Sessions: \(sessionCount)")
-        lines.append("Token count: \(tokenCount)")
-    }
-    return lines.joined(separator: "\n")
-}
-
-struct ResolvedToolSet {
-    let references: [ResolvedArtifactReference]
-    let tools: [any Tool]
-}
-
-func resolveToolManifests(_ toolSource: ToolSourceOptions) throws -> ResolvedToolSet {
-    let references = try toolSource.resolveTools()
-    if references.isEmpty {
-        return ResolvedToolSet(references: [], tools: [])
-    }
-
-    let manifests = try AFMArtifactRegistry.loadTools(from: references)
-    return ResolvedToolSet(
-        references: references,
-        tools: manifests.map { $0 as any Tool }
+    let humanResponse = context.streamsToConsole ? "" : response
+    let human = humanReadableSessionResponse(
+        response: humanResponse,
+        transcript: snapshot.transcript,
+        sessionCount: snapshot.sessionCount,
+        tokenCount: snapshot.tokenCount,
+        verbose: context.verbose
     )
+    try CLIOutput.emit(payload: payload, human: human, options: context.output)
 }
 
-func requiredResolvedInput(_ input: ResolvedTextInput?) throws -> ResolvedTextInput {
-    guard let input else {
-        throw ValidationError("Please provide --prompt, --prompt-file, or stdin.")
+private func emitChatResult(
+    messages: [String],
+    exchanges: [AFMConversationExchange],
+    snapshot: SessionSnapshot,
+    context: SessionCommandContext
+) throws {
+    let payload = SessionResponsePayload(
+        command: context.command,
+        adapter: context.adapterPath,
+        useCase: context.useCase,
+        guardrails: context.guardrails,
+        prompt: nil,
+        messages: messages,
+        response: nil,
+        exchanges: exchanges,
+        sessionCount: snapshot.sessionCount,
+        tokenCount: snapshot.tokenCount,
+        transcript: snapshot.transcript
+    )
+    if context.streamsToJSON {
+        emitSessionStreamingEvent(
+            context.event(
+                "session_completed",
+                content: SessionStreamingEventContent(
+                    exchanges: exchanges,
+                    sessionCount: snapshot.sessionCount,
+                    tokenCount: snapshot.tokenCount,
+                    transcript: snapshot.transcript
+                )
+            )
+        )
+        return
     }
-    return input
+
+    let human = humanReadableConversation(
+        ConversationRenderContext(
+            exchanges: exchanges,
+            transcript: snapshot.transcript,
+            sessionCount: snapshot.sessionCount,
+            tokenCount: snapshot.tokenCount,
+            verbose: context.verbose,
+            streamed: context.streamsToConsole
+        )
+    )
+    try CLIOutput.emit(payload: payload, human: human, options: context.output)
 }

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ToolCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ToolCommands.swift
@@ -55,12 +55,14 @@ struct ToolArgumentsOptions: ParsableArguments {
 
     func resolve() throws -> ResolvedTextInput {
         guard let resolved = try resolveSingleInput(
-            inlineValue: args,
-            fileValue: argsFile,
-            stdin: stdin,
-            inlineOptionName: "--args",
-            fileOptionName: "--args-file",
-            requiredMessage: "Please provide --args, --args-file, or stdin."
+            SingleInputRequest(
+                inlineValue: args,
+                fileValue: argsFile,
+                stdin: stdin,
+                inlineOptionName: "--args",
+                fileOptionName: "--args-file",
+                requiredMessage: "Please provide --args, --args-file, or stdin."
+            )
         ) else {
             throw ValidationError("Please provide --args, --args-file, or stdin.")
         }

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/TranscriptAndFeedbackCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/TranscriptAndFeedbackCommands.swift
@@ -91,6 +91,24 @@ struct TranscriptExportCommand: AsyncParsableCommand {
             _ = try await engine.sendMessage(entry, generationOptions: generationOptions)
         }
 
+        try await exportTranscript(
+            from: engine,
+            messages: messages,
+            adapterPath: adapterPath,
+            exportPath: exportPath,
+            outputOptions: resolvedOutput
+        )
+    }
+}
+
+private extension TranscriptExportCommand {
+    func exportTranscript(
+        from engine: FoundationLabConversationEngine,
+        messages: [String],
+        adapterPath: String?,
+        exportPath: String,
+        outputOptions: CLIOutputOptions
+    ) async throws {
         let entries = await MainActor.run { transcriptPayload(engine.session.transcript) }
         let sessionCount = await MainActor.run { engine.sessionCount }
         let tokenCount = await MainActor.run { engine.currentTokenCount }
@@ -123,7 +141,7 @@ struct TranscriptExportCommand: AsyncParsableCommand {
         } else {
             verboseHuman = human
         }
-        try CLIOutput.emit(payload: payload, human: verboseHuman, options: resolvedOutput)
+        try CLIOutput.emit(payload: payload, human: verboseHuman, options: outputOptions)
     }
 }
 
@@ -211,22 +229,43 @@ struct FeedbackExportCommand: AsyncParsableCommand {
             _ = try await session.respond(to: resolvedPrompt.value)
         }
 
-        let desiredEntry: Transcript.Entry?
-        if let desiredOutput, !desiredOutput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            desiredEntry = Transcript.Entry.response(Transcript.Response(assetIDs: [], segments: [
-                .text(.init(content: desiredOutput))
-            ]))
-        } else {
-            desiredEntry = nil
-        }
-
         let data = session.logFeedbackAttachment(
             sentiment: sentiment?.foundationModelsValue,
             issues: issues,
-            desiredOutput: desiredEntry
+            desiredOutput: desiredFeedbackEntry()
         )
         try writeFileData(data, to: exportPath)
+        try emitFeedbackExport(
+            data: data,
+            resolvedPrompt: resolvedPrompt,
+            adapterPath: adapterPath,
+            exportPath: exportPath,
+            outputOptions: resolvedOutput
+        )
+    }
+}
 
+private extension FeedbackExportCommand {
+    func desiredFeedbackEntry() -> Transcript.Entry? {
+        guard let desiredOutput,
+              !desiredOutput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return Transcript.Entry.response(
+            Transcript.Response(
+                assetIDs: [],
+                segments: [.text(.init(content: desiredOutput))]
+            )
+        )
+    }
+
+    func emitFeedbackExport(
+        data: Data,
+        resolvedPrompt: ResolvedTextInput,
+        adapterPath: String?,
+        exportPath: String,
+        outputOptions: CLIOutputOptions
+    ) throws {
         let payload = FeedbackExportSummaryPayload(
             command: "feedback export",
             adapter: adapterPath,
@@ -253,7 +292,7 @@ struct FeedbackExportCommand: AsyncParsableCommand {
         } else {
             verboseHuman = human
         }
-        try CLIOutput.emit(payload: payload, human: verboseHuman, options: resolvedOutput)
+        try CLIOutput.emit(payload: payload, human: verboseHuman, options: outputOptions)
     }
 }
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMArtifactRegistry.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMArtifactRegistry.swift
@@ -261,7 +261,10 @@ struct AFMManifestTool: Tool {
 
         guard process.terminationStatus == 0 else {
             let trimmedError = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw AFMRuntimeError.providerFailure(trimmedError.isEmpty ? "Tool '\(name)' exited with status \(process.terminationStatus)" : trimmedError)
+            let message = trimmedError.isEmpty
+                ? "Tool '\(name)' exited with status \(process.terminationStatus)"
+                : trimmedError
+            throw AFMRuntimeError.providerFailure(message)
         }
 
         switch manifest.runner.outputFormat ?? .json {

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLISchemaTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLISchemaTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+
+@Test("Schema commands expose list and run flows")
+func schemaCommands() throws {
+    let list = try runAFM("schema", "list", "--output", "json")
+    let typedPerson = try runAFM(
+        "schema", "run", "typed-person", "--output", "json", "--dry-run",
+        "--input", "Alex Rivera is a designer in Berlin."
+    )
+    let badPreset = try runAFM(
+        "schema", "run", "enum-schema", "--dry-run", "--preset", "missing"
+    )
+
+    #expect(list.status == 0)
+    #expect(typedPerson.status == 0)
+    #expect(badPreset.status == 64)
+    #expect(badPreset.stderr.contains("Unknown preset 'missing' for enum-schema"))
+
+    let listJSON = try parseJSONObject(list.stdout)
+    let typedJSON = try parseJSONObject(typedPerson.stdout)
+
+    let schemas = listJSON["schemas"] as? [[String: Any]]
+    #expect((schemas?.isEmpty == false))
+    #expect(typedJSON["command"] as? String == "schema run typed-person")
+    #expect(typedJSON["input"] as? String == "Alex Rivera is a designer in Berlin.")
+}
+
+@Test("Foundation Models flags surface in dry-run payloads")
+func foundationModelsFlagsSurfaceInDryRunPayloads() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-fmf-\(UUID().uuidString)")
+    let schemaDirectory = directory.appending(path: ".afm/schemas")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: schemaDirectory, withIntermediateDirectories: true)
+
+    let schema = """
+    title: PersonCard
+    type: object
+    properties:
+      name:
+        type: string
+    required:
+      - name
+    """
+    try schema.write(to: schemaDirectory.appending(path: "person-card.yaml"), atomically: true, encoding: .utf8)
+
+    let modelStatus = try runAFM(
+        "model", "status", "--output", "json", "--dry-run",
+        "--use-case", "content-tagging"
+    )
+    let customSchema = try runAFM(
+        "schema", "run", "custom", "--output", "json", "--dry-run",
+        "--schema", "person-card",
+        "--schema-dir", schemaDirectory.path(),
+        "--input", "Alex Rivera",
+        "--use-case", "content-tagging",
+        "--no-include-schema-in-prompt"
+    )
+    let feedback = try runAFM(
+        "feedback", "export", "--output", "json", "--dry-run",
+        "--prompt", "hello",
+        "--file", "/tmp/afm-feedback.json",
+        "--issue", "incorrect",
+        "--issue-explanation", "Wrong answer"
+    )
+    let tag = try runAFM(
+        "tag", "run", "--output", "json", "--dry-run",
+        "--prompt", "A joyful dog playing in a sunny park."
+    )
+
+    #expect(modelStatus.status == 0)
+    #expect(customSchema.status == 0)
+    #expect(feedback.status == 0)
+    #expect(tag.status == 0)
+
+    let modelJSON = try parseJSONObject(modelStatus.stdout)
+    let schemaJSON = try parseJSONObject(customSchema.stdout)
+    let feedbackJSON = try parseJSONObject(feedback.stdout)
+    let tagJSON = try parseJSONObject(tag.stdout)
+
+    #expect(modelJSON["useCase"] as? String == "content-tagging")
+    #expect(schemaJSON["useCase"] as? String == "content-tagging")
+    #expect(schemaJSON["includeSchemaInPrompt"] as? Bool == false)
+    #expect((feedbackJSON["feedbackIssues"] as? [String]) == ["incorrect"])
+    #expect(tagJSON["command"] as? String == "tag run")
+    #expect(tagJSON["useCase"] as? String == "content-tagging")
+}
+
+@Test("Custom schema files resolve from schema-dir and dry-run cleanly")
+func customSchemaFilesResolve() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-schemas-\(UUID().uuidString)")
+    let schemaDirectory = directory.appending(path: ".afm/schemas")
+    let inputFile = directory.appending(path: "input.txt")
+
+    try FileManager.default.createDirectory(at: schemaDirectory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let schema = """
+    title: PersonCard
+    type: object
+    properties:
+      name:
+        type: string
+      age:
+        type: integer
+      occupation:
+        type: string
+    required:
+      - name
+      - age
+      - occupation
+    """
+    try schema.write(to: schemaDirectory.appending(path: "person-card.yaml"), atomically: true, encoding: .utf8)
+    try "Alex Rivera is a 34-year-old designer in Berlin.".write(to: inputFile, atomically: true, encoding: .utf8)
+
+    let result = try runAFM(
+        "schema", "run", "custom",
+        "--output", "json",
+        "--dry-run",
+        "--schema", "person-card",
+        "--schema-dir", schemaDirectory.path(),
+        "--input", "@\(inputFile.path())"
+    )
+
+    #expect(result.status == 0)
+    let json = try parseJSONObject(result.stdout)
+    #expect(json["command"] as? String == "schema run custom")
+    #expect(json["schema"] as? String == "person-card")
+    #expect(json["schemaFile"] as? String == schemaDirectory.appending(path: "person-card.yaml").path())
+    #expect(json["input"] as? String == "Alex Rivera is a 34-year-old designer in Berlin.")
+    #expect(json["inputFile"] as? String == inputFile.path())
+}
+
+@Test("All dynamic schema workflows dry-run cleanly")
+func dynamicSchemaDryRuns() throws {
+    let basic = try runAFM(
+        "schema", "run", "basic-object", "--output", "json", "--dry-run", "--preset", "product"
+    )
+    let array = try runAFM(
+        "schema", "run", "array-schema", "--output", "json", "--dry-run", "--preset", "todo",
+        "--min-items", "2", "--max-items", "4"
+    )
+    let enumeration = try runAFM(
+        "schema", "run", "enum-schema", "--output", "json", "--dry-run",
+        "--choice", "high", "--choice", "medium", "--choice", "low"
+    )
+
+    #expect(basic.status == 0)
+    #expect(array.status == 0)
+    #expect(enumeration.status == 0)
+
+    let basicJSON = try parseJSONObject(basic.stdout)
+    let arrayJSON = try parseJSONObject(array.stdout)
+    let enumJSON = try parseJSONObject(enumeration.stdout)
+
+    #expect(basicJSON["command"] as? String == "schema run basic-object")
+    #expect(arrayJSON["command"] as? String == "schema run array-schema")
+    #expect(enumJSON["command"] as? String == "schema run enum-schema")
+}
+
+@Test("Piped schema input overrides preset defaults")
+func pipedSchemaInputOverridesPresetDefaults() throws {
+    let pipedInput = "Taylor is a 29-year-old architect in Seattle."
+    let result = try runAFM(
+        [
+            "schema", "run", "typed-person",
+            "--output", "json",
+            "--dry-run"
+        ],
+        stdin: "\(pipedInput)\n"
+    )
+
+    #expect(result.status == 0)
+    let json = try parseJSONObject(result.stdout)
+    #expect(json["input"] as? String == pipedInput)
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITestSupport.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITestSupport.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+struct CommandResult {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+}
+
+func runAFM(
+    _ arguments: String...,
+    environment: [String: String] = [:],
+    stdin: String? = nil
+) throws -> CommandResult {
+    try runAFM(arguments, environment: environment, stdin: stdin)
+}
+
+func runAFM(
+    _ arguments: [String],
+    environment: [String: String] = [:],
+    stdin: String? = nil
+) throws -> CommandResult {
+    let process = Process()
+    process.executableURL = try findAFMBinary()
+    process.currentDirectoryURL = packageRoot()
+    process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    let stdinPipe = stdin.map { _ in Pipe() }
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    process.standardInput = stdinPipe ?? FileHandle.nullDevice
+    process.arguments = arguments
+
+    try process.run()
+    let readGroup = DispatchGroup()
+    let stdoutBuffer = CommandDataBuffer()
+    let stderrBuffer = CommandDataBuffer()
+    captureProcessOutput(from: stdoutPipe.fileHandleForReading, into: stdoutBuffer, group: readGroup)
+    captureProcessOutput(from: stderrPipe.fileHandleForReading, into: stderrBuffer, group: readGroup)
+
+    if let stdin, let stdinPipe {
+        stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
+        try? stdinPipe.fileHandleForWriting.close()
+    }
+    process.waitUntilExit()
+    readGroup.wait()
+
+    return CommandResult(
+        status: process.terminationStatus,
+        stdout: decodedOutput(stdoutBuffer.data),
+        stderr: decodedOutput(stderrBuffer.data)
+    )
+}
+
+func parseJSONObject(_ text: String) throws -> [String: Any] {
+    let data = try #require(text.data(using: .utf8))
+    let object = try JSONSerialization.jsonObject(with: data)
+    return try #require(object as? [String: Any])
+}
+
+func parseJSONLines(_ text: String) throws -> [[String: Any]] {
+    let lines = text
+        .split(separator: "\n")
+        .map(String.init)
+        .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    return try lines.map(parseJSONObject)
+}
+
+private final class CommandDataBuffer: @unchecked Sendable {
+    var data = Data()
+}
+
+private func captureProcessOutput(
+    from handle: FileHandle,
+    into buffer: CommandDataBuffer,
+    group: DispatchGroup
+) {
+    group.enter()
+    DispatchQueue.global(qos: .userInitiated).async {
+        buffer.data = handle.readDataToEndOfFile()
+        group.leave()
+    }
+}
+
+private func decodedOutput(_ data: Data) -> String {
+    (String(data: data, encoding: .utf8) ?? "")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func findAFMBinary() throws -> URL {
+    let root = packageRoot()
+    let directCandidates = [
+        root.appending(path: ".build/debug/afm"),
+        root.appending(path: ".build/arm64-apple-macosx/debug/afm"),
+        root.appending(path: ".build/x86_64-apple-macosx/debug/afm")
+    ]
+
+    for candidate in directCandidates where FileManager.default.isExecutableFile(atPath: candidate.path()) {
+        return candidate
+    }
+
+    let buildRoot = root.appending(path: ".build")
+    if let enumerator = FileManager.default.enumerator(at: buildRoot, includingPropertiesForKeys: nil) {
+        for case let fileURL as URL in enumerator where fileURL.lastPathComponent == "afm" {
+            if FileManager.default.isExecutableFile(atPath: fileURL.path()) {
+                return fileURL
+            }
+        }
+    }
+
+    throw TestFailure("Could not find built afm executable under \(buildRoot.path())")
+}
+
+private func packageRoot() -> URL {
+    var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+    while directory.path != "/" {
+        let manifest = directory.appending(path: "Package.swift")
+        if FileManager.default.fileExists(atPath: manifest.path()) {
+            return directory
+        }
+        directory.deleteLastPathComponent()
+    }
+
+    preconditionFailure("Could not find the package root above \(#filePath)")
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -1,12 +1,6 @@
 import Foundation
 import Testing
 
-struct CommandResult {
-    let status: Int32
-    let stdout: String
-    let stderr: String
-}
-
 @Test("Root help shows grouped command discovery")
 func rootHelpShowsGroupedCommands() throws {
     let result = try runAFM("--help")
@@ -58,43 +52,8 @@ func leafCommandHelpCoverage() throws {
         let result = try runAFM(command)
         #expect(result.status == 0)
         #expect(result.stdout.contains("USAGE:"))
-        #expect(result.stdout.contains("--help"))
-        if command.contains("session")
-            || command == ["schema", "run", "typed-person", "--help"]
-            || command == ["schema", "run", "basic-object", "--help"]
-            || command == ["schema", "run", "array-schema", "--help"]
-            || command == ["schema", "run", "enum-schema", "--help"]
-            || command == ["schema", "run", "custom", "--help"]
-            || command.contains("transcript")
-            || command.contains("feedback")
-            || command == ["tag", "run", "--help"] {
-            #expect(result.stdout.contains("--guardrails <guardrails>"))
-        }
-        if command.contains("session")
-            || command.contains("feedback")
-            || command.contains("transcript")
-            || command.contains("schema")
-            || command == ["model", "status", "--help"]
-            || command == ["model", "languages", "--help"] {
-            #expect(result.stdout.contains("--use-case <use-case>") || command.contains("schema"))
-        }
-        if command == ["schema", "run", "custom", "--help"]
-            || command == ["schema", "run", "typed-person", "--help"]
-            || command == ["schema", "run", "basic-object", "--help"]
-            || command == ["schema", "run", "array-schema", "--help"]
-            || command == ["schema", "run", "enum-schema", "--help"] {
-            #expect(result.stdout.contains("--include-schema-in-prompt"))
-        }
-        if command.contains("session")
-            || command.contains("feedback")
-            || command.contains("transcript")
-            || command == ["schema", "run", "custom", "--help"]
-            || command == ["schema", "run", "typed-person", "--help"]
-            || command == ["schema", "run", "basic-object", "--help"]
-            || command == ["schema", "run", "array-schema", "--help"]
-            || command == ["schema", "run", "enum-schema", "--help"]
-            || command == ["tag", "run", "--help"] {
-            #expect(result.stdout.contains("--adapter <adapter>"))
+        for flag in expectedHelpFlags(for: command) {
+            #expect(result.stdout.contains(flag))
         }
     }
 }
@@ -286,239 +245,27 @@ func adapterDryRunAndValidation() throws {
     )
 }
 
-@Test("Schema commands expose list and run flows")
-func schemaCommands() throws {
-    let list = try runAFM("schema", "list", "--output", "json")
-    let typedPerson = try runAFM(
-        "schema", "run", "typed-person", "--output", "json", "--dry-run",
-        "--input", "Alex Rivera is a designer in Berlin."
-    )
-    let badPreset = try runAFM(
-        "schema", "run", "enum-schema", "--dry-run", "--preset", "missing"
-    )
-
-    #expect(list.status == 0)
-    #expect(typedPerson.status == 0)
-    #expect(badPreset.status == 64)
-    #expect(badPreset.stderr.contains("Unknown preset 'missing' for enum-schema"))
-
-    let listJSON = try parseJSONObject(list.stdout)
-    let typedJSON = try parseJSONObject(typedPerson.stdout)
-
-    let schemas = listJSON["schemas"] as? [[String: Any]]
-    #expect((schemas?.isEmpty == false))
-    #expect(typedJSON["command"] as? String == "schema run typed-person")
-    #expect(typedJSON["input"] as? String == "Alex Rivera is a designer in Berlin.")
-}
-
-@Test("Foundation Models flags surface in dry-run payloads")
-func foundationModelsFlagsSurfaceInDryRunPayloads() throws {
-    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-        .appending(path: "afm-fmf-\(UUID().uuidString)")
-    let schemaDirectory = directory.appending(path: ".afm/schemas")
-    defer { try? FileManager.default.removeItem(at: directory) }
-    try FileManager.default.createDirectory(at: schemaDirectory, withIntermediateDirectories: true)
-
-    let schema = """
-    title: PersonCard
-    type: object
-    properties:
-      name:
-        type: string
-    required:
-      - name
-    """
-    try schema.write(to: schemaDirectory.appending(path: "person-card.yaml"), atomically: true, encoding: .utf8)
-
-    let modelStatus = try runAFM(
-        "model", "status", "--output", "json", "--dry-run",
-        "--use-case", "content-tagging"
-    )
-    let customSchema = try runAFM(
-        "schema", "run", "custom", "--output", "json", "--dry-run",
-        "--schema", "person-card",
-        "--schema-dir", schemaDirectory.path(),
-        "--input", "Alex Rivera",
-        "--use-case", "content-tagging",
-        "--no-include-schema-in-prompt"
-    )
-    let feedback = try runAFM(
-        "feedback", "export", "--output", "json", "--dry-run",
-        "--prompt", "hello",
-        "--file", "/tmp/afm-feedback.json",
-        "--issue", "incorrect",
-        "--issue-explanation", "Wrong answer"
-    )
-    let tag = try runAFM(
-        "tag", "run", "--output", "json", "--dry-run",
-        "--prompt", "A joyful dog playing in a sunny park."
-    )
-
-    #expect(modelStatus.status == 0)
-    #expect(customSchema.status == 0)
-    #expect(feedback.status == 0)
-    #expect(tag.status == 0)
-
-    let modelJSON = try parseJSONObject(modelStatus.stdout)
-    let schemaJSON = try parseJSONObject(customSchema.stdout)
-    let feedbackJSON = try parseJSONObject(feedback.stdout)
-    let tagJSON = try parseJSONObject(tag.stdout)
-
-    #expect(modelJSON["useCase"] as? String == "content-tagging")
-    #expect(schemaJSON["useCase"] as? String == "content-tagging")
-    #expect(schemaJSON["includeSchemaInPrompt"] as? Bool == false)
-    #expect((feedbackJSON["feedbackIssues"] as? [String]) == ["incorrect"])
-    #expect(tagJSON["command"] as? String == "tag run")
-    #expect(tagJSON["useCase"] as? String == "content-tagging")
-}
-
-@Test("Custom schema files resolve from schema-dir and dry-run cleanly")
-func customSchemaFilesResolve() throws {
-    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-        .appending(path: "afm-schemas-\(UUID().uuidString)")
-    let schemaDirectory = directory.appending(path: ".afm/schemas")
-    let inputFile = directory.appending(path: "input.txt")
-
-    try FileManager.default.createDirectory(at: schemaDirectory, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: directory) }
-
-    let schema = """
-    title: PersonCard
-    type: object
-    properties:
-      name:
-        type: string
-      age:
-        type: integer
-      occupation:
-        type: string
-    required:
-      - name
-      - age
-      - occupation
-    """
-    try schema.write(to: schemaDirectory.appending(path: "person-card.yaml"), atomically: true, encoding: .utf8)
-    try "Alex Rivera is a 34-year-old designer in Berlin.".write(to: inputFile, atomically: true, encoding: .utf8)
-
-    let result = try runAFM(
-        "schema", "run", "custom",
-        "--output", "json",
-        "--dry-run",
-        "--schema", "person-card",
-        "--schema-dir", schemaDirectory.path(),
-        "--input", "@\(inputFile.path())"
-    )
-
-    #expect(result.status == 0)
-    let json = try parseJSONObject(result.stdout)
-    #expect(json["command"] as? String == "schema run custom")
-    #expect(json["schema"] as? String == "person-card")
-    #expect(json["schemaFile"] as? String == schemaDirectory.appending(path: "person-card.yaml").path())
-    #expect(json["input"] as? String == "Alex Rivera is a 34-year-old designer in Berlin.")
-    #expect(json["inputFile"] as? String == inputFile.path())
-}
-
-@Test("All dynamic schema workflows dry-run cleanly")
-func dynamicSchemaDryRuns() throws {
-    let basic = try runAFM(
-        "schema", "run", "basic-object", "--output", "json", "--dry-run", "--preset", "product"
-    )
-    let array = try runAFM(
-        "schema", "run", "array-schema", "--output", "json", "--dry-run", "--preset", "todo",
-        "--min-items", "2", "--max-items", "4"
-    )
-    let enumeration = try runAFM(
-        "schema", "run", "enum-schema", "--output", "json", "--dry-run",
-        "--choice", "high", "--choice", "medium", "--choice", "low"
-    )
-
-    #expect(basic.status == 0)
-    #expect(array.status == 0)
-    #expect(enumeration.status == 0)
-
-    let basicJSON = try parseJSONObject(basic.stdout)
-    let arrayJSON = try parseJSONObject(array.stdout)
-    let enumJSON = try parseJSONObject(enumeration.stdout)
-
-    #expect(basicJSON["command"] as? String == "schema run basic-object")
-    #expect(arrayJSON["command"] as? String == "schema run array-schema")
-    #expect(enumJSON["command"] as? String == "schema run enum-schema")
-}
-
-@Test("Piped schema input overrides preset defaults")
-func pipedSchemaInputOverridesPresetDefaults() throws {
-    let pipedInput = "Taylor is a 29-year-old architect in Seattle."
-    let result = try runAFM(
-        [
-            "schema", "run", "typed-person",
-            "--output", "json",
-            "--dry-run"
-        ],
-        stdin: "\(pipedInput)\n"
-    )
-
-    #expect(result.status == 0)
-    let json = try parseJSONObject(result.stdout)
-    #expect(json["input"] as? String == pipedInput)
-}
-
 @Test("Tool manifests validate, inspect, and call through the CLI")
 func toolManifestCommands() throws {
-    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-        .appending(path: "afm-tools-\(UUID().uuidString)")
-    let toolDirectory = directory.appending(path: ".afm/tools")
-    let argsFile = directory.appending(path: "args.json")
-
-    try FileManager.default.createDirectory(at: toolDirectory, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: directory) }
-
-    let toolManifest = """
-    name: echo_json
-    description: Echoes JSON arguments back to the caller.
-    parameters:
-      title: EchoPayload
-      type: object
-      properties:
-        city:
-          type: string
-      required:
-        - city
-    runner:
-      kind: shell
-      outputFormat: json
-      command: /bin/sh
-      args:
-        - -lc
-        - cat
-    """
-    let secondToolManifest = toolManifest.replacingOccurrences(
-        of: "name: echo_json",
-        with: "name: echo_json_two"
-    )
-    try toolManifest.write(to: toolDirectory.appending(path: "echo-json.yaml"), atomically: true, encoding: .utf8)
-    try secondToolManifest.write(
-        to: toolDirectory.appending(path: "echo-json-two.yaml"),
-        atomically: true,
-        encoding: .utf8
-    )
-    try #"{"city":"Berlin"}"#.write(to: argsFile, atomically: true, encoding: .utf8)
+    let fixture = try ToolManifestFixture()
+    defer { fixture.remove() }
 
     let inspect = try runAFM(
         "tool", "inspect", "--output", "json",
         "--tool", "echo-json",
-        "--tool-dir", toolDirectory.path()
+        "--tool-dir", fixture.toolDirectory.path()
     )
     let validate = try runAFM(
         "tool", "validate", "--output", "json",
         "--tool", "echo-json",
         "--tool", "echo-json-two",
-        "--tool-dir", toolDirectory.path()
+        "--tool-dir", fixture.toolDirectory.path()
     )
     let call = try runAFM(
         "tool", "call", "--output", "json",
         "--tool", "echo-json",
-        "--tool-dir", toolDirectory.path(),
-        "--args-file", argsFile.path()
+        "--tool-dir", fixture.toolDirectory.path(),
+        "--args-file", fixture.argumentsFile.path()
     )
 
     #expect(inspect.status == 0)
@@ -538,8 +285,8 @@ func toolManifestCommands() throws {
     #expect(validatedTools.compactMap { $0["name"] as? String } == ["echo_json", "echo_json_two"])
     #expect(
         validatedTools.compactMap { $0["file"] as? String } == [
-            toolDirectory.appending(path: "echo-json.yaml").path(),
-            toolDirectory.appending(path: "echo-json-two.yaml").path()
+            fixture.toolDirectory.appending(path: "echo-json.yaml").path(),
+            fixture.toolDirectory.appending(path: "echo-json-two.yaml").path()
         ]
     )
     #expect(callJSON["name"] as? String == "echo_json")
@@ -717,153 +464,92 @@ func modelCommandsReturnStructuredJSON() throws {
     let useCasesJSON = try parseJSONObject(useCases.stdout)
     let guardrailsJSON = try parseJSONObject(guardrails.stdout)
 
-    #expect(statusJSON["status"] as? String != nil)
-    #expect(statusJSON["reason"] as? String != nil)
-    #expect(statusJSON["useCase"] as? String != nil)
+    #expect(statusJSON["status"] is String)
+    #expect(statusJSON["reason"] is String)
+    #expect(statusJSON["useCase"] is String)
 
     let supportedLanguages = languagesJSON["languages"] as? [[String: Any]]
     #expect((supportedLanguages?.isEmpty == false))
-    #expect(languagesJSON["currentLanguage"] as? String != nil)
-    #expect(languagesJSON["useCase"] as? String != nil)
+    #expect(languagesJSON["currentLanguage"] is String)
+    #expect(languagesJSON["useCase"] is String)
     #expect((useCasesJSON["useCases"] as? [[String: Any]])?.isEmpty == false)
     #expect((guardrailsJSON["guardrails"] as? [[String: Any]])?.isEmpty == false)
 }
 
-private func runAFM(
-    _ arguments: String...,
-    environment: [String: String] = [:],
-    stdin: String? = nil
-) throws -> CommandResult {
-    try runAFM(arguments, environment: environment, stdin: stdin)
-}
+private func expectedHelpFlags(for command: [String]) -> [String] {
+    let commandGroup = command.first
+    let isSchemaRun = Array(command.prefix(2)) == ["schema", "run"]
+    var flags = ["--help"]
 
-private func runAFM(
-    _ arguments: [String],
-    environment: [String: String] = [:],
-    stdin: String? = nil
-) throws -> CommandResult {
-    let process = Process()
-    process.executableURL = try findAFMBinary()
-    process.currentDirectoryURL = packageRoot()
-    process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
-
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    let stdinPipe = stdin.map { _ in Pipe() }
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
-    if let stdinPipe {
-        process.standardInput = stdinPipe
-    } else {
-        process.standardInput = FileHandle.nullDevice
+    if commandGroup == "session"
+        || commandGroup == "feedback"
+        || commandGroup == "transcript"
+        || command == ["tag", "run", "--help"]
+        || isSchemaRun {
+        flags.append(contentsOf: ["--guardrails <guardrails>", "--adapter <adapter>"])
     }
-    process.arguments = arguments
-
-    try process.run()
-    let readGroup = DispatchGroup()
-    let stdoutBuffer = CommandDataBuffer()
-    let stderrBuffer = CommandDataBuffer()
-    captureProcessOutput(
-        from: stdoutPipe.fileHandleForReading,
-        into: stdoutBuffer,
-        group: readGroup
-    )
-    captureProcessOutput(
-        from: stderrPipe.fileHandleForReading,
-        into: stderrBuffer,
-        group: readGroup
-    )
-
-    if let stdin, let stdinPipe {
-        stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
-        try? stdinPipe.fileHandleForWriting.close()
+    if commandGroup == "session"
+        || commandGroup == "feedback"
+        || commandGroup == "transcript"
+        || command == ["model", "status", "--help"]
+        || command == ["model", "languages", "--help"] {
+        flags.append("--use-case <use-case>")
     }
-    process.waitUntilExit()
-    readGroup.wait()
-
-    let stdout = String(data: stdoutBuffer.data, encoding: .utf8) ?? ""
-    let stderr = String(data: stderrBuffer.data, encoding: .utf8) ?? ""
-
-    return CommandResult(
-        status: process.terminationStatus,
-        stdout: stdout.trimmingCharacters(in: .whitespacesAndNewlines),
-        stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-    )
-}
-
-private final class CommandDataBuffer: @unchecked Sendable {
-    var data = Data()
-}
-
-private func captureProcessOutput(
-    from handle: FileHandle,
-    into buffer: CommandDataBuffer,
-    group: DispatchGroup
-) {
-    group.enter()
-    DispatchQueue.global(qos: .userInitiated).async {
-        buffer.data = handle.readDataToEndOfFile()
-        group.leave()
+    if isSchemaRun {
+        flags.append("--include-schema-in-prompt")
     }
+    return flags
 }
 
-private func parseJSONObject(_ text: String) throws -> [String: Any] {
-    let data = try #require(text.data(using: .utf8))
-    let object = try JSONSerialization.jsonObject(with: data)
-    return try #require(object as? [String: Any])
-}
+private struct ToolManifestFixture {
+    let root: URL
+    let toolDirectory: URL
+    let argumentsFile: URL
 
-private func parseJSONLines(_ text: String) throws -> [[String: Any]] {
-    let lines = text
-        .split(separator: "\n")
-        .map(String.init)
-        .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    init() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "afm-tools-\(UUID().uuidString)")
+        toolDirectory = root.appending(path: ".afm/tools")
+        argumentsFile = root.appending(path: "args.json")
+        try FileManager.default.createDirectory(at: toolDirectory, withIntermediateDirectories: true)
 
-    return try lines.map(parseJSONObject)
-}
-
-private func findAFMBinary() throws -> URL {
-    let root = packageRoot()
-    let directCandidates = [
-        root.appending(path: ".build/debug/afm"),
-        root.appending(path: ".build/arm64-apple-macosx/debug/afm"),
-        root.appending(path: ".build/x86_64-apple-macosx/debug/afm")
-    ]
-
-    for candidate in directCandidates where FileManager.default.isExecutableFile(atPath: candidate.path()) {
-        return candidate
+        let manifest = """
+        name: echo_json
+        description: Echoes JSON arguments back to the caller.
+        parameters:
+          title: EchoPayload
+          type: object
+          properties:
+            city:
+              type: string
+          required:
+            - city
+        runner:
+          kind: shell
+          outputFormat: json
+          command: /bin/sh
+          args:
+            - -lc
+            - cat
+        """
+        let secondManifest = manifest.replacingOccurrences(
+            of: "name: echo_json",
+            with: "name: echo_json_two"
+        )
+        try manifest.write(
+            to: toolDirectory.appending(path: "echo-json.yaml"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try secondManifest.write(
+            to: toolDirectory.appending(path: "echo-json-two.yaml"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"city":"Berlin"}"#.write(to: argumentsFile, atomically: true, encoding: .utf8)
     }
 
-    let buildRoot = root.appending(path: ".build")
-    if let enumerator = FileManager.default.enumerator(at: buildRoot, includingPropertiesForKeys: nil) {
-        for case let fileURL as URL in enumerator where fileURL.lastPathComponent == "afm" {
-            if FileManager.default.isExecutableFile(atPath: fileURL.path()) {
-                return fileURL
-            }
-        }
-    }
-
-    throw TestFailure("Could not find built afm executable under \(buildRoot.path())")
-}
-
-private func packageRoot() -> URL {
-    var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-
-    while directory.path != "/" {
-        let manifest = directory.appending(path: "Package.swift")
-        if FileManager.default.fileExists(atPath: manifest.path()) {
-            return directory
-        }
-        directory.deleteLastPathComponent()
-    }
-
-    preconditionFailure("Could not find the package root above \(#filePath)")
-}
-
-private struct TestFailure: Error, CustomStringConvertible {
-    let description: String
-
-    init(_ description: String) {
-        self.description = description
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
     }
 }


### PR DESCRIPTION
## Summary
- refactor all 55 pre-existing SwiftLint findings in `FoundationLabCore` and `Tools/AFMCLI` without changing the public CLI surface
- split schema, session, and test support into focused helpers
- add a scoped strict SwiftLint configuration and enforce it in the AFM CLI workflow

## Validation
- `swiftlint lint --strict --config .swiftlint-core-cli.yml` (0 violations across 149 files)
- `swift test` (33 XCTest + 96 Swift Testing tests)
- `swift build -c release --product afm`
- Foundation Lab iPhone 17 Pro simulator build and launch (0 warnings, 0 errors)
- `actionlint .github/workflows/afm-cli.yml`
- CLI dry-run smoke tests for session, schema, and tool commands