### PR TITLE
[codex] Add image input resolution probe

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -135,7 +135,7 @@ enum ExampleType: String, CaseIterable, Identifiable {
         case .privateCloudCompute:
             return "Probe PCC availability, quota, and context size"
         case .imageInputPlayground:
-            return "Explore image attachments and references"
+            return "Explore image attachments and resolution boundaries"
         case .toolCallingModeLab:
             return "Compare allowed, required, and disallowed tools"
         case .dynamicProfileBuilder:

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
@@ -14,7 +14,7 @@ struct ImageInputPlaygroundView: View {
     var body: some View {
         ExampleViewBase(
             title: "Image Input",
-            description: "Explore image attachments and generated image references",
+            description: "Explore image attachments, references, and empirical resolution boundaries",
             defaultPrompt: "Turn this screenshot into a concise bug report.",
             currentPrompt: $currentPrompt,
             codeExample: selectedRecipe.code,
@@ -43,6 +43,8 @@ struct ImageInputPlaygroundView: View {
                         )
                     }
                 }
+
+                ImageInputResolutionFindingsView()
 
                 Xcode27Section("Recipes", systemImage: "list.bullet.clipboard") {
                     Picker("Recipe", selection: $selectedRecipe) {
@@ -114,13 +116,11 @@ private enum ImageInputRecipe: String, CaseIterable, Identifiable {
                 .label("screenshot")
 
             let session = LanguageModelSession()
-            let response = try await session.respond(
-                to: Prompt("\(prompt)")
-                // Include image attachment with the prompt when using the Xcode 27 attachment API.
-            )
-
-            let reference = try response.content as ImageReference
-            let resolved = reference.resolve(in: session.transcript)
+            let response = try await session.respond {
+                "\(prompt)"
+                image
+            }
+            print(response.content)
         }
         """
     }
@@ -131,4 +131,3 @@ private enum ImageInputRecipe: String, CaseIterable, Identifiable {
         ImageInputPlaygroundView()
     }
 }
-

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResolutionFindingCard.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResolutionFindingCard.swift
@@ -1,0 +1,45 @@
+//
+//  ImageInputResolutionFindingCard.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/14/26.
+//
+
+import SwiftUI
+
+struct ImageInputResolutionFindingCard: View {
+    let ratio: String
+    let largestCorrect: String
+    let firstIncorrect: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            Text(ratio)
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label("Largest correct", systemImage: "checkmark.circle.fill")
+                    .font(.footnote)
+                    .foregroundStyle(.green)
+
+                Text(largestCorrect)
+                    .font(.body.monospaced())
+                    .textSelection(.enabled)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label("First incorrect", systemImage: "exclamationmark.triangle.fill")
+                    .font(.footnote)
+                    .foregroundStyle(.orange)
+
+                Text(firstIncorrect)
+                    .font(.body.monospaced())
+                    .textSelection(.enabled)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color.secondary.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResolutionFindingsView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResolutionFindingsView.swift
@@ -1,0 +1,87 @@
+//
+//  ImageInputResolutionFindingsView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/14/26.
+//
+
+import SwiftUI
+
+struct ImageInputResolutionFindingsView: View {
+    var body: some View {
+        Xcode27Section("Resolution Probe", systemImage: "ruler") {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                Text(
+                    "Apple does not publish a maximum pixel size, megapixel count, file size, or aspect ratio for Foundation Models image attachments."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                Label(
+                    "Observed June 14, 2026 on macOS 27.0 beta build 26A5353q using the system model and a Display P3 JPEG.",
+                    systemImage: "macbook"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 220), spacing: Spacing.small)],
+                    spacing: Spacing.small
+                ) {
+                    ImageInputResolutionFindingCard(
+                        ratio: "1:1",
+                        largestCorrect: "23168x23168",
+                        firstIncorrect: "23169x23169"
+                    )
+
+                    ImageInputResolutionFindingCard(
+                        ratio: "16:9",
+                        largestCorrect: "30892x17377",
+                        firstIncorrect: "30893x17377"
+                    )
+
+                    ImageInputResolutionFindingCard(
+                        ratio: "9:16",
+                        largestCorrect: "17376x30891",
+                        firstIncorrect: "17377x30892"
+                    )
+
+                    ImageInputResolutionFindingCard(
+                        ratio: "4:3",
+                        largestCorrect: "26753x20065",
+                        firstIncorrect: "26754x20066"
+                    )
+                }
+
+                Divider()
+
+                Xcode27InfoRow(
+                    title: "Semantic failure",
+                    detail: "Requests above the boundary still completed successfully, but the model consistently changed a yellow diamond on a blue background into a circle on black.",
+                    systemImage: "exclamationmark.triangle.fill",
+                    tint: .orange
+                )
+
+                Xcode27InfoRow(
+                    title: "Inferred 2 GiB boundary",
+                    detail: "The measured flips align with a 4-byte BGRA decode buffer, using a 16-byte-aligned row stride, crossing 2^31 bytes. This is an implementation inference, not an official Apple limit.",
+                    systemImage: "memorychip",
+                    tint: .purple
+                )
+
+                Text("decodedBytes = ceil((width * 4) / 16) * 16 * height")
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+
+                Xcode27InfoRow(
+                    title: "Reproduce it",
+                    detail: "Run Tools/ImageInputProbe/image_input_probe.py with known expected terms to measure transport and semantic correctness on the current OS and model build.",
+                    systemImage: "terminal",
+                    tint: .blue
+                )
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ Xcode 27 adds several Foundation Models surfaces that are not available in the X
 - `GenerationOptions.toolCallingMode` with `.allowed`, `.required`, and `.disallowed`.
 - Foundation Models types are now available to watchOS 27 for many prompting, schema, transcript, tool, and feedback surfaces, while tvOS remains unavailable.
 
+### Probe image input limits
+
+Apple does not currently publish a maximum image resolution for Foundation
+Models attachments. The repo includes a CLI that resamples any source image
+through square and common landscape/portrait ratios, calls Apple's `fm` CLI,
+and records the first failing size:
+
+```bash
+Tools/ImageInputProbe/image_input_probe.py path/to/photo.jpg
+```
+
+See [Tools/ImageInputProbe/README.md](Tools/ImageInputProbe/README.md) for
+larger sweeps, semantic checks, JSONL reports, and the current beta's observed
+decoded-buffer boundary.
+
 ## Try it on TestFlight
 
 You can now try Foundation Lab on TestFlight! Join the beta: [https://testflight.apple.com/join/JWR9FpP3](https://testflight.apple.com/join/JWR9FpP3)

--- a/Tools/ImageInputProbe/README.md
+++ b/Tools/ImageInputProbe/README.md
@@ -1,0 +1,131 @@
+# Foundation Models Image Input Probe
+
+This CLI empirically tests image inputs against Apple's shipped `fm` command. It
+accepts any source image, resamples it into progressively larger common aspect
+ratios, sends each variant through the model, and records the first failure.
+
+## What Apple documents
+
+As of June 14, 2026, Apple's public Foundation Models documentation does not
+publish a maximum pixel width, height, megapixel count, file size, or aspect
+ratio for image attachments.
+
+Apple does document that:
+
+- `Attachment` accepts image file URLs, `CGImage`, `CIImage`, and
+  `CVPixelBuffer`.
+- The framework performs scaling and color conversion before model inference,
+  so callers do not need to pre-scale images just to satisfy the API.
+- Apple's Origami sample includes unscaled JPEGs as large as `5712x4284`
+  (about 24.5 MP).
+
+There is also a recent Apple Developer Forums Q&A asking for ideal image size
+and preprocessing guidance, but it does not currently have an answer.
+
+These sources describe behavior, not a contractual maximum. Any measured
+boundary may vary by OS build, model update, device memory, file format, and
+whether the system or Private Cloud Compute model is selected.
+
+## Initial macOS 27 beta observation
+
+On June 14, 2026, the system model on macOS 27.0 build `26A5353q` was tested
+with a Display P3 JPEG from Apple's Origami sample. The image contains a yellow
+diamond on a blue background. The prompt required the response to identify both
+`diamond` and `blue`.
+
+| Ratio | Largest correct result | First incorrect result |
+| --- | ---: | ---: |
+| 1:1 | `23168x23168` | `23169x23169` |
+| 16:9 | `30892x17377` | `30893x17377` |
+| 9:16 | `17376x30891` | `17377x30892` |
+| 4:3 | `26753x20065` | `26754x20066` |
+
+The calls above the boundary still exited successfully, but the model
+consistently reported a black background and a circle. This is a semantic
+failure, not an API rejection.
+
+The four boundaries align with an estimated 4-byte BGRA decode buffer, using a
+16-byte-aligned row stride, crossing `2^31` bytes:
+
+```text
+alignedRowBytes = ceil((width * 4) / 16) * 16
+estimatedDecodedBytes = alignedRowBytes * height
+```
+
+The JSONL report includes this estimate for every test. This relationship is an
+inference from current behavior, not a documented Apple limit, and should be
+retested on later OS/model builds and with other image formats.
+
+## Run
+
+Requirements:
+
+- macOS 27 with Apple Intelligence enabled
+- `/usr/bin/fm` and `/usr/bin/sips`
+- Python 3
+
+Start with the source image, then sweep square and common landscape/portrait
+ratios from a 512-pixel long edge through 8192 pixels:
+
+```bash
+Tools/ImageInputProbe/image_input_probe.py path/to/photo.jpg
+```
+
+Test only square and 16:9 images through a larger cap:
+
+```bash
+Tools/ImageInputProbe/image_input_probe.py path/to/photo.jpg \
+  --ratios 1:1,16:9 \
+  --max-long-edge 16384 \
+  --max-pixels 300000000
+```
+
+Use exact long-edge sizes:
+
+```bash
+Tools/ImageInputProbe/image_input_probe.py path/to/photo.jpg \
+  --ratios 1:1,16:9,9:16 \
+  --sizes 512,1024,2048,4096,8192,12288
+```
+
+Verify that the model still understands known image content, not just that the
+request returns:
+
+```bash
+Tools/ImageInputProbe/image_input_probe.py path/to/known-photo.jpg \
+  --prompt "What shape is centered, and what color is the background?" \
+  --expect diamond \
+  --expect blue
+```
+
+Keep generated images and write the report inside the repo:
+
+```bash
+Tools/ImageInputProbe/image_input_probe.py path/to/photo.jpg \
+  --output-dir tmp/image-input-probe/run-1 \
+  --keep-images
+```
+
+The default report is a timestamped `results.jsonl` under
+`/tmp/foundation-lab-image-probe/`.
+
+## Pass criteria
+
+A test passes only when `fm respond` exits successfully, returns a nonempty
+model response, and includes every optional `--expect` term. The report
+preserves separate transport and semantic status, dimensions, megapixels,
+encoded file size, generation time, inference time, response text, exit status,
+and raw error.
+
+`fm token-count --image` can be enabled with `--include-token-count`, but it is
+diagnostic only. On the macOS 27 beta tested on June 14, 2026, token counting
+returned `com.apple.VisionCore error 6` for images that worked correctly with
+`fm respond`.
+
+## Sources
+
+- [Analyzing images with multimodal prompting](https://developer.apple.com/documentation/FoundationModels/analyzing-images-with-multimodal-prompting)
+- [Attachment](https://developer.apple.com/documentation/foundationmodels/attachment)
+- [ImageAttachmentContent](https://developer.apple.com/documentation/foundationmodels/imageattachmentcontent)
+- [Origami sample](https://developer.apple.com/documentation/foundationmodels/origami-crafting-a-dynamic-tutorial-for-apple-intelligence)
+- [Foundation Models Q&A](https://developer.apple.com/forums/activities/1570080)

--- a/Tools/ImageInputProbe/image_input_probe.py
+++ b/Tools/ImageInputProbe/image_input_probe.py
@@ -610,7 +610,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         f"{format_megapixels(width, height):>8.2f} MP  "
                         f"{'-':>7}      SKIP         {skipped['reason']}"
                     )
-                    break
+                    continue
 
                 image_path = image_root / (
                     f"{ratio.width}x{ratio.height}-{width}x{height}.{extension}"

--- a/Tools/ImageInputProbe/image_input_probe.py
+++ b/Tools/ImageInputProbe/image_input_probe.py
@@ -640,7 +640,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "generation_seconds": round(generated.seconds, 4),
                     }
                     write_record(report_path, generation_failure)
-                    failures[ratio.label] = generation_failure
+                    failures.setdefault(ratio.label, generation_failure)
                     print(
                         f"{ratio.label:>7}  {f'{width}x{height}':>13}  "
                         f"{format_megapixels(width, height):>8.2f} MP  "
@@ -666,7 +666,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "generation_seconds": round(generated.seconds, 4),
                     }
                     write_record(report_path, inspection_failure)
-                    failures[ratio.label] = inspection_failure
+                    failures.setdefault(ratio.label, inspection_failure)
                     print(
                         f"{ratio.label:>7}  {f'{width}x{height}':>13}  "
                         f"{format_megapixels(width, height):>8.2f} MP  "

--- a/Tools/ImageInputProbe/image_input_probe.py
+++ b/Tools/ImageInputProbe/image_input_probe.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""Empirically probe Apple Foundation Models image-input limits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+DEFAULT_RATIOS = ("1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3")
+DEFAULT_PROMPT = "Describe this image in one short sentence."
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+ESTIMATED_PIXEL_BYTES = 4
+ESTIMATED_ROW_ALIGNMENT = 16
+TWO_GIB_BYTES = 1 << 31
+
+
+@dataclass(frozen=True)
+class AspectRatio:
+    label: str
+    width: int
+    height: int
+
+    def dimensions(self, long_edge: int) -> tuple[int, int]:
+        if self.width >= self.height:
+            width = long_edge
+            height = max(1, round(long_edge * self.height / self.width))
+        else:
+            height = long_edge
+            width = max(1, round(long_edge * self.width / self.height))
+        return width, height
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    seconds: float
+    timed_out: bool = False
+
+    @property
+    def combined_output(self) -> str:
+        return "\n".join(part for part in (self.stdout, self.stderr) if part).strip()
+
+
+def parse_ratio(value: str) -> AspectRatio:
+    parts = value.strip().split(":")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(f"Invalid aspect ratio '{value}'; expected W:H.")
+
+    try:
+        width, height = (int(part) for part in parts)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            f"Invalid aspect ratio '{value}'; W and H must be integers."
+        ) from error
+
+    if width <= 0 or height <= 0:
+        raise argparse.ArgumentTypeError(
+            f"Invalid aspect ratio '{value}'; W and H must be positive."
+        )
+
+    divisor = math.gcd(width, height)
+    normalized_width = width // divisor
+    normalized_height = height // divisor
+    return AspectRatio(
+        label=f"{normalized_width}:{normalized_height}",
+        width=normalized_width,
+        height=normalized_height,
+    )
+
+
+def parse_ratios(value: str) -> list[AspectRatio]:
+    ratios = [parse_ratio(item) for item in value.split(",") if item.strip()]
+    if not ratios:
+        raise argparse.ArgumentTypeError("Provide at least one aspect ratio.")
+    return ratios
+
+
+def parse_sizes(value: str) -> list[int]:
+    try:
+        sizes = [int(item) for item in value.split(",") if item.strip()]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("Sizes must be comma-separated integers.") from error
+
+    if not sizes or any(size <= 0 for size in sizes):
+        raise argparse.ArgumentTypeError("Sizes must contain positive integers.")
+    return list(dict.fromkeys(sizes))
+
+
+def parse_jpeg_quality(value: str) -> int:
+    try:
+        quality = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("JPEG quality must be an integer from 1 to 100.") from error
+    if not 1 <= quality <= 100:
+        raise argparse.ArgumentTypeError("JPEG quality must be an integer from 1 to 100.")
+    return quality
+
+
+def build_long_edges(
+    start: int,
+    maximum: int,
+    growth: float,
+    explicit_sizes: Sequence[int] | None = None,
+) -> list[int]:
+    if explicit_sizes:
+        return list(explicit_sizes)
+    if start <= 0 or maximum <= 0:
+        raise ValueError("Start and maximum long edges must be positive.")
+    if start > maximum:
+        raise ValueError("Start long edge cannot exceed maximum long edge.")
+    if growth <= 1:
+        raise ValueError("Growth must be greater than 1.")
+
+    sizes: list[int] = []
+    current = start
+    while current <= maximum:
+        sizes.append(current)
+        next_size = max(current + 1, round(current * growth))
+        if next_size > maximum:
+            break
+        current = next_size
+
+    if sizes[-1] != maximum:
+        sizes.append(maximum)
+    return sizes
+
+
+def clean_output(value: str) -> str:
+    return ANSI_ESCAPE.sub("", value).strip()
+
+
+def preview(value: str, limit: int = 100) -> str:
+    compact = " ".join(clean_output(value).split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 3]}..."
+
+
+def run_command(
+    command: Sequence[str],
+    timeout: float,
+    environment: dict[str, str] | None = None,
+) -> CommandResult:
+    started_at = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=environment,
+            check=False,
+        )
+        return CommandResult(
+            exit_code=completed.returncode,
+            stdout=clean_output(completed.stdout),
+            stderr=clean_output(completed.stderr),
+            seconds=time.monotonic() - started_at,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout.decode() if isinstance(error.stdout, bytes) else error.stdout or ""
+        stderr = error.stderr.decode() if isinstance(error.stderr, bytes) else error.stderr or ""
+        return CommandResult(
+            exit_code=124,
+            stdout=clean_output(stdout),
+            stderr=clean_output(stderr),
+            seconds=time.monotonic() - started_at,
+            timed_out=True,
+        )
+
+
+def image_properties(sips_path: str, image_path: Path, timeout: float) -> dict[str, object]:
+    result = run_command(
+        [sips_path, "-g", "pixelWidth", "-g", "pixelHeight", "-g", "format", str(image_path)],
+        timeout=timeout,
+    )
+    if result.exit_code != 0:
+        raise RuntimeError(result.combined_output or "Unable to inspect image.")
+
+    width_match = re.search(r"pixelWidth:\s*(\d+)", result.stdout)
+    height_match = re.search(r"pixelHeight:\s*(\d+)", result.stdout)
+    format_match = re.search(r"format:\s*(\S+)", result.stdout)
+    if not width_match or not height_match:
+        raise RuntimeError(f"Unable to read image dimensions from sips output: {result.stdout}")
+
+    return {
+        "width": int(width_match.group(1)),
+        "height": int(height_match.group(1)),
+        "format": format_match.group(1) if format_match else "unknown",
+        "bytes": image_path.stat().st_size,
+    }
+
+
+def generate_variant(
+    sips_path: str,
+    source: Path,
+    destination: Path,
+    width: int,
+    height: int,
+    image_format: str,
+    jpeg_quality: int,
+    timeout: float,
+) -> CommandResult:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    command = [sips_path, "-s", "format", image_format]
+    if image_format == "jpeg":
+        command.extend(["-s", "formatOptions", str(jpeg_quality)])
+    command.extend(["-z", str(height), str(width), str(source), "--out", str(destination)])
+    return run_command(command, timeout=timeout)
+
+
+def fm_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["NO_COLOR"] = "1"
+    environment["TERM"] = "dumb"
+    return environment
+
+
+def run_token_count(
+    fm_path: str,
+    image_path: Path,
+    prompt: str,
+    timeout: float,
+) -> tuple[int | None, CommandResult]:
+    result = run_command(
+        [
+            fm_path,
+            "token-count",
+            "--quiet",
+            "--image",
+            str(image_path),
+            "--text",
+            prompt,
+        ],
+        timeout=timeout,
+        environment=fm_environment(),
+    )
+    try:
+        token_count = int(result.stdout.strip()) if result.exit_code == 0 else None
+    except ValueError:
+        token_count = None
+    return token_count, result
+
+
+def run_response(
+    fm_path: str,
+    model: str,
+    image_path: Path,
+    prompt: str,
+    timeout: float,
+) -> CommandResult:
+    return run_command(
+        [
+            fm_path,
+            "respond",
+            "--model",
+            model,
+            "--no-stream",
+            "--greedy",
+            "--image",
+            str(image_path),
+            "--text",
+            prompt,
+        ],
+        timeout=timeout,
+        environment=fm_environment(),
+    )
+
+
+def write_record(report_path: Path, record: dict[str, object]) -> None:
+    with report_path.open("a", encoding="utf-8") as report:
+        json.dump(record, report, sort_keys=True)
+        report.write("\n")
+
+
+def format_megapixels(width: int, height: int) -> float:
+    return round(width * height / 1_000_000, 3)
+
+
+def estimated_bgra_buffer(width: int, height: int) -> tuple[int, int]:
+    unaligned_row_bytes = width * ESTIMATED_PIXEL_BYTES
+    row_bytes = (
+        (unaligned_row_bytes + ESTIMATED_ROW_ALIGNMENT - 1)
+        // ESTIMATED_ROW_ALIGNMENT
+        * ESTIMATED_ROW_ALIGNMENT
+    )
+    return row_bytes, row_bytes * height
+
+
+def missing_expected_terms(response: str, expected_terms: Sequence[str]) -> list[str]:
+    normalized_response = response.casefold()
+    return [term for term in expected_terms if term.casefold() not in normalized_response]
+
+
+def print_result(record: dict[str, object]) -> None:
+    dimensions = f"{record['width']}x{record['height']}"
+    file_mebibytes = int(record["bytes"]) / (1024 * 1024)
+    status = "PASS" if record["success"] else "FAIL"
+    detail = preview(str(record.get("response") or record.get("error") or ""))
+    print(
+        f"{str(record['ratio']):>7}  {dimensions:>13}  "
+        f"{float(record['megapixels']):>8.2f} MP  {file_mebibytes:>7.2f} MiB  "
+        f"{status:>4}  {float(record['response_seconds']):>6.2f}s  {detail}"
+    )
+
+
+def test_image(
+    *,
+    fm_path: str,
+    model: str,
+    image_path: Path,
+    ratio: str,
+    long_edge: int,
+    prompt: str,
+    timeout: float,
+    include_token_count: bool,
+    expected_terms: Sequence[str],
+    properties: dict[str, object],
+    generation_seconds: float,
+) -> dict[str, object]:
+    token_count: int | None = None
+    token_result: CommandResult | None = None
+    if include_token_count:
+        token_count, token_result = run_token_count(fm_path, image_path, prompt, timeout)
+
+    response_result = run_response(fm_path, model, image_path, prompt, timeout)
+    response_text = response_result.stdout.strip()
+    width = int(properties["width"])
+    height = int(properties["height"])
+    estimated_row_bytes, estimated_decoded_bytes = estimated_bgra_buffer(width, height)
+    transport_success = response_result.exit_code == 0 and bool(response_text)
+    missing_terms = (
+        missing_expected_terms(response_text, expected_terms) if transport_success else []
+    )
+    semantic_success = transport_success and not missing_terms
+    if not transport_success:
+        error = response_result.combined_output or "The model returned no output."
+    elif missing_terms:
+        error = f"Missing expected response terms: {', '.join(missing_terms)}."
+    else:
+        error = ""
+
+    return {
+        "type": "test",
+        "ratio": ratio,
+        "long_edge": long_edge,
+        "width": width,
+        "height": height,
+        "pixels": width * height,
+        "megapixels": format_megapixels(width, height),
+        "bytes": properties["bytes"],
+        "format": properties["format"],
+        "estimated_bgra_row_bytes": estimated_row_bytes,
+        "estimated_bgra_bytes": estimated_decoded_bytes,
+        "estimated_bgra_gibibytes": round(estimated_decoded_bytes / (1024**3), 6),
+        "estimated_bgra_crosses_2_gib": estimated_decoded_bytes >= TWO_GIB_BYTES,
+        "generation_seconds": round(generation_seconds, 4),
+        "token_count": token_count,
+        "token_count_exit_code": token_result.exit_code if token_result else None,
+        "token_count_seconds": round(token_result.seconds, 4) if token_result else None,
+        "token_count_error": (
+            token_result.combined_output if token_result and token_result.exit_code != 0 else None
+        ),
+        "response_exit_code": response_result.exit_code,
+        "response_seconds": round(response_result.seconds, 4),
+        "response": response_text,
+        "error": error,
+        "expected_terms": list(expected_terms),
+        "missing_expected_terms": missing_terms,
+        "transport_success": transport_success,
+        "semantic_success": semantic_success,
+        "timed_out": response_result.timed_out,
+        "success": semantic_success,
+    }
+
+
+def output_extension(image_format: str) -> str:
+    return {"jpeg": "jpg", "png": "png", "heic": "heic"}[image_format]
+
+
+def resolve_executable(value: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser().resolve()
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path)
+        raise FileNotFoundError(f"Executable not found: {path}")
+
+    resolved = shutil.which(value)
+    if resolved:
+        return resolved
+    raise FileNotFoundError(f"Executable not found on PATH: {value}")
+
+
+def macos_version_value(option: str) -> str:
+    result = run_command(["/usr/bin/sw_vers", option], timeout=5)
+    return result.stdout if result.exit_code == 0 else "unknown"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate progressively larger image variants and test them with Apple's fm CLI."
+        )
+    )
+    parser.add_argument("image", type=Path, help="Source image to resample and test.")
+    parser.add_argument(
+        "--ratios",
+        type=parse_ratios,
+        default=parse_ratios(",".join(DEFAULT_RATIOS)),
+        help=f"Comma-separated W:H ratios. Default: {','.join(DEFAULT_RATIOS)}",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=parse_sizes,
+        help="Explicit comma-separated long-edge sizes; overrides start/max/growth.",
+    )
+    parser.add_argument("--start-long-edge", type=int, default=512)
+    parser.add_argument("--max-long-edge", type=int, default=8192)
+    parser.add_argument("--growth", type=float, default=2.0)
+    parser.add_argument(
+        "--max-pixels",
+        type=int,
+        default=200_000_000,
+        help="Safety cap per generated image; pass 0 to disable. Default: %(default)s",
+    )
+    parser.add_argument("--model", choices=("system", "pcc"), default="system")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument(
+        "--expect",
+        action="append",
+        default=[],
+        help=(
+            "Case-insensitive term that must appear in the response. Repeat for multiple terms."
+        ),
+    )
+    parser.add_argument("--format", choices=("jpeg", "png", "heic"), default="jpeg")
+    parser.add_argument("--jpeg-quality", type=parse_jpeg_quality, default=80)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--fm-path", default="/usr/bin/fm")
+    parser.add_argument("--sips-path", default="/usr/bin/sips")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Report directory. Defaults to a timestamped directory under /tmp.",
+    )
+    parser.add_argument(
+        "--keep-images",
+        action="store_true",
+        help="Keep generated variants beside the JSONL report.",
+    )
+    parser.add_argument(
+        "--include-token-count",
+        action="store_true",
+        help="Also run fm token-count. This is diagnostic and does not decide pass/fail.",
+    )
+    parser.add_argument(
+        "--skip-source",
+        action="store_true",
+        help="Skip the original image and test only generated aspect-ratio variants.",
+    )
+    parser.add_argument(
+        "--continue-after-failure",
+        action="store_true",
+        help="Continue larger sizes after a failed model response.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+
+    source = arguments.image.expanduser().resolve()
+    if not source.is_file():
+        parser.error(f"Image does not exist: {source}")
+
+    try:
+        fm_path = resolve_executable(arguments.fm_path)
+        sips_path = resolve_executable(arguments.sips_path)
+        long_edges = build_long_edges(
+            arguments.start_long_edge,
+            arguments.max_long_edge,
+            arguments.growth,
+            arguments.sizes,
+        )
+    except (FileNotFoundError, ValueError) as error:
+        parser.error(str(error))
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_directory = (
+        arguments.output_dir.expanduser().resolve()
+        if arguments.output_dir
+        else Path(tempfile.gettempdir()) / "foundation-lab-image-probe" / timestamp
+    )
+    output_directory.mkdir(parents=True, exist_ok=True)
+    report_path = output_directory / "results.jsonl"
+    if report_path.exists():
+        report_path.unlink()
+
+    availability = run_command(
+        [fm_path, "available", "--model", arguments.model],
+        timeout=arguments.timeout,
+        environment=fm_environment(),
+    )
+    metadata: dict[str, object] = {
+        "type": "run",
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "source": str(source),
+        "fm_path": fm_path,
+        "model": arguments.model,
+        "prompt": arguments.prompt,
+        "expected_terms": arguments.expect,
+        "ratios": [ratio.label for ratio in arguments.ratios],
+        "long_edges": long_edges,
+        "max_pixels": arguments.max_pixels,
+        "output_format": arguments.format,
+        "host": {
+            "macos": macos_version_value("-productVersion") or platform.mac_ver()[0],
+            "build": macos_version_value("-buildVersion"),
+            "machine": platform.machine(),
+        },
+        "availability_exit_code": availability.exit_code,
+        "availability": availability.combined_output,
+    }
+    write_record(report_path, metadata)
+
+    print(f"Source: {source}")
+    print(f"Model: {arguments.model} ({availability.combined_output or 'unknown availability'})")
+    print(f"Report: {report_path}")
+    print()
+    print("  ratio     dimensions        pixels      file  test    time  response/error")
+
+    successful_tests = 0
+    failures: dict[str, dict[str, object]] = {}
+    largest_successes: dict[str, dict[str, object]] = {}
+
+    if not arguments.skip_source:
+        try:
+            properties = image_properties(sips_path, source, arguments.timeout)
+            source_record = test_image(
+                fm_path=fm_path,
+                model=arguments.model,
+                image_path=source,
+                ratio="source",
+                long_edge=max(int(properties["width"]), int(properties["height"])),
+                prompt=arguments.prompt,
+                timeout=arguments.timeout,
+                include_token_count=arguments.include_token_count,
+                expected_terms=arguments.expect,
+                properties=properties,
+                generation_seconds=0,
+            )
+            write_record(report_path, source_record)
+            print_result(source_record)
+            successful_tests += int(bool(source_record["success"]))
+        except RuntimeError as error:
+            source_error = {
+                "type": "test",
+                "ratio": "source",
+                "success": False,
+                "error": str(error),
+            }
+            write_record(report_path, source_error)
+            print(f"{'source':>7}  {'unknown':>13}  {'-':>11}  {'-':>8}  FAIL         {error}")
+
+    image_root = output_directory / "images"
+    temporary_images: tempfile.TemporaryDirectory[str] | None = None
+    if not arguments.keep_images:
+        temporary_images = tempfile.TemporaryDirectory(prefix="foundation-lab-image-probe-")
+        image_root = Path(temporary_images.name)
+
+    extension = output_extension(arguments.format)
+    try:
+        for ratio in arguments.ratios:
+            for long_edge in long_edges:
+                width, height = ratio.dimensions(long_edge)
+                pixels = width * height
+                if arguments.max_pixels and pixels > arguments.max_pixels:
+                    skipped = {
+                        "type": "skipped",
+                        "ratio": ratio.label,
+                        "long_edge": long_edge,
+                        "width": width,
+                        "height": height,
+                        "pixels": pixels,
+                        "reason": (
+                            f"Exceeded --max-pixels {arguments.max_pixels}; "
+                            "raise the cap or pass 0 to disable it."
+                        ),
+                    }
+                    write_record(report_path, skipped)
+                    print(
+                        f"{ratio.label:>7}  {f'{width}x{height}':>13}  "
+                        f"{format_megapixels(width, height):>8.2f} MP  "
+                        f"{'-':>7}      SKIP         {skipped['reason']}"
+                    )
+                    break
+
+                image_path = image_root / (
+                    f"{ratio.width}x{ratio.height}-{width}x{height}.{extension}"
+                )
+                generated = generate_variant(
+                    sips_path=sips_path,
+                    source=source,
+                    destination=image_path,
+                    width=width,
+                    height=height,
+                    image_format=arguments.format,
+                    jpeg_quality=arguments.jpeg_quality,
+                    timeout=arguments.timeout,
+                )
+                if generated.exit_code != 0:
+                    generation_failure = {
+                        "type": "test",
+                        "ratio": ratio.label,
+                        "long_edge": long_edge,
+                        "width": width,
+                        "height": height,
+                        "pixels": pixels,
+                        "megapixels": format_megapixels(width, height),
+                        "success": False,
+                        "stage": "generation",
+                        "error": generated.combined_output,
+                        "generation_seconds": round(generated.seconds, 4),
+                    }
+                    write_record(report_path, generation_failure)
+                    failures[ratio.label] = generation_failure
+                    print(
+                        f"{ratio.label:>7}  {f'{width}x{height}':>13}  "
+                        f"{format_megapixels(width, height):>8.2f} MP  "
+                        f"{'-':>7}  FAIL  {generated.seconds:>6.2f}s  "
+                        f"{preview(generated.combined_output)}"
+                    )
+                    break
+
+                try:
+                    properties = image_properties(sips_path, image_path, arguments.timeout)
+                except RuntimeError as error:
+                    inspection_failure = {
+                        "type": "test",
+                        "ratio": ratio.label,
+                        "long_edge": long_edge,
+                        "width": width,
+                        "height": height,
+                        "pixels": pixels,
+                        "megapixels": format_megapixels(width, height),
+                        "success": False,
+                        "stage": "inspection",
+                        "error": str(error),
+                        "generation_seconds": round(generated.seconds, 4),
+                    }
+                    write_record(report_path, inspection_failure)
+                    failures[ratio.label] = inspection_failure
+                    print(
+                        f"{ratio.label:>7}  {f'{width}x{height}':>13}  "
+                        f"{format_megapixels(width, height):>8.2f} MP  "
+                        f"{'-':>7}  FAIL  {generated.seconds:>6.2f}s  {preview(str(error))}"
+                    )
+                    break
+
+                record = test_image(
+                    fm_path=fm_path,
+                    model=arguments.model,
+                    image_path=image_path,
+                    ratio=ratio.label,
+                    long_edge=long_edge,
+                    prompt=arguments.prompt,
+                    timeout=arguments.timeout,
+                    include_token_count=arguments.include_token_count,
+                    expected_terms=arguments.expect,
+                    properties=properties,
+                    generation_seconds=generated.seconds,
+                )
+                write_record(report_path, record)
+                print_result(record)
+
+                if record["success"]:
+                    successful_tests += 1
+                    largest_successes[ratio.label] = record
+                else:
+                    failures.setdefault(ratio.label, record)
+                    if not arguments.continue_after_failure:
+                        break
+    finally:
+        if temporary_images:
+            temporary_images.cleanup()
+
+    print()
+    print("Summary")
+    for ratio in arguments.ratios:
+        success = largest_successes.get(ratio.label)
+        failure = failures.get(ratio.label)
+        if success and failure:
+            print(
+                f"- {ratio.label}: largest success {success['width']}x{success['height']} "
+                f"({success['megapixels']:.2f} MP); first failure "
+                f"{failure.get('width', '?')}x{failure.get('height', '?')}."
+            )
+        elif success:
+            print(
+                f"- {ratio.label}: no failure through {success['width']}x{success['height']} "
+                f"({success['megapixels']:.2f} MP)."
+            )
+        elif failure:
+            print(f"- {ratio.label}: failed at the first tested size.")
+        else:
+            print(f"- {ratio.label}: no generated size was tested.")
+
+    print(f"- Full results: {report_path}")
+    return 0 if successful_tests else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/ImageInputProbe/tests/test_image_input_probe.py
+++ b/Tools/ImageInputProbe/tests/test_image_input_probe.py
@@ -1,6 +1,8 @@
+import io
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -145,6 +147,103 @@ class MainLoopTests(unittest.TestCase):
                     return_value=successful_record,
                 ) as test_image,
             ):
+                with redirect_stdout(io.StringIO()):
+                    exit_code = image_input_probe.main(
+                        [
+                            str(source),
+                            "--skip-source",
+                            "--ratios",
+                            "1:1",
+                            "--sizes",
+                            "20,10",
+                            "--max-pixels",
+                            "150",
+                            "--fm-path",
+                            "fm",
+                            "--sips-path",
+                            "sips",
+                            "--output-dir",
+                            str(output_directory),
+                        ]
+                    )
+
+        self.assertEqual(exit_code, 0)
+        generate_variant.assert_called_once()
+        self.assertEqual(generate_variant.call_args.kwargs["width"], 10)
+        self.assertEqual(generate_variant.call_args.kwargs["height"], 10)
+        self.assertEqual(test_image.call_args.kwargs["long_edge"], 10)
+
+    def test_first_failure_is_preserved_when_later_generation_fails(self):
+        successful_record = {
+            "ratio": "1:1",
+            "width": 5,
+            "height": 5,
+            "megapixels": 0.0,
+            "bytes": 1,
+            "response_seconds": 0.0,
+            "response": "ok",
+            "success": True,
+        }
+        semantic_failure = {
+            "ratio": "1:1",
+            "width": 10,
+            "height": 10,
+            "megapixels": 0.0,
+            "bytes": 1,
+            "response_seconds": 0.0,
+            "error": "missing expected term",
+            "success": False,
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.jpg"
+            source.touch()
+            output_directory = root / "output"
+            output = io.StringIO()
+
+            with (
+                mock.patch.object(
+                    image_input_probe,
+                    "run_command",
+                    return_value=image_input_probe.CommandResult(0, "", "", 0),
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "resolve_executable",
+                    side_effect=lambda value: value,
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "macos_version_value",
+                    return_value="test",
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "generate_variant",
+                    side_effect=[
+                        image_input_probe.CommandResult(0, "", "", 0),
+                        image_input_probe.CommandResult(0, "", "", 0),
+                        image_input_probe.CommandResult(1, "", "generation failed", 0),
+                    ],
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "image_properties",
+                    return_value={
+                        "width": 5,
+                        "height": 5,
+                        "format": "jpeg",
+                        "bytes": 1,
+                    },
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "test_image",
+                    side_effect=[successful_record, semantic_failure],
+                ),
+                redirect_stdout(output),
+            ):
                 exit_code = image_input_probe.main(
                     [
                         str(source),
@@ -152,9 +251,8 @@ class MainLoopTests(unittest.TestCase):
                         "--ratios",
                         "1:1",
                         "--sizes",
-                        "20,10",
-                        "--max-pixels",
-                        "150",
+                        "5,10,20",
+                        "--continue-after-failure",
                         "--fm-path",
                         "fm",
                         "--sips-path",
@@ -165,10 +263,8 @@ class MainLoopTests(unittest.TestCase):
                 )
 
         self.assertEqual(exit_code, 0)
-        generate_variant.assert_called_once()
-        self.assertEqual(generate_variant.call_args.kwargs["width"], 10)
-        self.assertEqual(generate_variant.call_args.kwargs["height"], 10)
-        self.assertEqual(test_image.call_args.kwargs["long_edge"], 10)
+        self.assertIn("first failure 10x10.", output.getvalue())
+        self.assertNotIn("first failure 20x20.", output.getvalue())
 
 
 if __name__ == "__main__":

--- a/Tools/ImageInputProbe/tests/test_image_input_probe.py
+++ b/Tools/ImageInputProbe/tests/test_image_input_probe.py
@@ -1,0 +1,91 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+TOOL_DIRECTORY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_DIRECTORY))
+
+import image_input_probe
+
+
+class AspectRatioTests(unittest.TestCase):
+    def test_parse_ratio_normalizes_values(self):
+        ratio = image_input_probe.parse_ratio("32:18")
+
+        self.assertEqual(ratio.label, "16:9")
+        self.assertEqual((ratio.width, ratio.height), (16, 9))
+
+    def test_landscape_dimensions_use_long_edge_as_width(self):
+        ratio = image_input_probe.parse_ratio("16:9")
+
+        self.assertEqual(ratio.dimensions(1920), (1920, 1080))
+
+    def test_portrait_dimensions_use_long_edge_as_height(self):
+        ratio = image_input_probe.parse_ratio("9:16")
+
+        self.assertEqual(ratio.dimensions(1920), (1080, 1920))
+
+
+class LongEdgeTests(unittest.TestCase):
+    def test_growth_includes_maximum_cap(self):
+        sizes = image_input_probe.build_long_edges(512, 12_288, 2)
+
+        self.assertEqual(sizes, [512, 1024, 2048, 4096, 8192, 12_288])
+
+    def test_explicit_sizes_preserve_order_and_values(self):
+        sizes = image_input_probe.build_long_edges(
+            512,
+            8192,
+            2,
+            explicit_sizes=[1024, 768, 2048],
+        )
+
+        self.assertEqual(sizes, [1024, 768, 2048])
+
+
+class JPEGQualityTests(unittest.TestCase):
+    def test_valid_quality(self):
+        self.assertEqual(image_input_probe.parse_jpeg_quality("80"), 80)
+
+    def test_invalid_quality(self):
+        with self.assertRaises(Exception):
+            image_input_probe.parse_jpeg_quality("101")
+
+
+class ExpectedTermsTests(unittest.TestCase):
+    def test_matching_is_case_insensitive(self):
+        missing = image_input_probe.missing_expected_terms(
+            "The colors are Blue and Gold.",
+            ["blue", "gold"],
+        )
+
+        self.assertEqual(missing, [])
+
+    def test_missing_terms_are_returned(self):
+        missing = image_input_probe.missing_expected_terms(
+            "The colors are dark green and black.",
+            ["blue", "gold"],
+        )
+
+        self.assertEqual(missing, ["blue", "gold"])
+
+
+class EstimatedBufferTests(unittest.TestCase):
+    def test_square_boundary_matches_observed_behavior(self):
+        _, last_success_bytes = image_input_probe.estimated_bgra_buffer(23_168, 23_168)
+        _, first_failure_bytes = image_input_probe.estimated_bgra_buffer(23_169, 23_169)
+
+        self.assertLess(last_success_bytes, image_input_probe.TWO_GIB_BYTES)
+        self.assertGreaterEqual(first_failure_bytes, image_input_probe.TWO_GIB_BYTES)
+
+    def test_landscape_boundary_matches_observed_behavior(self):
+        _, last_success_bytes = image_input_probe.estimated_bgra_buffer(30_892, 17_377)
+        _, first_failure_bytes = image_input_probe.estimated_bgra_buffer(30_893, 17_377)
+
+        self.assertLess(last_success_bytes, image_input_probe.TWO_GIB_BYTES)
+        self.assertGreaterEqual(first_failure_bytes, image_input_probe.TWO_GIB_BYTES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ImageInputProbe/tests/test_image_input_probe.py
+++ b/Tools/ImageInputProbe/tests/test_image_input_probe.py
@@ -1,6 +1,8 @@
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 TOOL_DIRECTORY = Path(__file__).resolve().parents[1]
@@ -85,6 +87,88 @@ class EstimatedBufferTests(unittest.TestCase):
 
         self.assertLess(last_success_bytes, image_input_probe.TWO_GIB_BYTES)
         self.assertGreaterEqual(first_failure_bytes, image_input_probe.TWO_GIB_BYTES)
+
+
+class MainLoopTests(unittest.TestCase):
+    def test_pixel_cap_skip_does_not_abort_non_monotonic_explicit_sizes(self):
+        successful_record = {
+            "ratio": "1:1",
+            "width": 10,
+            "height": 10,
+            "megapixels": 0.0,
+            "bytes": 1,
+            "response_seconds": 0.0,
+            "response": "ok",
+            "success": True,
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.jpg"
+            source.touch()
+            output_directory = root / "output"
+
+            with (
+                mock.patch.object(
+                    image_input_probe,
+                    "run_command",
+                    return_value=image_input_probe.CommandResult(0, "", "", 0),
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "resolve_executable",
+                    side_effect=lambda value: value,
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "macos_version_value",
+                    return_value="test",
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "generate_variant",
+                    return_value=image_input_probe.CommandResult(0, "", "", 0),
+                ) as generate_variant,
+                mock.patch.object(
+                    image_input_probe,
+                    "image_properties",
+                    return_value={
+                        "width": 10,
+                        "height": 10,
+                        "format": "jpeg",
+                        "bytes": 1,
+                    },
+                ),
+                mock.patch.object(
+                    image_input_probe,
+                    "test_image",
+                    return_value=successful_record,
+                ) as test_image,
+            ):
+                exit_code = image_input_probe.main(
+                    [
+                        str(source),
+                        "--skip-source",
+                        "--ratios",
+                        "1:1",
+                        "--sizes",
+                        "20,10",
+                        "--max-pixels",
+                        "150",
+                        "--fm-path",
+                        "fm",
+                        "--sips-path",
+                        "sips",
+                        "--output-dir",
+                        str(output_directory),
+                    ]
+                )
+
+        self.assertEqual(exit_code, 0)
+        generate_variant.assert_called_once()
+        self.assertEqual(generate_variant.call_args.kwargs["width"], 10)
+        self.assertEqual(generate_variant.call_args.kwargs["height"], 10)
+        self.assertEqual(test_image.call_args.kwargs["long_edge"], 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a standalone `Tools/ImageInputProbe` CLI that resamples an input image across square, landscape, and portrait ratios, invokes Apple's `fm` CLI, and records transport and semantic results as JSONL
- surface the June 14, 2026 macOS 27 beta findings in Lab > Image Input, including the four measured boundaries and the inferred decoded-buffer relationship
- document the lack of an official Apple maximum, reproduction commands, caveats, and source links
- update the Image Input code example to include the attachment in the multimodal prompt

## Why

Apple does not publish a contractual maximum image resolution. Testing also showed that inputs beyond the observed boundary can still return successful requests while visual understanding becomes incorrect. This adds a repeatable way to detect that semantic boundary on future OS and model builds, while keeping the current measurements clearly labeled as empirical rather than official limits.

## Current observation

| Ratio | Largest correct | First incorrect |
| --- | ---: | ---: |
| 1:1 | `23168x23168` | `23169x23169` |
| 16:9 | `30892x17377` | `30893x17377` |
| 9:16 | `17376x30891` | `17377x30892` |
| 4:3 | `26753x20065` | `26754x20066` |

These flips correlate with a 4-byte BGRA buffer using a 16-byte-aligned row stride crossing 2 GiB. That relationship is an implementation inference, not an Apple-documented limit.

## Validation

- `python3 -m unittest discover -s Tools/ImageInputProbe/tests -v` (11 tests)
- `python3 -m py_compile Tools/ImageInputProbe/image_input_probe.py`
- `Tools/ImageInputProbe/image_input_probe.py --help`
- built, installed, and launched `Foundation Lab` on an iPhone 17 Pro simulator running iOS 27.0
- `git diff --check`