### PR TITLE
feat(ai): add Gemini video session wrapper

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -21,6 +21,7 @@ enum ExampleType: String, CaseIterable, Identifiable {
     case contextWindowInspector = "context_window_inspector"
     case privateCloudCompute = "private_cloud_compute"
     case imageInputPlayground = "image_input_playground"
+    case geminiVideoInput = "gemini_video_input"
     case toolCallingModeLab = "tool_calling_mode_lab"
     case dynamicProfileBuilder = "dynamic_profile_builder"
     case reasoningLevelComparison = "reasoning_level_comparison"
@@ -69,6 +70,8 @@ enum ExampleType: String, CaseIterable, Identifiable {
             return "Private Cloud"
         case .imageInputPlayground:
             return "Image Input"
+        case .geminiVideoInput:
+            return "Gemini Video"
         case .toolCallingModeLab:
             return "Tool Modes"
         case .dynamicProfileBuilder:
@@ -136,6 +139,8 @@ enum ExampleType: String, CaseIterable, Identifiable {
             return "Probe PCC availability, quota, and context size"
         case .imageInputPlayground:
             return "Explore image attachments and resolution boundaries"
+        case .geminiVideoInput:
+            return "Analyze video with a custom LanguageModelSession"
         case .toolCallingModeLab:
             return "Compare allowed, required, and disallowed tools"
         case .dynamicProfileBuilder:
@@ -203,6 +208,8 @@ enum ExampleType: String, CaseIterable, Identifiable {
             return "icloud.and.arrow.up"
         case .imageInputPlayground:
             return "photo.on.rectangle.angled"
+        case .geminiVideoInput:
+            return "video.badge.waveform"
         case .toolCallingModeLab:
             return "hammer"
         case .dynamicProfileBuilder:

--- a/Foundation Lab/Models/VideoSegment.swift
+++ b/Foundation Lab/Models/VideoSegment.swift
@@ -1,0 +1,31 @@
+//
+//  VideoSegment.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/15/26.
+//
+
+import Foundation
+import FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct VideoSegment: Transcript.CustomSegment {
+    struct Content: Codable, Equatable, Sendable {
+        let data: Data
+        let mimeType: String
+    }
+
+    let id: String
+    let content: Content
+
+    init(
+        id: String = UUID().uuidString,
+        data: Data,
+        mimeType: String
+    ) {
+        self.id = id
+        content = Content(data: data, mimeType: mimeType)
+    }
+}

--- a/Foundation Lab/Resources/AlvordDesertSunset-LICENSE.md
+++ b/Foundation Lab/Resources/AlvordDesertSunset-LICENSE.md
@@ -1,0 +1,8 @@
+# Alvord Desert Sunset Video
+
+- Source: https://commons.wikimedia.org/wiki/File:Alvord_Desert_(36291851745).webm
+- Creator: Bureau of Land Management Oregon & Washington
+- Description: Storm clouds moving over the Alvord Desert at sunset
+- License: Public domain
+
+The bundled MP4 is a transcoded version of the source video.

--- a/Foundation Lab/Services/GeminiDeveloperVideoLanguageModel.swift
+++ b/Foundation Lab/Services/GeminiDeveloperVideoLanguageModel.swift
@@ -1,0 +1,432 @@
+//
+//  GeminiDeveloperVideoLanguageModel.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/15/26.
+//
+
+import Foundation
+import FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct GeminiDeveloperVideoLanguageModel: LanguageModel {
+    typealias Executor = GeminiDeveloperVideoLanguageModelExecutor
+
+    let capabilities = LanguageModelCapabilities(capabilities: [])
+    let executorConfiguration: Executor.Configuration
+
+    init(apiKey: String, modelName: String) {
+        executorConfiguration = Executor.Configuration(
+            apiKey: apiKey,
+            modelName: modelName
+        )
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct GeminiDeveloperVideoLanguageModelExecutor: LanguageModelExecutor {
+    typealias Model = GeminiDeveloperVideoLanguageModel
+
+    struct Configuration: Hashable, Sendable {
+        let apiKey: String
+        let modelName: String
+    }
+
+    private let configuration: Configuration
+    private let client: GeminiDeveloperAPIClient
+
+    init(configuration: Configuration) throws {
+        self.configuration = configuration
+        client = GeminiDeveloperAPIClient(
+            apiKey: configuration.apiKey,
+            modelName: configuration.modelName
+        )
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension GeminiDeveloperVideoLanguageModelExecutor {
+    func respond(
+        to request: LanguageModelExecutorGenerationRequest,
+        model: GeminiDeveloperVideoLanguageModel,
+        streamingInto channel: LanguageModelExecutorGenerationChannel
+    ) async throws {
+        try validate(request)
+        let convertedTranscript = try convert(request.transcript)
+        let response = try await client.generateContent(
+            contents: convertedTranscript.contents,
+            systemInstruction: convertedTranscript.systemInstruction
+        )
+
+        guard !response.text.isEmpty else {
+            throw GeminiDeveloperAPIError.noTextResponse
+        }
+
+        await send(response, for: request.id, into: channel)
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension GeminiDeveloperVideoLanguageModelExecutor {
+    func validate(_ request: LanguageModelExecutorGenerationRequest) throws {
+        guard request.schema == nil else {
+            throw LanguageModelError.unsupportedGenerationGuide(
+                .init(
+                    schemaName: nil,
+                    debugDescription: "The Gemini video experiment currently supports text responses only."
+                )
+            )
+        }
+
+        guard request.enabledToolDefinitions.isEmpty else {
+            throw LanguageModelError.unsupportedCapability(
+                .init(
+                    capability: .toolCalling,
+                    debugDescription: "Tool calling is outside this focused video-input experiment."
+                )
+            )
+        }
+    }
+
+    func convert(_ transcript: Transcript) throws -> ConvertedTranscript {
+        var systemParts = [GeminiDeveloperAPIClient.Part]()
+        var contents = [GeminiDeveloperAPIClient.Content]()
+
+        for entry in transcript {
+            switch entry {
+            case let .instructions(instructions):
+                systemParts.append(contentsOf: try geminiParts(
+                    from: instructions.segments,
+                    entry: entry,
+                    allowsCustomMedia: false
+                ))
+
+            case let .prompt(prompt):
+                let parts = try geminiParts(
+                    from: prompt.segments,
+                    entry: entry,
+                    allowsCustomMedia: true
+                )
+                appendContent(role: "user", parts: parts, to: &contents)
+
+            case let .response(response):
+                let parts = try geminiParts(
+                    from: response.segments,
+                    entry: entry,
+                    allowsCustomMedia: true
+                )
+                appendContent(role: "model", parts: parts, to: &contents)
+
+            case .reasoning:
+                continue
+
+            case .toolCalls, .toolOutput:
+                throw LanguageModelError.unsupportedCapability(
+                    .init(
+                        capability: .toolCalling,
+                        debugDescription: "Tool transcript entries are not supported by this video wrapper."
+                    )
+                )
+
+            @unknown default:
+                throw unsupportedTranscriptError(
+                    entry,
+                    detail: "The transcript contains an unknown entry type."
+                )
+            }
+        }
+
+        guard !contents.isEmpty else {
+            throw GeminiDeveloperAPIError.emptyPrompt
+        }
+
+        return ConvertedTranscript(
+            contents: contents,
+            systemInstruction: systemParts.isEmpty
+                ? nil
+                : GeminiDeveloperAPIClient.Content(role: nil, parts: systemParts)
+        )
+    }
+
+    func appendContent(
+        role: String,
+        parts: [GeminiDeveloperAPIClient.Part],
+        to contents: inout [GeminiDeveloperAPIClient.Content]
+    ) {
+        guard !parts.isEmpty else {
+            return
+        }
+        contents.append(.init(role: role, parts: parts))
+    }
+
+    func send(
+        _ response: GeminiDeveloperAPIClient.Response,
+        for requestID: UUID,
+        into channel: LanguageModelExecutorGenerationChannel
+    ) async {
+        let text = response.text
+        let responseEntryID = requestID.uuidString
+        await channel.send(
+            .response(
+                entryID: responseEntryID,
+                action: .appendText(text, tokenCount: response.usageMetadata?.candidatesTokenCount ?? 0)
+            )
+        )
+        await channel.send(
+            .response(
+                entryID: responseEntryID,
+                action: .updateMetadata([
+                    "provider": "Gemini Developer API",
+                    "model": response.modelVersion ?? configuration.modelName
+                ])
+            )
+        )
+
+        if let usage = response.usageMetadata {
+            await channel.send(
+                .response(
+                    entryID: responseEntryID,
+                    action: .updateUsage(
+                        input: .init(
+                            totalTokenCount: usage.promptTokenCount,
+                            cachedTokenCount: usage.cachedContentTokenCount ?? 0
+                        ),
+                        output: .init(
+                            totalTokenCount: usage.candidatesTokenCount,
+                            reasoningTokenCount: usage.thoughtsTokenCount ?? 0
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    struct ConvertedTranscript {
+        let contents: [GeminiDeveloperAPIClient.Content]
+        let systemInstruction: GeminiDeveloperAPIClient.Content?
+    }
+
+    func geminiParts(
+        from segments: [Transcript.Segment],
+        entry: Transcript.Entry,
+        allowsCustomMedia: Bool
+    ) throws -> [GeminiDeveloperAPIClient.Part] {
+        var parts = [GeminiDeveloperAPIClient.Part]()
+
+        for segment in segments {
+            switch segment {
+            case let .text(text):
+                parts.append(.text(text.content))
+
+            case let .structure(structure):
+                parts.append(.text(structure.content.jsonString))
+
+            case let .custom(customSegment):
+                guard allowsCustomMedia else {
+                    throw unsupportedTranscriptError(
+                        entry,
+                        detail: "Gemini system instructions support text only."
+                    )
+                }
+
+                if let video = customSegment as? VideoSegment {
+                    parts.append(.inlineData(
+                        data: video.content.data,
+                        mimeType: video.content.mimeType
+                    ))
+                } else {
+                    throw unsupportedTranscriptError(
+                        entry,
+                        detail: "Only VideoSegment custom segments are supported."
+                    )
+                }
+
+            case .attachment:
+                throw unsupportedTranscriptError(
+                    entry,
+                    detail: "Use VideoSegment for video input in this experiment."
+                )
+
+            @unknown default:
+                throw unsupportedTranscriptError(
+                    entry,
+                    detail: "The transcript contains an unknown segment type."
+                )
+            }
+        }
+
+        return parts
+    }
+
+    func unsupportedTranscriptError(
+        _ entry: Transcript.Entry,
+        detail: String
+    ) -> LanguageModelError {
+        .unsupportedTranscriptContent(
+            .init(
+                unsupportedContent: [entry],
+                debugDescription: detail
+            )
+        )
+    }
+}
+
+struct GeminiDeveloperAPIClient: Sendable {
+    struct Content: Codable, Sendable {
+        let role: String?
+        let parts: [Part]
+    }
+
+    struct Part: Codable, Sendable {
+        let text: String?
+        let inlineData: InlineData?
+
+        static func text(_ text: String) -> Part {
+            Part(text: text, inlineData: nil)
+        }
+
+        static func inlineData(data: Data, mimeType: String) -> Part {
+            Part(
+                text: nil,
+                inlineData: .init(
+                    mimeType: mimeType,
+                    data: data.base64EncodedString()
+                )
+            )
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case text
+            case inlineData = "inline_data"
+        }
+    }
+
+    struct InlineData: Codable, Sendable {
+        let mimeType: String
+        let data: String
+
+        enum CodingKeys: String, CodingKey {
+            case mimeType = "mime_type"
+            case data
+        }
+    }
+
+    struct Response: Decodable, Sendable {
+        struct Candidate: Decodable, Sendable {
+            let content: Content
+        }
+
+        struct UsageMetadata: Decodable, Sendable {
+            let promptTokenCount: Int
+            let cachedContentTokenCount: Int?
+            let candidatesTokenCount: Int
+            let thoughtsTokenCount: Int?
+            let totalTokenCount: Int
+        }
+
+        let candidates: [Candidate]
+        let usageMetadata: UsageMetadata?
+        let modelVersion: String?
+
+        var text: String {
+            candidates.first?.content.parts.compactMap(\.text).joined() ?? ""
+        }
+    }
+
+    private struct RequestBody: Encodable {
+        let contents: [Content]
+        let systemInstruction: Content?
+    }
+
+    private struct ErrorResponse: Decodable {
+        struct Details: Decodable {
+            let message: String
+        }
+
+        let error: Details
+    }
+
+    let apiKey: String
+    let modelName: String
+    var urlSession = URLSession.shared
+
+    func generateContent(
+        contents: [Content],
+        systemInstruction: Content?
+    ) async throws -> Response {
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw GeminiDeveloperAPIError.apiKeyMissing
+        }
+
+        guard let encodedModelName = modelName.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ),
+            let url = URL(
+                string: "https://generativelanguage.googleapis.com/v1beta/models/\(encodedModelName):generateContent"
+            ) else {
+            throw GeminiDeveloperAPIError.invalidModelName(modelName)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.httpBody = try JSONEncoder().encode(
+            RequestBody(
+                contents: contents,
+                systemInstruction: systemInstruction
+            )
+        )
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GeminiDeveloperAPIError.invalidResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let message = (try? JSONDecoder().decode(ErrorResponse.self, from: data))
+                .map(\.error.message)
+                ?? HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode)
+            throw GeminiDeveloperAPIError.requestFailed(
+                statusCode: httpResponse.statusCode,
+                message: message
+            )
+        }
+
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}
+
+enum GeminiDeveloperAPIError: LocalizedError, Sendable {
+    case apiKeyMissing
+    case emptyPrompt
+    case invalidModelName(String)
+    case invalidResponse
+    case noTextResponse
+    case requestFailed(statusCode: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .apiKeyMissing:
+            return "Enter a Gemini API key or launch with GEMINI_API_KEY."
+        case .emptyPrompt:
+            return "The transcript did not contain a prompt Gemini can send."
+        case let .invalidModelName(modelName):
+            return "The Gemini model name is invalid: \(modelName)."
+        case .invalidResponse:
+            return "Gemini returned an invalid HTTP response."
+        case .noTextResponse:
+            return "Gemini completed without returning text."
+        case let .requestFailed(statusCode, message):
+            return "Gemini request failed with HTTP \(statusCode): \(message)"
+        }
+    }
+}

--- a/Foundation Lab/Services/GeminiDeveloperVideoLanguageModel.swift
+++ b/Foundation Lab/Services/GeminiDeveloperVideoLanguageModel.swift
@@ -362,7 +362,8 @@ struct GeminiDeveloperAPIClient: Sendable {
         contents: [Content],
         systemInstruction: Content?
     ) async throws -> Response {
-        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let requestAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !requestAPIKey.isEmpty else {
             throw GeminiDeveloperAPIError.apiKeyMissing
         }
 
@@ -378,7 +379,7 @@ struct GeminiDeveloperAPIClient: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.setValue(requestAPIKey, forHTTPHeaderField: "x-goog-api-key")
         request.httpBody = try JSONEncoder().encode(
             RequestBody(
                 contents: contents,

--- a/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
+++ b/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
@@ -48,8 +48,18 @@ final class GeminiVideoInputViewModel {
     }
 
     var videoSize: String {
-        guard let videoURL,
-              let values = try? videoURL.resourceValues(forKeys: [.fileSizeKey]),
+        guard let videoURL else {
+            return "Unknown size"
+        }
+
+        let accessed = videoURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                videoURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        guard let values = try? videoURL.resourceValues(forKeys: [.fileSizeKey]),
               let bytes = values.fileSize else {
             return "Unknown size"
         }
@@ -159,8 +169,13 @@ private extension GeminiVideoInputViewModel {
             }
         }
 
+        let file = try FileHandle(forReadingFrom: url)
+        defer {
+            try? file.close()
+        }
+
         return LoadedVideo(
-            data: try Data(contentsOf: url, options: .mappedIfSafe),
+            data: try file.readToEnd() ?? Data(),
             mimeType: mimeType(for: url)
         )
     }

--- a/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
+++ b/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import Observation
+import UniformTypeIdentifiers
 
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @available(tvOS, unavailable)
@@ -176,23 +177,37 @@ private extension GeminiVideoInputViewModel {
 
         return LoadedVideo(
             data: try file.readToEnd() ?? Data(),
-            mimeType: mimeType(for: url)
+            mimeType: try mimeType(for: url)
         )
     }
 
-    nonisolated static func mimeType(for url: URL) -> String {
-        switch url.pathExtension.lowercased() {
-        case "mov":
-            return "video/quicktime"
-        case "m4v":
-            return "video/x-m4v"
-        default:
-            return "video/mp4"
+    nonisolated static func mimeType(for url: URL) throws -> String {
+        let resourceType = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
+        let fileType = resourceType ?? UTType(filenameExtension: url.pathExtension)
+
+        guard let fileType,
+              fileType.conforms(to: .movie),
+              let mimeType = fileType.preferredMIMEType else {
+            throw GeminiVideoInputError.unsupportedVideoFormat(url.pathExtension)
         }
+
+        return mimeType
     }
 }
 
 private struct LoadedVideo: Sendable {
     let data: Data
     let mimeType: String
+}
+
+private enum GeminiVideoInputError: LocalizedError {
+    case unsupportedVideoFormat(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unsupportedVideoFormat(pathExtension):
+            let format = pathExtension.isEmpty ? "unknown" : pathExtension.uppercased()
+            return "The selected \(format) file does not have a recognized video MIME type."
+        }
+    }
 }

--- a/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
+++ b/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
@@ -1,0 +1,183 @@
+//
+//  GeminiVideoInputViewModel.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/15/26.
+//
+
+import Foundation
+import FoundationModels
+import Observation
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+@Observable
+final class GeminiVideoInputViewModel {
+    static let modelName = "gemini-3.5-flash"
+    static let defaultPrompt = """
+    Return exactly three concise bullets: (1) describe the cracked terrain and distant horizon, (2) describe how \
+    the storm clouds and rain shafts move and how the light changes, and (3) summarize the color palette and mood \
+    shift. Report only clearly visible details. Do not identify the location or name any optical phenomenon.
+    """
+
+    var apiKey: String
+    var prompt = defaultPrompt
+    var videoURL: URL?
+    var result = ""
+    var resultIsSuccess = false
+    var errorMessage: String?
+    var isRunning = false
+
+    init(
+        bundle: Bundle = .main,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        let environmentAPIKey = environment["GEMINI_API_KEY"] ?? ""
+        apiKey = environmentAPIKey
+        videoURL = bundle.url(
+            forResource: "AlvordDesertSunset",
+            withExtension: "mp4",
+            subdirectory: "Resources"
+        ) ?? bundle.url(forResource: "AlvordDesertSunset", withExtension: "mp4")
+    }
+
+    var videoName: String {
+        videoURL?.lastPathComponent ?? "No video selected"
+    }
+
+    var videoSize: String {
+        guard let videoURL,
+              let values = try? videoURL.resourceValues(forKeys: [.fileSizeKey]),
+              let bytes = values.fileSize else {
+            return "Unknown size"
+        }
+
+        return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension GeminiVideoInputViewModel {
+    var codeExample: String {
+        """
+        let video = VideoSegment(data: data, mimeType: "video/mp4")
+        let model = GeminiDeveloperVideoLanguageModel(
+            apiKey: apiKey,
+            modelName: "\(Self.modelName)"
+        )
+        let session = LanguageModelSession(model: model)
+        let response = try await session.respond {
+            video
+            prompt
+        }
+        """
+    }
+
+    func selectVideo(_ url: URL) {
+        videoURL = url
+        result = ""
+        errorMessage = nil
+    }
+
+    func analyzeVideo() async {
+        guard let videoURL else {
+            errorMessage = "Choose a video before running the analysis."
+            return
+        }
+
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty else {
+            errorMessage = "Enter a prompt before running the experiment."
+            return
+        }
+
+        if apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errorMessage = GeminiDeveloperAPIError.apiKeyMissing.localizedDescription
+            return
+        }
+
+        isRunning = true
+        errorMessage = nil
+        result = ""
+        resultIsSuccess = false
+
+        defer {
+            isRunning = false
+        }
+
+        do {
+            let loadedVideo = try await Task.detached(priority: .userInitiated) {
+                try Self.loadVideo(from: videoURL)
+            }.value
+            let video = VideoSegment(
+                data: loadedVideo.data,
+                mimeType: loadedVideo.mimeType
+            )
+
+            try await runCustomWrapper(video: video, prompt: trimmedPrompt)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func reset() {
+        prompt = Self.defaultPrompt
+        result = ""
+        errorMessage = nil
+        resultIsSuccess = false
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension GeminiVideoInputViewModel {
+    func runCustomWrapper(video: VideoSegment, prompt: String) async throws {
+        let model = GeminiDeveloperVideoLanguageModel(
+            apiKey: apiKey,
+            modelName: Self.modelName
+        )
+        let session = LanguageModelSession(model: model)
+        let response = try await session.respond {
+            video
+            prompt
+        }
+
+        result = response.content
+        resultIsSuccess = !response.content.isEmpty
+    }
+
+    nonisolated static func loadVideo(from url: URL) throws -> LoadedVideo {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        return LoadedVideo(
+            data: try Data(contentsOf: url, options: .mappedIfSafe),
+            mimeType: mimeType(for: url)
+        )
+    }
+
+    nonisolated static func mimeType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "mov":
+            return "video/quicktime"
+        case "m4v":
+            return "video/x-m4v"
+        default:
+            return "video/mp4"
+        }
+    }
+}
+
+private struct LoadedVideo: Sendable {
+    let data: Data
+    let mimeType: String
+}

--- a/Foundation Lab/Views/Examples/ExampleType+Destination.swift
+++ b/Foundation Lab/Views/Examples/ExampleType+Destination.swift
@@ -36,6 +36,16 @@ extension ExampleType {
             PrivateCloudComputeView()
         case .imageInputPlayground:
             ImageInputPlaygroundView()
+        case .geminiVideoInput:
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+                GeminiVideoInputView()
+            } else {
+                ContentUnavailableView(
+                    "Xcode 27 Required",
+                    systemImage: "video.slash",
+                    description: Text("Custom LanguageModel executors require iOS, macOS, or visionOS 27.")
+                )
+            }
         case .toolCallingModeLab:
             ToolCallingModeLabView()
         case .dynamicProfileBuilder:
@@ -91,7 +101,7 @@ extension ExampleType {
         switch self {
         case .structuredData, .generationGuides, .generationOptions, .modelRuntime,
              .contextWindowInspector, .privateCloudCompute, .imageInputPlayground,
-             .toolCallingModeLab, .dynamicProfileBuilder, .reasoningLevelComparison,
+             .geminiVideoInput, .toolCallingModeLab, .dynamicProfileBuilder, .reasoningLevelComparison,
              .transcriptExplorer, .agentFlowInspector, .historyTransformLab,
              .riskyToolConfirmation, .modelRouterDashboard, .contextBudgetVisualizer,
              .toolCallTrajectoryViewer, .foundationModelsSecurityPlayground,
@@ -120,6 +130,7 @@ extension ExampleType {
             .contextWindowInspector,
             .privateCloudCompute,
             .imageInputPlayground,
+            .geminiVideoInput,
             .toolCallingModeLab,
             .dynamicProfileBuilder,
             .reasoningLevelComparison,

--- a/Foundation Lab/Views/Examples/Xcode27/GeminiVideoInputView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/GeminiVideoInputView.swift
@@ -1,0 +1,222 @@
+//
+//  GeminiVideoInputView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/15/26.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct GeminiVideoInputView: View {
+    @State private var viewModel = GeminiVideoInputViewModel()
+    @State private var isChoosingVideo = false
+    @State private var isShowingAPIKey = false
+
+    var body: some View {
+        @Bindable var viewModel = viewModel
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .top, spacing: Spacing.large) {
+                        videoSection
+                            .frame(minWidth: 560)
+
+                        promptSection
+                            .frame(width: 380)
+                    }
+
+                    VStack(alignment: .leading, spacing: Spacing.large) {
+                        videoSection
+                        promptSection
+                    }
+                }
+
+                if !viewModel.result.isEmpty {
+                    ResultDisplay(
+                        result: viewModel.result,
+                        isSuccess: viewModel.resultIsSuccess
+                    )
+                }
+
+                CodeDisclosure(code: viewModel.codeExample)
+            }
+            .frame(maxWidth: 1_280)
+            .padding(.horizontal, Spacing.large)
+            .padding(.vertical, Spacing.large)
+            .frame(maxWidth: .infinity)
+        }
+        .navigationTitle("Gemini Video")
+        .fileImporter(
+            isPresented: $isChoosingVideo,
+            allowedContentTypes: [.movie],
+            allowsMultipleSelection: false
+        ) { result in
+            handleVideoImport(result)
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isShowingAPIKey = true
+                } label: {
+                    Label(
+                        "API Key",
+                        systemImage: viewModel.apiKey.isEmpty ? "key" : "key.fill"
+                    )
+                }
+                .help(viewModel.apiKey.isEmpty ? "Add Gemini API key" : "Edit Gemini API key")
+            }
+        }
+        .sheet(isPresented: $isShowingAPIKey) {
+            GeminiAPIKeySheet(viewModel: viewModel)
+        }
+    }
+
+    private var videoSection: some View {
+        Xcode27Section("Video Input", systemImage: "video") {
+            if let videoURL = viewModel.videoURL {
+                GeminiVideoPreview(url: videoURL)
+                    .aspectRatio(16 / 9, contentMode: .fit)
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(viewModel.videoName)
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+
+                        Text(viewModel.videoSize)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Button("Choose Video") {
+                        isChoosingVideo = true
+                    }
+                    .buttonStyle(.bordered)
+                }
+            } else {
+                ContentUnavailableView(
+                    "Sample Video Missing",
+                    systemImage: "video.slash",
+                    description: Text("Choose an MP4, MOV, or M4V file to continue.")
+                )
+
+                Button("Choose Video") {
+                    isChoosingVideo = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private var promptSection: some View {
+        Xcode27Section("Ask Gemini", systemImage: "sparkles") {
+            TextField("Describe what Gemini should inspect", text: $viewModel.prompt, axis: .vertical)
+                .lineLimit(8...12)
+                .textFieldStyle(.plain)
+                .padding(Spacing.medium)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: CornerRadius.medium))
+
+            if let errorMessage = viewModel.errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Button(
+                viewModel.isRunning ? "Analyzing Video..." : "Analyze Video",
+                systemImage: viewModel.isRunning ? "hourglass" : "play.fill"
+            ) {
+                Task {
+                    await viewModel.analyzeVideo()
+                }
+            }
+            .buttonStyle(.glassProminent)
+            .controlSize(.large)
+            .frame(maxWidth: .infinity)
+            .disabled(
+                viewModel.isRunning
+                    || viewModel.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            )
+        }
+    }
+
+    private func handleVideoImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case let .success(urls):
+            if let url = urls.first {
+                viewModel.selectVideo(url)
+            }
+        case let .failure(error):
+            viewModel.errorMessage = error.localizedDescription
+        }
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private struct GeminiAPIKeySheet: View {
+    let viewModel: GeminiVideoInputViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var apiKey: String
+
+    init(viewModel: GeminiVideoInputViewModel) {
+        self.viewModel = viewModel
+        _apiKey = State(initialValue: viewModel.apiKey)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    SecureField("AI Studio API key", text: $apiKey)
+                        .textFieldStyle(.roundedBorder)
+                        .privacySensitive()
+                } footer: {
+                    Text("Kept in memory for this session.")
+                }
+            }
+            .navigationTitle("Gemini API Key")
+#if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+#endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        viewModel.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                        dismiss()
+                    }
+                }
+            }
+        }
+#if os(macOS)
+        .frame(minWidth: 420, minHeight: 180)
+#else
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+#endif
+    }
+}
+
+#Preview {
+    if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+        NavigationStack {
+            GeminiVideoInputView()
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/GeminiVideoPreview.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/GeminiVideoPreview.swift
@@ -14,13 +14,9 @@ import SwiftUI
 struct GeminiVideoPreview: View {
     let url: URL
 
-    @State private var player: AVPlayer
+    @State private var player = AVPlayer()
     @State private var isPlaying = false
-
-    init(url: URL) {
-        self.url = url
-        _player = State(initialValue: AVPlayer(url: url))
-    }
+    @State private var securityScopedURL: URL?
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -43,10 +39,11 @@ struct GeminiVideoPreview: View {
         }
         .accessibilityLabel("Selected Gemini video input")
         .onAppear {
+            load(url)
             play()
         }
         .onChange(of: url) { _, newURL in
-            player.replaceCurrentItem(with: AVPlayerItem(url: newURL))
+            load(newURL)
             play()
         }
         .onReceive(NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)) { notification in
@@ -59,7 +56,21 @@ struct GeminiVideoPreview: View {
         .onDisappear {
             player.pause()
             isPlaying = false
+            stopAccessingSecurityScopedURL()
         }
+    }
+
+    private func load(_ url: URL) {
+        stopAccessingSecurityScopedURL()
+        if url.startAccessingSecurityScopedResource() {
+            securityScopedURL = url
+        }
+        player.replaceCurrentItem(with: AVPlayerItem(url: url))
+    }
+
+    private func stopAccessingSecurityScopedURL() {
+        securityScopedURL?.stopAccessingSecurityScopedResource()
+        securityScopedURL = nil
     }
 
     private func togglePlayback() {

--- a/Foundation Lab/Views/Examples/Xcode27/GeminiVideoPreview.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/GeminiVideoPreview.swift
@@ -1,0 +1,162 @@
+//
+//  GeminiVideoPreview.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/15/26.
+//
+
+import AVFoundation
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct GeminiVideoPreview: View {
+    let url: URL
+
+    @State private var player: AVPlayer
+    @State private var isPlaying = false
+
+    init(url: URL) {
+        self.url = url
+        _player = State(initialValue: AVPlayer(url: url))
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            GeminiPlatformVideoPlayer(player: player)
+
+            Button(
+                isPlaying ? "Pause video" : "Play video",
+                systemImage: isPlaying ? "pause.fill" : "play.fill"
+            ) {
+                togglePlayback()
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.glassProminent)
+            .padding(Spacing.small)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.medium))
+        .overlay {
+            RoundedRectangle(cornerRadius: CornerRadius.medium)
+                .strokeBorder(.quaternary)
+        }
+        .accessibilityLabel("Selected Gemini video input")
+        .onAppear {
+            play()
+        }
+        .onChange(of: url) { _, newURL in
+            player.replaceCurrentItem(with: AVPlayerItem(url: newURL))
+            play()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)) { notification in
+            guard notification.object as? AVPlayerItem === player.currentItem else {
+                return
+            }
+            player.seek(to: .zero)
+            play()
+        }
+        .onDisappear {
+            player.pause()
+            isPlaying = false
+        }
+    }
+
+    private func togglePlayback() {
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            play()
+        }
+    }
+
+    private func play() {
+        player.play()
+        isPlaying = true
+    }
+}
+
+#if os(macOS)
+@available(macOS 27.0, *)
+private struct GeminiPlatformVideoPlayer: NSViewRepresentable {
+    let player: AVPlayer
+
+    func makeNSView(context: Context) -> GeminiPlayerView {
+        GeminiPlayerView(player: player)
+    }
+
+    func updateNSView(_ view: GeminiPlayerView, context: Context) {
+        view.player = player
+    }
+}
+
+@available(macOS 27.0, *)
+private final class GeminiPlayerView: NSView {
+    private let playerLayer = AVPlayerLayer()
+
+    var player: AVPlayer? {
+        get { playerLayer.player }
+        set { playerLayer.player = newValue }
+    }
+
+    init(player: AVPlayer) {
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer = playerLayer
+        playerLayer.player = player
+        playerLayer.videoGravity = .resizeAspect
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layout() {
+        super.layout()
+        playerLayer.frame = bounds
+    }
+}
+#else
+@available(iOS 27.0, visionOS 27.0, *)
+private struct GeminiPlatformVideoPlayer: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> GeminiPlayerView {
+        GeminiPlayerView(player: player)
+    }
+
+    func updateUIView(_ view: GeminiPlayerView, context: Context) {
+        view.player = player
+    }
+}
+
+@available(iOS 27.0, visionOS 27.0, *)
+private final class GeminiPlayerView: UIView {
+    override static var layerClass: AnyClass {
+        AVPlayerLayer.self
+    }
+
+    private var playerLayer: AVPlayerLayer {
+        guard let layer = layer as? AVPlayerLayer else {
+            fatalError("GeminiPlayerView requires AVPlayerLayer.")
+        }
+        return layer
+    }
+
+    var player: AVPlayer? {
+        get { playerLayer.player }
+        set { playerLayer.player = newValue }
+    }
+
+    init(player: AVPlayer) {
+        super.init(frame: .zero)
+        self.player = player
+        playerLayer.videoGravity = .resizeAspect
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Add a Gemini video-input lab that keeps Apple's `LanguageModelSession` as the app-facing API while using a custom executor to send `Transcript.CustomSegment` video data directly to the Gemini Developer API.

```mermaid
flowchart TD
    A["Open the Gemini Video example"] --> B["Use the bundled public-domain landscape video or choose another movie"]
    B --> C["Enter a session-only Gemini API key and prompt"]
    C --> D{"Is the input ready?"}
    D -- "no" --> E["Show a focused validation error"]
    D -- "yes" --> F["Wrap the movie as a custom transcript segment"]
    F --> G["Send it through LanguageModelSession"]
    G --> H["Translate the transcript into a direct Gemini request"]
    H --> I["Stream the text and usage metadata back into the session"]
    I --> J["Show the video analysis result"]

    classDef new fill:#16a34a,color:#fff,stroke:#15803d
    class B,C,D,E,F,G,H,I,J new
```

Every successful request still passes through `LanguageModelSession`; the custom executor only adapts transcript content to Gemini's HTTP endpoint.

## What Changed

- Added a native `VideoSegment` conforming to `Transcript.CustomSegment`.
- Added a custom Foundation Models `LanguageModel` and executor for Gemini video requests.
- Added the macOS/iOS video lab UI, preview, prompt, API-key sheet, and result display.
- Bundled a 16:9 public-domain Alvord Desert storm clip with attribution.
- Uses `URLSession` directly, with no Firebase AI Logic package or transitive Firebase dependencies.

## Why

Apple's on-device Foundation Models model does not accept video input, but Xcode 27 custom language-model execution can preserve the `LanguageModelSession` interface while routing a video custom segment to a provider that supports it.

## Testing

- `DEVELOPER_DIR=/Users/rudrank/Downloads/Xcode-beta.app/Contents/Developer xcodebuild -project FoundationLab.xcodeproj -scheme 'Foundation Lab' -destination 'platform=macOS,arch=arm64' -derivedDataPath .build-gemini-video build`
- Focused SwiftLint run on the new files and destination routing: 0 violations.
- Live request with the bundled 1920x1080 MP4 returned a scene-grounded three-bullet analysis from `gemini-3.5-flash`.
- Secret scan confirmed no API key is committed.
