### PR TITLE
[UI] Restore native Lab catalog navigation

### DIFF
--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -1,6 +1,198 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Agent Workflows" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agenten-Workflows"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Workflows"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flujos de agentes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flux d’agents"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flussi degli agenti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェントワークフロー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "에이전트 워크플로"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fluxos de agentes"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智能体工作流"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代理工作流程"
+          }
+        }
+      }
+    },
+    "Developer Tools" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entwicklerwerkzeuge"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developer Tools"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herramientas para desarrolladores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outils de développement"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strumenti per sviluppatori"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発者ツール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개발자 도구"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ferramentas para desenvolvedores"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开发者工具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開發者工具"
+          }
+        }
+      }
+    },
+    "Models & Input" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelle & Eingabe"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Models & Input"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelos y entrada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modèles et entrée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelli e input"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルと入力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델 및 입력"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelos e entrada"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型与输入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型與輸入"
+          }
+        }
+      }
+    },
     "" : {
       "comment" : "An empty string placeholder that may be used for default or fallback values.",
       "localizations" : {

--- a/Foundation Lab/Views/Components/LabExampleSection.swift
+++ b/Foundation Lab/Views/Components/LabExampleSection.swift
@@ -1,0 +1,45 @@
+//
+//  LabExampleSection.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct LabExampleSection: View {
+    private let title: LocalizedStringKey
+    private let examples: [ExampleType]
+
+    init(_ title: LocalizedStringKey, examples: [ExampleType]) {
+        self.title = title
+        self.examples = examples
+    }
+
+    var body: some View {
+        if !examples.isEmpty {
+            Section {
+                ForEach(examples) { example in
+                    NavigationLink(value: example) {
+                        LabNavigationRow(
+                            title: example.title,
+                            subtitle: example.subtitle,
+                            systemImage: example.icon
+                        )
+                    }
+                }
+            } header: {
+                Text(title)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        List {
+            LabExampleSection(
+                "Generation Options",
+                examples: ExampleType.generationExamples
+            )
+        }
+    }
+}

--- a/Foundation Lab/Views/Components/LabNavigationRow.swift
+++ b/Foundation Lab/Views/Components/LabNavigationRow.swift
@@ -1,0 +1,45 @@
+//
+//  LabNavigationRow.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct LabNavigationRow: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text(title)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, Spacing.xSmall)
+        } icon: {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .foregroundStyle(.tint)
+                .frame(width: 28)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    List {
+        LabNavigationRow(
+            title: "Private Cloud",
+            subtitle: "Probe availability, quota, and context size.",
+            systemImage: "icloud.and.arrow.up"
+        )
+    }
+}

--- a/Foundation Lab/Views/Examples/ExampleType+Destination.swift
+++ b/Foundation Lab/Views/Examples/ExampleType+Destination.swift
@@ -122,19 +122,28 @@ extension ExampleType {
     }
 
     static var studioExamples: [ExampleType] {
-        var examples: [ExampleType] = [
-            .structuredData,
-            .generationGuides,
-            .generationOptions,
-            .modelRuntime,
-            .contextWindowInspector,
-            .privateCloudCompute,
-            .imageInputPlayground,
-            .geminiVideoInput,
-            .toolCallingModeLab,
-            .dynamicProfileBuilder,
-            .reasoningLevelComparison,
-            .transcriptExplorer,
+        var examples = generationExamples + modelAndInputExamples + sessionExamples + agentExamples
+#if os(macOS)
+        examples.append(.evaluationsLab)
+#endif
+        examples.append(.fmCLIPythonPlayground)
+        return examples
+    }
+
+    static var generationExamples: [ExampleType] {
+        [.structuredData, .generationGuides, .generationOptions]
+    }
+
+    static var modelAndInputExamples: [ExampleType] {
+        [.modelRuntime, .contextWindowInspector, .privateCloudCompute, .imageInputPlayground, .geminiVideoInput]
+    }
+
+    static var sessionExamples: [ExampleType] {
+        [.toolCallingModeLab, .dynamicProfileBuilder, .reasoningLevelComparison, .transcriptExplorer]
+    }
+
+    static var agentExamples: [ExampleType] {
+        [
             .agentFlowInspector,
             .historyTransformLab,
             .riskyToolConfirmation,
@@ -146,6 +155,10 @@ extension ExampleType {
             .spotlightRAGExplorer,
             .providerBridgeWalkthrough
         ]
+    }
+
+    static var developerToolExamples: [ExampleType] {
+        var examples: [ExampleType] = []
 #if os(macOS)
         examples.append(.evaluationsLab)
 #endif

--- a/Foundation Lab/Views/LabCatalogList.swift
+++ b/Foundation Lab/Views/LabCatalogList.swift
@@ -1,0 +1,127 @@
+//
+//  LabCatalogList.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct LabCatalogList: View {
+    let searchText: String
+
+    var body: some View {
+        if hasResults {
+            List {
+                LabExampleSection(
+                    "Generation Options",
+                    examples: filtered(ExampleType.generationExamples)
+                )
+                LabExampleSection(
+                    "Models & Input",
+                    examples: filtered(ExampleType.modelAndInputExamples)
+                )
+                LabExampleSection(
+                    "Session",
+                    examples: filtered(ExampleType.sessionExamples)
+                )
+                LabExampleSection(
+                    "Agent Workflows",
+                    examples: filtered(ExampleType.agentExamples)
+                )
+                LabExampleSection(
+                    "Developer Tools",
+                    examples: filtered(ExampleType.developerToolExamples)
+                )
+
+                if !filteredTools.isEmpty {
+                    Section("Tools") {
+                        ForEach(filteredTools, id: \.self) { tool in
+                            NavigationLink(value: tool) {
+                                LabNavigationRow(
+                                    title: tool.displayName,
+                                    subtitle: tool.shortDescription,
+                                    systemImage: tool.icon
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if !filteredSchemas.isEmpty {
+                    Section("Dynamic Schemas") {
+                        ForEach(filteredSchemas) { example in
+                            NavigationLink(value: example) {
+                                LabNavigationRow(
+                                    title: example.title,
+                                    subtitle: example.subtitle,
+                                    systemImage: example.icon
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if !filteredLanguages.isEmpty {
+                    Section("Languages") {
+                        ForEach(filteredLanguages) { language in
+                            NavigationLink(value: language) {
+                                LabNavigationRow(
+                                    title: language.title,
+                                    subtitle: language.subtitle,
+                                    systemImage: language.icon
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+#if os(iOS)
+            .listStyle(.insetGrouped)
+#else
+            .listStyle(.inset)
+#endif
+        } else {
+            ContentUnavailableView.search(text: trimmedSearchText)
+        }
+    }
+
+    private var filteredTools: [ToolExample] {
+        ToolExample.allCases.filter { matches($0.displayName, $0.shortDescription) }
+    }
+
+    private var filteredSchemas: [DynamicSchemaExampleType] {
+        DynamicSchemaExampleType.allCases.filter { matches($0.title, $0.subtitle) }
+    }
+
+    private var filteredLanguages: [LanguageExample] {
+        LanguageExample.allCases.filter { matches($0.title, $0.subtitle) }
+    }
+
+    private var hasResults: Bool {
+        !filtered(ExampleType.studioExamples).isEmpty
+            || !filteredTools.isEmpty
+            || !filteredSchemas.isEmpty
+            || !filteredLanguages.isEmpty
+    }
+
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func filtered(_ examples: [ExampleType]) -> [ExampleType] {
+        examples.filter { matches($0.title, $0.subtitle) }
+    }
+
+    private func matches(_ title: String, _ subtitle: String) -> Bool {
+        let query = trimmedSearchText
+        guard !query.isEmpty else { return true }
+
+        return title.localizedStandardContains(query)
+            || subtitle.localizedStandardContains(query)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LabCatalogList(searchText: "")
+    }
+}

--- a/Foundation Lab/Views/LabView.swift
+++ b/Foundation Lab/Views/LabView.swift
@@ -8,191 +8,27 @@
 import SwiftUI
 
 struct LabView: View {
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-
     @State private var searchText = ""
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.xLarge) {
-                if horizontalSizeClass != .compact {
-                    labHeader
-                }
-
-                if hasResults {
-                    examplesSection
-                    toolsSection
-                    schemasSection
-                    languagesSection
-                } else {
-                    ContentUnavailableView.search(text: searchText)
-                }
-            }
-            .padding(.horizontal, Spacing.medium)
-            .padding(.vertical, Spacing.large)
-        }
-        .navigationTitle("Lab")
+        LabCatalogList(searchText: searchText)
+            .navigationTitle("Lab")
 #if os(iOS)
-        .navigationBarTitleDisplayMode(.large)
+            .navigationBarTitleDisplayMode(.large)
 #endif
-        .searchable(text: $searchText, prompt: "Search Lab")
-        .navigationDestination(for: ExampleType.self) { exampleType in
-            exampleType.destination
-        }
-        .navigationDestination(for: ToolExample.self) { tool in
-            tool.destination
-        }
-        .navigationDestination(for: DynamicSchemaExampleType.self) { example in
-            example.destination
-        }
-        .navigationDestination(for: LanguageExample.self) { languageExample in
-            languageExample.destination
-        }
-    }
-
-    private var labHeader: some View {
-        VStack(alignment: .leading, spacing: Spacing.xSmall) {
-            Text("Lab")
-                .font(.largeTitle.bold())
-
-            Text("Foundation Models examples, tools, dynamic schemas, and language demos.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var examplesSection: some View {
-        LabSection(
-            title: "Model Controls",
-            subtitle: "Generation options, guides, and structured output."
-        ) {
-            ForEach(filteredStudioExamples) { exampleType in
-                NavigationLink(value: exampleType) {
-                    GenericCardView(
-                        icon: exampleType.icon,
-                        title: exampleType.title,
-                        subtitle: exampleType.subtitle
-                    )
-                }
-                .buttonStyle(.plain)
+            .searchable(text: $searchText, prompt: "Search Lab")
+            .navigationDestination(for: ExampleType.self) { exampleType in
+                exampleType.destination
             }
-        }
-    }
-
-    private var toolsSection: some View {
-        LabSection(
-            title: "Tools",
-            subtitle: "System capabilities the model can call."
-        ) {
-            ForEach(filteredTools, id: \.self) { tool in
-                NavigationLink(value: tool) {
-                    GenericCardView(
-                        icon: tool.icon,
-                        title: tool.displayName,
-                        subtitle: tool.shortDescription
-                    )
-                }
-                .buttonStyle(.plain)
+            .navigationDestination(for: ToolExample.self) { tool in
+                tool.destination
             }
-        }
-    }
-
-    private var schemasSection: some View {
-        LabSection(
-            title: "Dynamic Schemas",
-            subtitle: "Build and validate generation schemas."
-        ) {
-            ForEach(filteredSchemas) { example in
-                NavigationLink(value: example) {
-                    GenericCardView(
-                        icon: example.icon,
-                        title: example.title,
-                        subtitle: example.subtitle
-                    )
-                }
-                .buttonStyle(.plain)
+            .navigationDestination(for: DynamicSchemaExampleType.self) { example in
+                example.destination
             }
-        }
-    }
-
-    private var languagesSection: some View {
-        LabSection(
-            title: "Languages",
-            subtitle: "Detect, select, and manage multilingual sessions."
-        ) {
-            ForEach(filteredLanguages) { languageExample in
-                NavigationLink(value: languageExample) {
-                    GenericCardView(
-                        icon: languageExample.icon,
-                        title: languageExample.title,
-                        subtitle: languageExample.subtitle
-                    )
-                }
-                .buttonStyle(.plain)
+            .navigationDestination(for: LanguageExample.self) { languageExample in
+                languageExample.destination
             }
-        }
-    }
-
-    private var filteredStudioExamples: [ExampleType] {
-        ExampleType.studioExamples.filter { matches($0.title, $0.subtitle) }
-    }
-
-    private var filteredTools: [ToolExample] {
-        ToolExample.allCases.filter { matches($0.displayName, $0.shortDescription) }
-    }
-
-    private var filteredSchemas: [DynamicSchemaExampleType] {
-        DynamicSchemaExampleType.allCases.filter { matches($0.title, $0.subtitle) }
-    }
-
-    private var filteredLanguages: [LanguageExample] {
-        LanguageExample.allCases.filter { matches($0.title, $0.subtitle) }
-    }
-
-    private var hasResults: Bool {
-        !filteredStudioExamples.isEmpty ||
-        !filteredTools.isEmpty ||
-        !filteredSchemas.isEmpty ||
-        !filteredLanguages.isEmpty
-    }
-
-    private var trimmedSearchText: String {
-        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func matches(_ title: String, _ subtitle: String) -> Bool {
-        let query = trimmedSearchText
-        guard !query.isEmpty else { return true }
-
-        return title.localizedStandardContains(query) ||
-        subtitle.localizedStandardContains(query)
-    }
-}
-
-private struct LabSection<Content: View>: View {
-    let title: String
-    let subtitle: String
-    @ViewBuilder var content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            SectionHeader(title: title, subtitle: subtitle)
-
-            LazyVGrid(columns: adaptiveGridColumns, spacing: Spacing.large) {
-                content
-            }
-        }
-    }
-
-    private var adaptiveGridColumns: [GridItem] {
-#if os(iOS)
-        [
-            GridItem(.flexible(minimum: 140), spacing: Spacing.large),
-            GridItem(.flexible(minimum: 140), spacing: Spacing.large)
-        ]
-#else
-        [GridItem(.adaptive(minimum: 240), spacing: Spacing.large)]
-#endif
     }
 }
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Apple-platform developers exploring, learning, and validating the Foundation Models framework on iPhone, iPad, and Mac. They need to move quickly from a capability to a working example, understand what the model is doing, and inspect results without decoding a decorative dashboard.
+
+## Product Purpose
+
+Foundation Lab is a native companion for learning and testing Apple Foundation Models APIs. It should make a large technical surface feel approachable while keeping the framework, the prompt, and the generated result—not the interface chrome—at the center of attention.
+
+## Brand Personality
+
+Native, quiet, and precise. The app should feel like a thoughtful Apple developer tool: confident without being loud, technically serious without becoming clinical, and helpful without over-explaining.
+
+## Anti-references
+
+Generic SaaS dashboards, identical card grids, cards nested inside cards, decorative metric tiles, multicolor status mosaics, tiny badges, and interfaces that look assembled from AI-generated component recipes. Avoid promoting every capability into an equally weighted destination or panel.
+
+## Design Principles
+
+1. Put the capability first: prompts, source material, controls, and results should dominate each screen.
+2. Use native structure before custom decoration: navigation, lists, sections, forms, tables, disclosure, and inspectors should carry hierarchy.
+3. Reveal complexity progressively: show the primary path first and keep diagnostics, code, and advanced controls available without making them compete.
+4. Let whitespace and typography separate ideas; backgrounds and rounded containers must have a functional reason.
+5. Preserve expert efficiency while keeping terminology and next actions understandable to developers encountering an API for the first time.
+
+## Accessibility & Inclusion
+
+Follow Apple platform accessibility conventions throughout. Support Dynamic Type, VoiceOver, Voice Control, keyboard navigation, Reduce Motion, sufficient contrast, non-color status cues, and minimum 44-point touch targets on iOS. Layouts must remain usable with long localized text and increased text sizes.


### PR DESCRIPTION
## What

- Replaces the dense Lab card grid with a grouped native `List`.
- Organizes examples by generation, model/input, session, agent workflow, and developer-tool intent.
- Preserves search and every existing navigation destination.
- Adds a small product UI contract and localizes the three new section names across all 10 supported locales.

## Why

The June UI additions flattened unlike destinations into one wall of rounded cards. Native list hierarchy, typography, and disclosure make the catalog easier to scan on iPhone, iPad, and Mac without changing capability.

## Impact

UI structure only; no model, tool, or session behavior changes.

## Validation

- Strict SwiftLint: 0 violations across 5 changed Swift files
- Swift parser: passed
- String catalog JSON and 10-locale coverage: passed
- Diff check and independent cross-review: passed
- Full build reaches only pre-existing Xcode 27 API failures under the installed Xcode 26.5 toolchain; the local Xcode 27 beta `xcodebuild` is not runnable.