### PR TITLE
[UI] Rebuild Studio as a native workbench

### DIFF
--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioContent.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioContent.swift
@@ -28,9 +28,7 @@ struct AdapterStudioContent: View {
         .alert(
             "Adapter Studio",
             isPresented: $viewModel.isShowingError
-        ) {
-            Button("OK", role: .cancel) {}
-        } message: {
+        ) { } message: {
             Text(viewModel.presentedError)
         }
         .onDisappear(perform: viewModel.cancel)
@@ -39,8 +37,7 @@ struct AdapterStudioContent: View {
             "Adapter Comparison Requires macOS",
             systemImage: "macbook",
             description: Text(
-                "Use Foundation Lab on a Mac to import .fmadapter packages. "
-                    + "Training and export remain available through the fmas CLI."
+                "Use Foundation Lab on a Mac to import .fmadapter packages. Training and export remain available through the fmas CLI."
             )
         )
 #endif

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioContent.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioContent.swift
@@ -37,7 +37,8 @@ struct AdapterStudioContent: View {
             "Adapter Comparison Requires macOS",
             systemImage: "macbook",
             description: Text(
-                "Use Foundation Lab on a Mac to import .fmadapter packages. Training and export remain available through the fmas CLI."
+                "Use Foundation Lab on a Mac to import .fmadapter packages. "
+                    + "Training and export remain available through the fmas CLI."
             )
         )
 #endif

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioEvaluationView.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioEvaluationView.swift
@@ -8,7 +8,7 @@ struct AdapterStudioEvaluationView: View {
         VStack(alignment: .leading, spacing: Spacing.xLarge) {
             VStack(alignment: .leading, spacing: Spacing.small) {
                 Text("Interactive Timing")
-                    .font(.title3.bold())
+                    .font(.headline)
 
                 Text(
                     "The two models stream concurrently for fast visual comparison. "
@@ -36,16 +36,16 @@ struct AdapterStudioEvaluationView: View {
                 ) {
                     GridRow {
                         Text("Metric")
-                            .font(.caption.bold())
+                            .font(.subheadline.bold())
                             .foregroundStyle(.secondary)
                         Text("Base")
-                            .font(.caption.bold())
+                            .font(.subheadline.bold())
                             .foregroundStyle(.secondary)
                         Text("Adapter")
-                            .font(.caption.bold())
+                            .font(.subheadline.bold())
                             .foregroundStyle(.secondary)
                         Text("Adapter delta")
-                            .font(.caption.bold())
+                            .font(.subheadline.bold())
                             .foregroundStyle(.secondary)
                     }
 
@@ -93,18 +93,13 @@ struct AdapterStudioEvaluationView: View {
                     }
                 }
                 .font(.callout.monospacedDigit())
-                .padding(Spacing.large)
-                .background(
-                    Color.secondaryBackgroundColor,
-                    in: .rect(cornerRadius: CornerRadius.large)
-                )
             }
         }
     }
 
     private func durationLabel(_ duration: TimeInterval?) -> String {
         guard let duration else { return "--" }
-        return duration.formatted(.number.precision(.fractionLength(2))) + "s"
+        return "\(duration.formatted(.number.precision(.fractionLength(2))))s"
     }
 
     private func deltaLabel(
@@ -114,9 +109,7 @@ struct AdapterStudioEvaluationView: View {
         guard let base, let adapter else { return "--" }
         let delta = adapter - base
         let prefix = delta > 0 ? "+" : ""
-        return prefix
-            + delta.formatted(.number.precision(.fractionLength(2)))
-            + "s"
+        return "\(prefix)\(delta.formatted(.number.precision(.fractionLength(2))))s"
     }
 }
 #endif

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioInspector.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioInspector.swift
@@ -3,40 +3,16 @@ import SwiftUI
 struct AdapterStudioInspector: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.large) {
-            HStack(spacing: 0) {
-                VStack(spacing: 2) {
-                    Text("2")
-                        .font(.headline.monospacedDigit())
-                    Text("Models")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                Text("Comparison")
+                    .font(.headline)
 
-                Divider()
-
-                VStack(spacing: 2) {
-                    Text("Fresh")
-                        .font(.headline)
-                    Text("Sessions")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-
-                Divider()
-
-                VStack(spacing: 2) {
-                    Text("Local")
-                        .font(.headline)
-                    Text("Inference")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
+                LabeledContent("Models", value: "2")
+                LabeledContent("Sessions", value: "Fresh")
+                LabeledContent("Inference", value: "Local")
             }
-            .frame(height: 52)
-            .accessibilityElement(children: .contain)
+
+            Divider()
 
             VStack(alignment: .leading, spacing: Spacing.medium) {
                 Text("Comparison Rules")

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioMetadataView.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioMetadataView.swift
@@ -7,7 +7,7 @@ struct AdapterStudioMetadataView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             LabeledContent("Name", value: metadata.fileName)
-                .padding(Spacing.medium)
+                .padding(.vertical, Spacing.small)
 
             Divider()
 
@@ -18,7 +18,7 @@ struct AdapterStudioMetadataView: View {
                     countStyle: .file
                 )
             )
-            .padding(Spacing.medium)
+            .padding(.vertical, Spacing.small)
 
             if let modifiedAt = metadata.modifiedAt {
                 Divider()
@@ -28,28 +28,24 @@ struct AdapterStudioMetadataView: View {
                 } label: {
                     Text("Modified")
                 }
-                .padding(Spacing.medium)
+                .padding(.vertical, Spacing.small)
             }
 
             if !metadata.creatorDefinedMetadata.isEmpty {
-                Divider()
-
                 ForEach(
                     metadata.creatorDefinedMetadata.keys.sorted(),
                     id: \.self
                 ) { key in
+                    Divider()
+
                     LabeledContent(
                         key,
                         value: metadata.creatorDefinedMetadata[key] ?? ""
                     )
-                    .padding(Spacing.medium)
+                    .padding(.vertical, Spacing.small)
                 }
             }
         }
-        .background(
-            Color.secondaryBackgroundColor,
-            in: .rect(cornerRadius: CornerRadius.large)
-        )
     }
 }
 #endif

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioOutputView.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioOutputView.swift
@@ -8,7 +8,7 @@ struct AdapterStudioOutputView: View {
         VStack(alignment: .leading, spacing: Spacing.xLarge) {
             VStack(alignment: .leading, spacing: Spacing.small) {
                 Text("Latest Output")
-                    .font(.title3.bold())
+                    .font(.headline)
 
                 Text(
                     "Responses remain selectable for manual review. "
@@ -35,6 +35,8 @@ struct AdapterStudioOutputView: View {
                             isActive: false
                         )
 
+                        Divider()
+
                         AdapterStudioResponseColumn(
                             title: "Custom Adapter",
                             subtitle: viewModel.adapterContext?.metadata.fileName
@@ -51,6 +53,8 @@ struct AdapterStudioOutputView: View {
                             column: viewModel.baseColumn,
                             isActive: false
                         )
+
+                        Divider()
 
                         AdapterStudioResponseColumn(
                             title: "Custom Adapter",

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioPreviewView.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioPreviewView.swift
@@ -8,7 +8,7 @@ struct AdapterStudioPreviewView: View {
         VStack(alignment: .leading, spacing: Spacing.xLarge) {
             VStack(alignment: .leading, spacing: Spacing.small) {
                 Text("Adapter Workflow")
-                    .font(.title3.bold())
+                    .font(.headline)
 
                 Text(
                     "Train and export with Apple's toolkit, then use this workspace "
@@ -20,28 +20,24 @@ struct AdapterStudioPreviewView: View {
 
             VStack(alignment: .leading, spacing: 0) {
                 LabeledContent("1. Configure toolkit", value: "fmas init")
-                    .padding(Spacing.medium)
+                    .padding(.vertical, Spacing.small)
                 Divider()
                 LabeledContent("2. Install dependencies", value: "fmas setup")
-                    .padding(Spacing.medium)
+                    .padding(.vertical, Spacing.small)
                 Divider()
                 LabeledContent("3. Train", value: "fmas train-adapter --help")
-                    .padding(Spacing.medium)
+                    .padding(.vertical, Spacing.small)
                 Divider()
                 LabeledContent("4. Export", value: "fmas export --help")
-                    .padding(Spacing.medium)
+                    .padding(.vertical, Spacing.small)
                 Divider()
                 LabeledContent(
                     "5. Compare",
                     value: viewModel.adapterContext?.metadata.fileName
                         ?? "Import the .fmadapter package"
                 )
-                .padding(Spacing.medium)
+                .padding(.vertical, Spacing.small)
             }
-            .background(
-                Color.secondaryBackgroundColor,
-                in: .rect(cornerRadius: CornerRadius.large)
-            )
 
             Label(
                 "Adapters are tied to a specific system-model version. "

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioResponseColumn.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioResponseColumn.swift
@@ -14,7 +14,7 @@ struct AdapterStudioResponseColumn: View {
                     .font(.headline)
 
                 Text(subtitle)
-                    .font(.caption)
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -54,18 +54,18 @@ struct AdapterStudioResponseColumn: View {
                 HStack(spacing: Spacing.large) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("First token")
-                            .font(.caption)
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
                         Text(durationLabel(metrics.timeToFirstToken))
-                        .font(.callout.monospacedDigit())
+                            .font(.callout.monospacedDigit())
                     }
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Total")
-                            .font(.caption)
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
                         Text(durationLabel(metrics.totalDuration))
-                        .font(.callout.monospacedDigit())
+                            .font(.callout.monospacedDigit())
                     }
 
                     Spacer(minLength: 0)
@@ -73,17 +73,12 @@ struct AdapterStudioResponseColumn: View {
                 .accessibilityElement(children: .combine)
             }
         }
-        .padding(Spacing.large)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(
-            Color.secondaryBackgroundColor,
-            in: .rect(cornerRadius: CornerRadius.large)
-        )
+        .frame(minWidth: 280, maxWidth: .infinity, alignment: .topLeading)
     }
 
     private func durationLabel(_ duration: TimeInterval?) -> String {
         guard let duration else { return "--" }
-        return duration.formatted(.number.precision(.fractionLength(2))) + "s"
+        return "\(duration.formatted(.number.precision(.fractionLength(2))))s"
     }
 }
 

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioRunsView.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioRunsView.swift
@@ -8,7 +8,7 @@ struct AdapterStudioRunsView: View {
         VStack(alignment: .leading, spacing: Spacing.xLarge) {
             VStack(alignment: .leading, spacing: Spacing.small) {
                 Text("Prompt")
-                    .font(.title3.bold())
+                    .font(.headline)
 
                 TextField(
                     "Enter one prompt for both models",
@@ -16,12 +16,7 @@ struct AdapterStudioRunsView: View {
                     axis: .vertical
                 )
                 .lineLimit(5...10)
-                .textFieldStyle(.plain)
-                .padding(Spacing.medium)
-                .background(
-                    Color.secondaryBackgroundColor,
-                    in: .rect(cornerRadius: CornerRadius.medium)
-                )
+                .textFieldStyle(.roundedBorder)
                 .disabled(viewModel.isRunning)
 
                 HStack {
@@ -70,6 +65,8 @@ struct AdapterStudioRunsView: View {
                         isActive: viewModel.isRunning
                     )
 
+                    Divider()
+
                     AdapterStudioResponseColumn(
                         title: "Custom Adapter",
                         subtitle: viewModel.adapterContext?.metadata.fileName
@@ -86,6 +83,8 @@ struct AdapterStudioRunsView: View {
                         column: viewModel.baseColumn,
                         isActive: viewModel.isRunning
                     )
+
+                    Divider()
 
                     AdapterStudioResponseColumn(
                         title: "Custom Adapter",

--- a/Foundation Lab/AdapterStudio/Views/AdapterStudioSettingsView.swift
+++ b/Foundation Lab/AdapterStudio/Views/AdapterStudioSettingsView.swift
@@ -8,7 +8,7 @@ struct AdapterStudioSettingsView: View {
         VStack(alignment: .leading, spacing: Spacing.xLarge) {
             VStack(alignment: .leading, spacing: Spacing.small) {
                 Text("Adapter Package")
-                    .font(.title3.bold())
+                    .font(.headline)
 
                 Text(
                     "Foundation Lab copies imported .fmadapter packages into "
@@ -18,33 +18,18 @@ struct AdapterStudioSettingsView: View {
                 .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: Spacing.small) {
-                Button(
-                    "Import Adapter",
-                    systemImage: "tray.and.arrow.down",
-                    action: viewModel.importAdapter
-                )
-                .buttonStyle(.borderedProminent)
-
-                Menu("Saved Adapters", systemImage: "archivebox") {
-                    if viewModel.availableAdapters.isEmpty {
-                        Text("No saved adapters")
-                    } else {
-                        ForEach(viewModel.availableAdapters, id: \.self) { url in
-                            Button(url.lastPathComponent) {
-                                viewModel.loadAdapter(at: url)
-                            }
-                        }
-                    }
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: Spacing.small) {
+                    importButton
+                    savedAdaptersMenu
+                    showInFinderButton
                 }
 
-                Button(
-                    "Show in Finder",
-                    systemImage: "folder",
-                    action: viewModel.showAdaptersDirectory
-                )
-
-                Spacer(minLength: 0)
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    importButton
+                    savedAdaptersMenu
+                    showInFinderButton
+                }
             }
 
             if let metadata = viewModel.adapterContext?.metadata {
@@ -58,12 +43,39 @@ struct AdapterStudioSettingsView: View {
                     )
                 )
                 .frame(maxWidth: .infinity, minHeight: 220)
-                .background(
-                    Color.secondaryBackgroundColor,
-                    in: .rect(cornerRadius: CornerRadius.large)
-                )
             }
         }
+    }
+
+    private var importButton: some View {
+        Button(
+            "Import Adapter",
+            systemImage: "tray.and.arrow.down",
+            action: viewModel.importAdapter
+        )
+        .buttonStyle(.borderedProminent)
+    }
+
+    private var savedAdaptersMenu: some View {
+        Menu("Saved Adapters", systemImage: "archivebox") {
+            if viewModel.availableAdapters.isEmpty {
+                Text("No saved adapters")
+            } else {
+                ForEach(viewModel.availableAdapters, id: \.self) { url in
+                    Button(url.lastPathComponent) {
+                        viewModel.loadAdapter(at: url)
+                    }
+                }
+            }
+        }
+    }
+
+    private var showInFinderButton: some View {
+        Button(
+            "Show in Finder",
+            systemImage: "folder",
+            action: viewModel.showAdaptersDirectory
+        )
     }
 }
 #endif

--- a/Foundation Lab/Views/AppBenchStudioContent.swift
+++ b/Foundation Lab/Views/AppBenchStudioContent.swift
@@ -30,7 +30,9 @@ struct AppBenchStudioContent: View {
             section(title: "Execution Surfaces") {
                 VStack(spacing: 0) {
                     detailRow(title: "Mac", value: "appbench CLI")
+                    Divider()
                     detailRow(title: "iPhone and iPad", value: "Signed AppBenchDeviceRunner")
+                    Divider()
                     detailRow(title: "Simulator", value: "Build and interface validation only")
                 }
             }
@@ -38,8 +40,11 @@ struct AppBenchStudioContent: View {
             section(title: "Publishable Protocol") {
                 VStack(spacing: 0) {
                     detailRow(title: "Warmups", value: "5")
+                    Divider()
                     detailRow(title: "Measured runs", value: "20 or more")
+                    Divider()
                     detailRow(title: "Order", value: "Randomized with a recorded seed")
+                    Divider()
                     detailRow(title: "Report", value: "Median, p90, and failure rate")
                 }
             }
@@ -54,10 +59,7 @@ struct AppBenchStudioContent: View {
 
             section(title: "Physical Device") {
                 VStack(alignment: .leading, spacing: Spacing.medium) {
-                    Text(
-                        "Open the AppBenchDeviceRunner project, select a physical Apple Intelligence device, "
-                            + "and run its scheme."
-                    )
+                    Text("Open the AppBenchDeviceRunner project, select a physical Apple Intelligence device, and run its scheme.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
 
@@ -97,9 +99,13 @@ struct AppBenchStudioContent: View {
             section(title: "Suites") {
                 VStack(spacing: 0) {
                     detailRow(title: "Practical Quick", value: "Fast development pass")
+                    Divider()
                     detailRow(title: "Practical Full", value: "10 workloads, 25 samples each")
+                    Divider()
                     detailRow(title: "Safety Guardrails", value: "False positives and expected protection")
+                    Divider()
                     detailRow(title: "Synthetic Performance", value: "Sustained generation")
+                    Divider()
                     detailRow(title: "Context Limits", value: "Long-context behavior")
                 }
             }
@@ -118,7 +124,9 @@ struct AppBenchStudioContent: View {
             section(title: "Artifacts") {
                 VStack(spacing: 0) {
                     detailRow(title: "JSON", value: "Complete machine-readable trials and environment")
+                    Divider()
                     detailRow(title: "Markdown", value: "Human-readable scenario summaries")
+                    Divider()
                     detailRow(title: "Curated results", value: "Tools/AppBench/Results")
                 }
             }
@@ -137,7 +145,7 @@ struct AppBenchStudioContent: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: Spacing.large) {
             Text(title)
-                .font(.title3.bold())
+                .font(.headline)
 
             content()
         }
@@ -151,12 +159,7 @@ struct AppBenchStudioContent: View {
         } label: {
             Text(title)
         }
-        .font(.callout)
-        .padding(.horizontal, Spacing.large)
-        .padding(.vertical, Spacing.medium)
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
+        .padding(.vertical, Spacing.small)
     }
 
     private func command(_ command: String) -> some View {
@@ -165,21 +168,15 @@ struct AppBenchStudioContent: View {
             .textSelection(.enabled)
             .padding(Spacing.medium)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.medium))
+            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.small))
     }
 
     private func note(title: String, detail: String) -> some View {
-        Label {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.callout.bold())
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-        } icon: {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+            Text(detail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/Foundation Lab/Views/AppBenchStudioContent.swift
+++ b/Foundation Lab/Views/AppBenchStudioContent.swift
@@ -59,7 +59,10 @@ struct AppBenchStudioContent: View {
 
             section(title: "Physical Device") {
                 VStack(alignment: .leading, spacing: Spacing.medium) {
-                    Text("Open the AppBenchDeviceRunner project, select a physical Apple Intelligence device, and run its scheme.")
+                    Text(
+                        "Open the AppBenchDeviceRunner project, select a physical Apple Intelligence device, "
+                            + "and run its scheme."
+                    )
                     .font(.callout)
                     .foregroundStyle(.secondary)
 

--- a/Foundation Lab/Views/AppBenchStudioInspector.swift
+++ b/Foundation Lab/Views/AppBenchStudioInspector.swift
@@ -11,9 +11,6 @@ struct AppBenchStudioInspector: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.large) {
             VStack(alignment: .leading, spacing: Spacing.small) {
-                Text("Benchmark")
-                    .font(.headline)
-
                 metric(value: "5", title: "Suites")
                 metric(value: "10", title: "Workloads")
                 metric(value: "2", title: "Runners")

--- a/Foundation Lab/Views/AppBenchStudioInspector.swift
+++ b/Foundation Lab/Views/AppBenchStudioInspector.swift
@@ -10,14 +10,16 @@ import SwiftUI
 struct AppBenchStudioInspector: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.large) {
-            HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                Text("Benchmark")
+                    .font(.headline)
+
                 metric(value: "5", title: "Suites")
-                Divider()
                 metric(value: "10", title: "Workloads")
-                Divider()
                 metric(value: "2", title: "Runners")
             }
-            .frame(height: 52)
+
+            Divider()
 
             VStack(alignment: .leading, spacing: Spacing.medium) {
                 Text("Canonical Execution")
@@ -32,29 +34,22 @@ struct AppBenchStudioInspector: View {
     }
 
     private func metric(value: String, title: String) -> some View {
-        VStack(spacing: 2) {
+        LabeledContent {
             Text(value)
-                .font(.headline.monospacedDigit())
+                .font(.callout.monospacedDigit())
+        } label: {
             Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .font(.callout)
         }
-        .frame(maxWidth: .infinity)
-        .accessibilityElement(children: .combine)
     }
 
     private func note(title: String, detail: String) -> some View {
-        Label {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.callout.bold())
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-        } icon: {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.callout)
+            Text(detail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/Foundation Lab/Views/StudioActivityInspector.swift
+++ b/Foundation Lab/Views/StudioActivityInspector.swift
@@ -21,9 +21,9 @@ struct StudioActivityInspector: View {
             promptInspector
         case .structuredOutput, .capabilityMatrix:
             ContentUnavailableView(
-                "No Activity",
+                workspace.title,
                 systemImage: workspace.icon,
-                description: Text("This workspace is planned for a future update.")
+                description: Text(workspace.subtitle)
             )
             .padding(Spacing.large)
         }
@@ -70,11 +70,8 @@ struct StudioActivityInspector: View {
 
     private var summary: some View {
         VStack(alignment: .leading, spacing: Spacing.small) {
-            Text("Summary")
-                .font(.headline)
-
             metric(value: "\(promptRuns.count)", title: "Runs")
-            metric(value: averageDurationLabel, title: "Average Duration")
+            metric(value: averageDurationLabel, title: "Average")
             metric(value: "\(selectedVariantCount)", title: "Variants")
         }
     }

--- a/Foundation Lab/Views/StudioActivityInspector.swift
+++ b/Foundation Lab/Views/StudioActivityInspector.swift
@@ -1,0 +1,121 @@
+//
+//  StudioActivityInspector.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioActivityInspector: View {
+    let workspace: StudioWorkspace
+    let promptRuns: [StudioPromptRun]
+    let selectedVariantCount: Int
+    let createdAt: Date
+
+    var body: some View {
+        switch workspace {
+        case .adapterComparison:
+            AdapterStudioInspector()
+        case .benchmarkRuns:
+            AppBenchStudioInspector()
+        case .promptTesting:
+            promptInspector
+        case .structuredOutput, .capabilityMatrix:
+            ContentUnavailableView(
+                "No Activity",
+                systemImage: workspace.icon,
+                description: Text("This workspace is planned for a future update.")
+            )
+            .padding(Spacing.large)
+        }
+    }
+
+    private var promptInspector: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            summary
+            Divider()
+
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                HStack {
+                    Text("Activity")
+                        .font(.headline)
+                    Spacer()
+                    Text(Date.now, style: .date)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                ForEach(activityEvents) { event in
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text(event.title)
+                                .font(.callout)
+                            Spacer()
+                            Text(event.date, style: .time)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text(event.detail)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, Spacing.small)
+
+                    Divider()
+                }
+            }
+        }
+        .padding(Spacing.large)
+    }
+
+    private var summary: some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            Text("Summary")
+                .font(.headline)
+
+            metric(value: "\(promptRuns.count)", title: "Runs")
+            metric(value: averageDurationLabel, title: "Average Duration")
+            metric(value: "\(selectedVariantCount)", title: "Variants")
+        }
+    }
+
+    private func metric(value: String, title: String) -> some View {
+        LabeledContent {
+            Text(value)
+                .font(.callout.monospacedDigit())
+                .lineLimit(1)
+        } label: {
+            Text(title)
+                .font(.callout)
+        }
+    }
+
+    private var averageDurationLabel: String {
+        guard !promptRuns.isEmpty else { return "--" }
+        let totalDuration = promptRuns.reduce(0) { $0 + $1.duration }
+        let average = totalDuration / Double(promptRuns.count)
+        return "\(average.formatted(.number.precision(.fractionLength(2))))s"
+    }
+
+    private var activityEvents: [StudioActivityEvent] {
+        if promptRuns.isEmpty {
+            return [
+                StudioActivityEvent(
+                    id: "studio-created",
+                    title: "Studio Created",
+                    detail: "Local Evaluation Studio",
+                    date: createdAt
+                )
+            ]
+        }
+
+        return promptRuns.prefix(6).map {
+            StudioActivityEvent(
+                id: $0.id.uuidString,
+                title: "Prompt Variant Completed",
+                detail: $0.variant.title,
+                date: $0.finishedAt
+            )
+        }
+    }
+}

--- a/Foundation Lab/Views/StudioPromptRunDetailView.swift
+++ b/Foundation Lab/Views/StudioPromptRunDetailView.swift
@@ -1,0 +1,56 @@
+//
+//  StudioPromptRunDetailView.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioPromptRunDetailView: View {
+    let run: StudioPromptRun
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(run.variant.title)
+                            .font(.headline)
+                        Text(run.finishedAt, style: .time)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(run.durationLabel)
+                            .font(.headline.monospacedDigit())
+                        Text(run.tokenLabel)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Prompt")
+                        .font(.headline)
+                    Text(run.prompt)
+                        .font(.callout)
+                        .textSelection(.enabled)
+                }
+
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Output")
+                        .font(.headline)
+                    Text(run.output)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding()
+        }
+        .frame(minWidth: 320, idealWidth: 420, maxWidth: 520, minHeight: 320, idealHeight: 460)
+    }
+}

--- a/Foundation Lab/Views/StudioPromptSettingsView.swift
+++ b/Foundation Lab/Views/StudioPromptSettingsView.swift
@@ -1,0 +1,127 @@
+//
+//  StudioPromptSettingsView.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioPromptSettingsView: View {
+    @Binding var promptText: String
+    @Binding var selectedVariants: Set<StudioPromptVariant>
+
+    let isRunning: Bool
+    let errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xLarge) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: Spacing.xLarge) {
+                    promptEditor
+                        .frame(minWidth: 320)
+
+                    Divider()
+
+                    variantSelector
+                        .frame(minWidth: 300)
+                }
+
+                VStack(alignment: .leading, spacing: Spacing.xLarge) {
+                    promptEditor
+                    Divider()
+                    variantSelector
+                }
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Text("Run Configuration")
+                    .font(.headline)
+
+                VStack(spacing: 0) {
+                    parameterRow(title: "Execution", value: "Sequential local runs")
+                    parameterRow(title: "Selected Variants", value: "\(selectedVariants.count)")
+                    parameterRow(title: "Prompt Characters", value: "\(promptText.count)")
+                    parameterRow(title: "Result Capture", value: "Output, latency, token count")
+                }
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var promptEditor: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            Label("Base Prompt", systemImage: "text.quote")
+                .font(.headline)
+
+            TextField(
+                "Enter a prompt to run through each selected variant",
+                text: $promptText,
+                axis: .vertical
+            )
+            .lineLimit(6...12)
+            .textFieldStyle(.roundedBorder)
+            .disabled(isRunning)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var variantSelector: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            Label("Variants", systemImage: "square.stack.3d.up")
+                .font(.headline)
+
+            VStack(spacing: 0) {
+                ForEach(StudioPromptVariant.allCases) { variant in
+                    Toggle(isOn: variantBinding(for: variant)) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(variant.title)
+                            Text(variant.subtitle)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .disabled(isRunning)
+                    .padding(.vertical, Spacing.small)
+
+                    if variant != StudioPromptVariant.allCases.last {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func parameterRow(title: String, value: String) -> some View {
+        LabeledContent {
+            Text(value)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        } label: {
+            Text(title)
+                .font(.callout)
+        }
+        .padding(.vertical, Spacing.small)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    private func variantBinding(for variant: StudioPromptVariant) -> Binding<Bool> {
+        Binding {
+            selectedVariants.contains(variant)
+        } set: { isSelected in
+            if isSelected {
+                selectedVariants.insert(variant)
+            } else {
+                selectedVariants.remove(variant)
+            }
+        }
+    }
+}

--- a/Foundation Lab/Views/StudioPromptSettingsView.swift
+++ b/Foundation Lab/Views/StudioPromptSettingsView.swift
@@ -58,7 +58,7 @@ struct StudioPromptSettingsView: View {
                 .font(.headline)
 
             TextField(
-                "Enter a prompt to run through each selected variant",
+                "Enter your prompt...",
                 text: $promptText,
                 axis: .vertical
             )

--- a/Foundation Lab/Views/StudioPromptStageView.swift
+++ b/Foundation Lab/Views/StudioPromptStageView.swift
@@ -61,9 +61,6 @@ struct StudioPromptStageView: View {
                     Divider()
                 }
             }
-            .popover(item: $selectedRun, arrowEdge: .trailing) { run in
-                StudioPromptRunDetailView(run: run)
-            }
         }
     }
 
@@ -100,6 +97,19 @@ struct StudioPromptStageView: View {
         .buttonStyle(.plain)
         .padding(.vertical, Spacing.small)
         .help("Show full prompt run")
+        .popover(
+            isPresented: Binding(
+                get: { selectedRun?.id == run.id },
+                set: { isPresented in
+                    if !isPresented, selectedRun?.id == run.id {
+                        selectedRun = nil
+                    }
+                }
+            ),
+            arrowEdge: .trailing
+        ) {
+            StudioPromptRunDetailView(run: run)
+        }
     }
 
     @ViewBuilder

--- a/Foundation Lab/Views/StudioPromptStageView.swift
+++ b/Foundation Lab/Views/StudioPromptStageView.swift
@@ -1,0 +1,200 @@
+//
+//  StudioPromptStageView.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioPromptStageView: View {
+    @Binding var stage: StudioPipelineStage
+    @Binding var promptText: String
+    @Binding var selectedVariants: Set<StudioPromptVariant>
+
+    let runs: [StudioPromptRun]
+    let isRunning: Bool
+    let errorMessage: String?
+
+    @State private var selectedRun: StudioPromptRun?
+
+    var body: some View {
+        switch stage {
+        case .settings:
+            StudioPromptSettingsView(
+                promptText: $promptText,
+                selectedVariants: $selectedVariants,
+                isRunning: isRunning,
+                errorMessage: errorMessage
+            )
+        case .runs:
+            runsContent
+        case .evaluation:
+            evaluationContent
+        case .preview:
+            previewContent
+        case .output:
+            outputContent
+        }
+    }
+
+    @ViewBuilder
+    private var runsContent: some View {
+        if runs.isEmpty, isRunning {
+            ContentUnavailableView {
+                Label("Running selected variants", systemImage: "hourglass")
+            } description: {
+                Text("Results will appear here as soon as the first prompt run finishes.")
+            } actions: {
+                ProgressView()
+                    .controlSize(.large)
+            }
+            .frame(maxWidth: .infinity, minHeight: 320)
+        } else if runs.isEmpty {
+            unavailableState(
+                title: "Prompt runs unavailable",
+                systemImage: "play.circle",
+                subtitle: "Set up the prompt source and run selected variants to view run progress."
+            )
+        } else {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                ForEach(runs) { run in
+                    runRow(run)
+                    Divider()
+                }
+            }
+            .popover(item: $selectedRun, arrowEdge: .trailing) { run in
+                StudioPromptRunDetailView(run: run)
+            }
+        }
+    }
+
+    private func runRow(_ run: StudioPromptRun) -> some View {
+        Button {
+            selectedRun = run
+        } label: {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(run.variant.title)
+                        .font(.headline)
+
+                    Spacer(minLength: Spacing.medium)
+
+                    Text(run.durationLabel)
+                        .font(.headline.monospacedDigit())
+                }
+
+                Text(run.output)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: Spacing.medium) {
+                    Text(run.finishedAt, style: .time)
+                    Text(run.tokenLabel)
+                }
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, Spacing.small)
+        .help("Show full prompt run")
+    }
+
+    @ViewBuilder
+    private var evaluationContent: some View {
+        if runs.isEmpty {
+            unavailableState(
+                title: "Evaluation unavailable",
+                systemImage: "chart.bar.doc.horizontal",
+                subtitle: "Run at least one variant to compare latency, tokens, and answer shape."
+            )
+        } else {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Text("Comparison")
+                    .font(.headline)
+
+                VStack(spacing: 0) {
+                    ForEach(runs) { run in
+                        parameterRow(
+                            title: run.variant.title,
+                            value: "\(run.durationLabel) • \(run.tokenLabel)"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var previewContent: some View {
+        if let latestRun {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                Text(latestRun.variant.title)
+                    .font(.headline)
+                Text(latestRun.output)
+                    .textSelection(.enabled)
+            }
+        } else {
+            unavailableState(
+                title: "Preview unavailable",
+                systemImage: "eye",
+                subtitle: "Run a prompt variant to preview the most recent generated output."
+            )
+        }
+    }
+
+    private var outputContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            Text("Run Artifact")
+                .font(.headline)
+
+            VStack(spacing: 0) {
+                parameterRow(title: "Format", value: "Studio run summary")
+                parameterRow(title: "Runs", value: "\(runs.count)")
+                parameterRow(title: "Status", value: runs.isEmpty ? "No exportable runs" : "Ready")
+            }
+
+            Button(
+                "Review Runs",
+                systemImage: "doc.text.magnifyingglass",
+                action: showRuns
+            )
+            .disabled(runs.isEmpty)
+        }
+    }
+
+    private func parameterRow(title: String, value: String) -> some View {
+        LabeledContent {
+            Text(value)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        } label: {
+            Text(title)
+                .font(.callout)
+        }
+        .padding(.vertical, Spacing.small)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    private func unavailableState(title: String, systemImage: String, subtitle: String) -> some View {
+        ContentUnavailableView(
+            title,
+            systemImage: systemImage,
+            description: Text(subtitle)
+        )
+        .frame(maxWidth: .infinity, minHeight: 320)
+    }
+
+    private var latestRun: StudioPromptRun? {
+        runs.max { $0.finishedAt < $1.finishedAt }
+    }
+
+    private func showRuns() {
+        stage = .runs
+    }
+}

--- a/Foundation Lab/Views/StudioSourceList.swift
+++ b/Foundation Lab/Views/StudioSourceList.swift
@@ -7,7 +7,6 @@ import SwiftUI
 
 struct StudioSourceList: View {
     @Binding var selectedWorkspace: StudioWorkspace
-    @Binding var selectedPromptVariants: Set<StudioPromptVariant>
 
     var body: some View {
         List {
@@ -40,19 +39,7 @@ struct StudioSourceList: View {
     private var workspaceSources: some View {
         switch selectedWorkspace {
         case .promptTesting:
-            Section("Prompt Variants") {
-                ForEach(StudioPromptVariant.allCases) { variant in
-                    Toggle(isOn: variantBinding(for: variant)) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(variant.title)
-                            Text(variant.subtitle)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
-                        }
-                    }
-                }
-            }
+            EmptyView()
         case .benchmarkRuns:
             Section("Runners") {
                 sourceInfoRow(title: "Mac CLI", subtitle: "Publishable", systemImage: "terminal")
@@ -83,26 +70,11 @@ struct StudioSourceList: View {
         }
     }
 
-    private func variantBinding(for variant: StudioPromptVariant) -> Binding<Bool> {
-        Binding {
-            selectedPromptVariants.contains(variant)
-        } set: { isSelected in
-            if isSelected {
-                selectedPromptVariants.insert(variant)
-            } else {
-                selectedPromptVariants.remove(variant)
-            }
-        }
-    }
 }
 
 #Preview {
     @Previewable @State var selectedWorkspace = StudioWorkspace.promptTesting
-    @Previewable @State var variants = Set(StudioPromptVariant.allCases)
 
-    StudioSourceList(
-        selectedWorkspace: $selectedWorkspace,
-        selectedPromptVariants: $variants
-    )
+    StudioSourceList(selectedWorkspace: $selectedWorkspace)
     .frame(width: 260)
 }

--- a/Foundation Lab/Views/StudioSourceList.swift
+++ b/Foundation Lab/Views/StudioSourceList.swift
@@ -1,0 +1,108 @@
+//
+//  StudioSourceList.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioSourceList: View {
+    @Binding var selectedWorkspace: StudioWorkspace
+    @Binding var selectedPromptVariants: Set<StudioPromptVariant>
+
+    var body: some View {
+        List {
+            Section("Workspaces") {
+                Picker("Workspace", selection: $selectedWorkspace) {
+                    ForEach(StudioWorkspace.allCases) { workspace in
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(workspace.title)
+                                Text(workspace.status)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: workspace.icon)
+                        }
+                        .tag(workspace)
+                    }
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            }
+
+            workspaceSources
+        }
+        .listStyle(.sidebar)
+    }
+
+    @ViewBuilder
+    private var workspaceSources: some View {
+        switch selectedWorkspace {
+        case .promptTesting:
+            Section("Prompt Variants") {
+                ForEach(StudioPromptVariant.allCases) { variant in
+                    Toggle(isOn: variantBinding(for: variant)) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(variant.title)
+                            Text(variant.subtitle)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                }
+            }
+        case .benchmarkRuns:
+            Section("Runners") {
+                sourceInfoRow(title: "Mac CLI", subtitle: "Publishable", systemImage: "terminal")
+                sourceInfoRow(title: "Device Runner", subtitle: "iPhone and iPad", systemImage: "iphone")
+                sourceInfoRow(title: "Simulator", subtitle: "Validation only", systemImage: "hammer")
+            }
+        case .adapterComparison:
+            Section("Surfaces") {
+                sourceInfoRow(title: "Base Model", subtitle: "Fresh session", systemImage: "cpu")
+                sourceInfoRow(title: "Custom Adapter", subtitle: ".fmadapter", systemImage: "shippingbox")
+                sourceInfoRow(title: "Training CLI", subtitle: "fmas", systemImage: "terminal")
+            }
+        case .structuredOutput, .capabilityMatrix:
+            EmptyView()
+        }
+    }
+
+    private func sourceInfoRow(title: String, subtitle: String, systemImage: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: systemImage)
+        }
+    }
+
+    private func variantBinding(for variant: StudioPromptVariant) -> Binding<Bool> {
+        Binding {
+            selectedPromptVariants.contains(variant)
+        } set: { isSelected in
+            if isSelected {
+                selectedPromptVariants.insert(variant)
+            } else {
+                selectedPromptVariants.remove(variant)
+            }
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var selectedWorkspace = StudioWorkspace.promptTesting
+    @Previewable @State var variants = Set(StudioPromptVariant.allCases)
+
+    StudioSourceList(
+        selectedWorkspace: $selectedWorkspace,
+        selectedPromptVariants: $variants
+    )
+    .frame(width: 260)
+}

--- a/Foundation Lab/Views/StudioStageBar.swift
+++ b/Foundation Lab/Views/StudioStageBar.swift
@@ -1,0 +1,89 @@
+//
+//  StudioStageBar.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioStageBar: View {
+    @Binding var workspace: StudioWorkspace
+    @Binding var stage: StudioPipelineStage
+
+    let isCompact: Bool
+    let isRunning: Bool
+    let canRun: Bool
+    let run: () -> Void
+
+    var body: some View {
+        if isCompact {
+            compactBar
+        } else {
+            regularBar
+        }
+    }
+
+    private var regularBar: some View {
+        HStack(spacing: Spacing.large) {
+#if os(macOS)
+            Picker("Workspace", selection: $workspace) {
+                ForEach(StudioWorkspace.allCases) { workspace in
+                    Label(workspace.title, systemImage: workspace.icon)
+                        .tag(workspace)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 220)
+#endif
+
+            Picker("Stage", selection: $stage) {
+                ForEach(StudioPipelineStage.allCases) { stage in
+                    Label(stage.title, systemImage: stage.systemImage)
+                        .tag(stage)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(maxWidth: 560)
+
+            Spacer(minLength: 0)
+
+#if os(macOS)
+            if workspace == .promptTesting {
+                Button(
+                    "Run",
+                    systemImage: isRunning ? "hourglass" : "play.fill",
+                    action: run
+                )
+                .buttonStyle(.borderedProminent)
+                .disabled(isRunning || !canRun)
+                .help("Run selected prompt variants")
+            }
+#endif
+        }
+        .padding(.horizontal, Spacing.xLarge)
+        .padding(.vertical, Spacing.small)
+        .background(.bar)
+    }
+
+    private var compactBar: some View {
+        HStack {
+            Label(stage.title, systemImage: stage.systemImage)
+                .font(.headline)
+
+            Spacer(minLength: Spacing.medium)
+
+            Picker("Stage", selection: $stage) {
+                ForEach(StudioPipelineStage.allCases) { stage in
+                    Label(stage.title, systemImage: stage.systemImage)
+                        .tag(stage)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+        }
+        .padding(.horizontal, Spacing.medium)
+        .frame(minHeight: 44)
+        .background(.bar)
+    }
+}

--- a/Foundation Lab/Views/StudioStageBar.swift
+++ b/Foundation Lab/Views/StudioStageBar.swift
@@ -67,21 +67,16 @@ struct StudioStageBar: View {
     }
 
     private var compactBar: some View {
-        HStack {
-            Label(stage.title, systemImage: stage.systemImage)
-                .font(.headline)
-
-            Spacer(minLength: Spacing.medium)
-
-            Picker("Stage", selection: $stage) {
-                ForEach(StudioPipelineStage.allCases) { stage in
-                    Label(stage.title, systemImage: stage.systemImage)
-                        .tag(stage)
-                }
+        Picker("Stage", selection: $stage) {
+            ForEach(StudioPipelineStage.allCases) { stage in
+                Label(stage.title, systemImage: stage.systemImage)
+                    .tag(stage)
             }
-            .pickerStyle(.menu)
-            .labelsHidden()
         }
+        .pickerStyle(.menu)
+        .labelsHidden()
+        .accessibilityLabel("Stage")
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, Spacing.medium)
         .frame(minHeight: 44)
         .background(.bar)

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -32,7 +32,6 @@ struct StudioView: View {
         StudioWorkbenchView(
             workspace: $selectedWorkspace,
             stage: $selectedStage,
-            selectedPromptVariants: $selectedPromptVariants,
             isRunning: isRunningPromptTests,
             canRun: canRunPromptTests,
             run: runPromptTests,

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -9,17 +9,18 @@ import SwiftUI
 import FoundationLabCore
 
 struct StudioView: View {
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-
     @State private var selectedWorkspace: StudioWorkspace = .promptTesting
     @State private var selectedStage: StudioPipelineStage = .settings
     @State private var promptText = "Summarize what makes Apple Foundation Models useful for an offline journaling app."
     @State private var selectedPromptVariants: Set<StudioPromptVariant> = Set(StudioPromptVariant.allCases)
     @State private var promptRuns: [StudioPromptRun] = []
-    @State private var selectedPromptRun: StudioPromptRun?
     @State private var isRunningPromptTests = false
     @State private var promptTestError: String?
     @State private var studioCreatedAt = Date.now
+
+#if os(iOS)
+    @State private var isShowingInspector = false
+#endif
 
 #if os(macOS)
     @State private var adapterStudioViewModel = AdapterStudioViewModel()
@@ -28,13 +29,16 @@ struct StudioView: View {
     private let generateTextUseCase = GenerateTextUseCase()
 
     var body: some View {
-        Group {
-            if horizontalSizeClass == .compact {
-                compactLayout
-            } else {
-                workbenchLayout
-            }
-        }
+        StudioWorkbenchView(
+            workspace: $selectedWorkspace,
+            stage: $selectedStage,
+            selectedPromptVariants: $selectedPromptVariants,
+            isRunning: isRunningPromptTests,
+            canRun: canRunPromptTests,
+            run: runPromptTests,
+            content: stageContent,
+            inspector: studioInspector
+        )
         .navigationTitle("Studio")
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -43,327 +47,30 @@ struct StudioView: View {
 #if os(iOS)
             if selectedWorkspace == .promptTesting {
                 ToolbarItem(placement: .primaryAction) {
-                    Button(action: runPromptTests) {
-                        Label("Run", systemImage: isRunningPromptTests ? "hourglass" : "play.fill")
-                    }
+                    Button(
+                        "Run",
+                        systemImage: isRunningPromptTests ? "hourglass" : "play.fill",
+                        action: runPromptTests
+                    )
                     .disabled(isRunningPromptTests || !canRunPromptTests)
                 }
             }
-#endif
-        }
-    }
 
-    private var workbenchLayout: some View {
-        VStack(spacing: 0) {
-#if os(macOS)
-            GeometryReader { proxy in
-                if proxy.size.width < 920 {
-                    narrowWorkbenchLayout
-                } else {
-                    HSplitView {
-                        primaryWorkbenchColumn
-                            .frame(minWidth: 0, idealWidth: 820, maxWidth: .infinity, maxHeight: .infinity)
-                            .layoutPriority(1)
-
-                        activityInspector
-                            .frame(minWidth: 240, idealWidth: 300, maxWidth: 320)
-                    }
+            ToolbarItem(placement: .secondaryAction) {
+                Button("Studio Details", systemImage: "sidebar.trailing") {
+                    isShowingInspector.toggle()
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-#else
-            HStack(spacing: 0) {
-                studioSourceList
-                    .frame(width: 250)
-
-                Divider()
-
-                VStack(spacing: 0) {
-                    stageBar
-                    Divider()
-                    mainWorkspace
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-                Divider()
-
-                activityInspector
-                    .frame(width: 280)
-            }
 #endif
-
-            Divider()
-            statusBar
         }
-        .background(Color.secondaryBackgroundColor.opacity(0.28))
-    }
-
-    private var primaryWorkbenchColumn: some View {
-        VStack(spacing: 0) {
-            stageBar
-            Divider()
-            mainWorkspace
-        }
-    }
-
-    private var narrowWorkbenchLayout: some View {
-        VStack(spacing: 0) {
-            stageBar
-            Divider()
-
+#if os(iOS)
+        .inspector(isPresented: $isShowingInspector) {
             ScrollView {
-                VStack(alignment: .leading, spacing: Spacing.large) {
-                    workspaceHeader
-                    compactStageContent
-                }
-                .padding()
+                studioInspector
             }
+            .presentationDetents([.medium, .large])
         }
-    }
-
-    private var compactLayout: some View {
-        VStack(spacing: 0) {
-            compactStageBar
-            Divider()
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: Spacing.large) {
-                    compactWorkspacePicker
-                    compactStageContent
-                    activityInspectorContent
-                }
-                .padding()
-            }
-        }
-    }
-
-    private var studioSourceList: some View {
-        VStack(alignment: .leading, spacing: Spacing.large) {
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text("Foundation Lab")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-
-                Label("Local Evaluation Studio", systemImage: "doc.text.magnifyingglass")
-                    .font(.headline)
-            }
-
-            sourceSection("Workspaces") {
-                ForEach(StudioWorkspace.allCases) { workspace in
-                    sourceRow(
-                        title: workspace.title,
-                        subtitle: workspace.status,
-                        systemImage: workspace.icon,
-                        isSelected: selectedWorkspace == workspace
-                    ) {
-                        selectedWorkspace = workspace
-                    }
-                }
-            }
-
-            workspaceSources
-
-            Spacer(minLength: 0)
-        }
-        .padding(Spacing.large)
-        .background(.regularMaterial)
-    }
-
-    @ViewBuilder
-    private var workspaceSources: some View {
-        switch selectedWorkspace {
-        case .promptTesting:
-            sourceSection("Prompt Sources") {
-                ForEach(StudioPromptVariant.allCases) { variant in
-                    sourceRow(
-                        title: variant.title,
-                        subtitle: selectedPromptVariants.contains(variant) ? "Included" : "Excluded",
-                        systemImage: selectedPromptVariants.contains(variant) ? "checkmark.square.fill" : "square",
-                        isSelected: selectedPromptVariants.contains(variant)
-                    ) {
-                        togglePromptVariant(variant)
-                    }
-                }
-            }
-        case .benchmarkRuns:
-            sourceSection("Runners") {
-                sourceInfoRow(title: "Mac CLI", subtitle: "Publishable", systemImage: "terminal")
-                sourceInfoRow(title: "Device Runner", subtitle: "iPhone and iPad", systemImage: "iphone")
-                sourceInfoRow(title: "Simulator", subtitle: "Validation only", systemImage: "hammer")
-            }
-        case .adapterComparison:
-            sourceSection("Surfaces") {
-                sourceInfoRow(title: "Base Model", subtitle: "Fresh session", systemImage: "cpu")
-                sourceInfoRow(title: "Custom Adapter", subtitle: ".fmadapter", systemImage: "shippingbox")
-                sourceInfoRow(title: "Training CLI", subtitle: "fmas", systemImage: "terminal")
-            }
-        case .structuredOutput, .capabilityMatrix:
-            EmptyView()
-        }
-    }
-
-    private func sourceSection<Content: View>(
-        _ title: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.small) {
-            Text(title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: Spacing.xSmall) {
-                content()
-            }
-        }
-    }
-
-    private func sourceInfoRow(title: String, subtitle: String, systemImage: String) -> some View {
-        HStack(spacing: Spacing.small) {
-            Image(systemName: systemImage)
-                .font(.body)
-                .frame(width: 20)
-
-            Text(title)
-                .lineLimit(1)
-
-            Spacer(minLength: 0)
-
-            Text(subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        }
-        .font(.callout)
-        .padding(.horizontal, Spacing.medium)
-        .padding(.vertical, Spacing.small)
-    }
-
-    private func sourceRow(
-        title: String,
-        subtitle: String,
-        systemImage: String,
-        isSelected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            HStack(spacing: Spacing.small) {
-                Image(systemName: systemImage)
-                    .font(.body)
-                    .frame(width: 20)
-
-                Text(title)
-                    .lineLimit(1)
-
-                Spacer(minLength: 0)
-
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(isSelected ? .white.opacity(0.86) : .secondary)
-                    .lineLimit(1)
-            }
-            .font(.callout)
-            .foregroundStyle(isSelected ? .white : .primary)
-            .padding(.horizontal, Spacing.medium)
-            .padding(.vertical, Spacing.small)
-            .background(isSelected ? Color.accentColor : Color.clear, in: .rect(cornerRadius: CornerRadius.small))
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var stageBar: some View {
-        HStack(spacing: Spacing.large) {
-#if os(macOS)
-            Picker("Workspace", selection: $selectedWorkspace) {
-                ForEach(StudioWorkspace.allCases) { workspace in
-                    Label(workspace.title, systemImage: workspace.icon)
-                        .tag(workspace)
-                }
-            }
-            .pickerStyle(.menu)
-            .labelsHidden()
-            .frame(width: 220)
-
-            if selectedWorkspace == .promptTesting {
-                Button(
-                    "Run selected prompt variants",
-                    systemImage: isRunningPromptTests ? "hourglass" : "play.fill",
-                    action: runPromptTests
-                )
-                .labelStyle(.iconOnly)
-                .font(.title3)
-                .frame(width: 34, height: 34)
-                .buttonStyle(.borderless)
-                .disabled(isRunningPromptTests || !canRunPromptTests)
-                .help("Run selected prompt variants")
-            }
 #endif
-
-            Picker("Stage", selection: $selectedStage) {
-                ForEach(StudioPipelineStage.allCases) { stage in
-                    Label(stage.title, systemImage: stage.systemImage)
-                        .tag(stage)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .frame(maxWidth: 560)
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, Spacing.xLarge)
-        .padding(.vertical, Spacing.small)
-        .background(.bar)
-    }
-
-    private var compactStageBar: some View {
-        HStack(spacing: Spacing.xSmall) {
-            ForEach(StudioPipelineStage.allCases) { stage in
-                Button {
-                    selectedStage = stage
-                } label: {
-                    Text(stage.title)
-                        .font(.caption.weight(.semibold))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.78)
-                        .frame(maxWidth: .infinity, minHeight: 32)
-                        .foregroundStyle(selectedStage == stage ? .white : .primary)
-                        .background(
-                            selectedStage == stage ? Color.accentColor : Color.secondaryBackgroundColor,
-                            in: .capsule
-                        )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(.horizontal, Spacing.medium)
-        .padding(.vertical, Spacing.small)
-        .background(.bar)
-    }
-
-    private var mainWorkspace: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.xLarge) {
-                workspaceHeader
-                stageContent
-            }
-            .padding(.horizontal, 34)
-            .padding(.vertical, Spacing.xLarge)
-            .frame(maxWidth: 960, alignment: .leading)
-        }
-        .background(.background)
-    }
-
-    private var workspaceHeader: some View {
-        VStack(alignment: .leading, spacing: Spacing.xSmall) {
-            Text(selectedWorkspace.title)
-                .font(.title.bold())
-
-            Text(selectedWorkspace.subtitle)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
     }
 
     @ViewBuilder
@@ -372,41 +79,22 @@ struct StudioView: View {
             adapterStudioContent
         } else if selectedWorkspace == .benchmarkRuns {
             AppBenchStudioContent(stage: selectedStage)
+        } else if selectedWorkspace == .structuredOutput || selectedWorkspace == .capabilityMatrix {
+            ContentUnavailableView(
+                selectedWorkspace.title,
+                systemImage: selectedWorkspace.icon,
+                description: Text("This workspace is planned for a future Foundation Lab update.")
+            )
+            .frame(maxWidth: .infinity, minHeight: 320)
         } else {
-            switch selectedStage {
-            case .settings:
-                promptSettingsContent
-            case .runs:
-                runsContent
-            case .evaluation:
-                evaluationContent
-            case .preview:
-                previewContent
-            case .output:
-                outputContent
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var compactStageContent: some View {
-        if selectedWorkspace == .adapterComparison {
-            adapterStudioContent
-        } else if selectedWorkspace == .benchmarkRuns {
-            AppBenchStudioContent(stage: selectedStage)
-        } else {
-            switch selectedStage {
-            case .settings:
-                compactPromptSettingsContent
-            case .runs:
-                runsContent
-            case .evaluation:
-                evaluationContent
-            case .preview:
-                previewContent
-            case .output:
-                outputContent
-            }
+            StudioPromptStageView(
+                stage: $selectedStage,
+                promptText: $promptText,
+                selectedVariants: $selectedPromptVariants,
+                runs: promptRuns,
+                isRunning: isRunningPromptTests,
+                errorMessage: promptTestError
+            )
         }
     }
 
@@ -422,638 +110,19 @@ struct StudioView: View {
 #endif
     }
 
-    private var promptSettingsContent: some View {
-        VStack(alignment: .leading, spacing: Spacing.xLarge) {
-            settingsPanel(title: "Data") {
-                HStack(alignment: .top, spacing: Spacing.large) {
-                    promptDataSlot(
-                        title: "Base Prompt",
-                        systemImage: "text.quote",
-                        isEnabled: true
-                    ) {
-                        TextEditor(text: $promptText)
-                            .font(.body)
-                            .frame(minHeight: 140)
-                            .scrollContentBackground(.hidden)
-                            .padding(Spacing.small)
-                            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
-                    }
-
-                    promptDataSlot(
-                        title: "Variants",
-                        systemImage: "square.stack.3d.up",
-                        isEnabled: !selectedPromptVariants.isEmpty
-                    ) {
-                        VStack(alignment: .leading, spacing: Spacing.small) {
-                            ForEach(StudioPromptVariant.allCases) { variant in
-                                Toggle(isOn: variantBinding(for: variant)) {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(variant.title)
-                                            .font(.callout)
-                                        Text(variant.subtitle)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            settingsPanel(title: "Parameters") {
-                VStack(spacing: 0) {
-                    parameterRow(title: "Execution", value: "Sequential local runs")
-                    parameterRow(title: "Selected Variants", value: "\(selectedPromptVariants.count)")
-                    parameterRow(title: "Prompt Characters", value: "\(promptText.count)")
-                    parameterRow(title: "Result Capture", value: "Output, latency, token count")
-                }
-            }
-
-            if let promptTestError {
-                Label(promptTestError, systemImage: "exclamationmark.triangle.fill")
-                    .font(.callout)
-                    .foregroundStyle(.red)
-            }
-        }
-    }
-
-    private var compactPromptSettingsContent: some View {
-        VStack(alignment: .leading, spacing: Spacing.large) {
-            compactPanel(title: "Base Prompt", systemImage: "text.quote") {
-                TextEditor(text: $promptText)
-                    .font(.body)
-                    .frame(minHeight: 180)
-                    .scrollContentBackground(.hidden)
-                    .padding(Spacing.small)
-                    .background(.background, in: .rect(cornerRadius: CornerRadius.small))
-            }
-
-            compactPanel(title: "Variants", systemImage: "square.stack.3d.up") {
-                VStack(spacing: 0) {
-                    ForEach(StudioPromptVariant.allCases) { variant in
-                        Toggle(isOn: variantBinding(for: variant)) {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(variant.title)
-                                    .font(.callout.weight(.semibold))
-
-                                Text(variant.subtitle)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                        }
-                        .padding(.vertical, Spacing.medium)
-
-                        if variant != StudioPromptVariant.allCases.last {
-                            Divider()
-                        }
-                    }
-                }
-            }
-
-            compactPanel(title: "Run Configuration", systemImage: "slider.horizontal.3") {
-                VStack(spacing: 0) {
-                    compactParameterRow(title: "Execution", value: "Sequential")
-                    compactParameterRow(title: "Variants", value: "\(selectedPromptVariants.count)")
-                    compactParameterRow(title: "Prompt", value: "\(promptText.count) characters")
-                    compactParameterRow(title: "Capture", value: "Output, latency, tokens")
-                }
-            }
-
-            if let promptTestError {
-                Label(promptTestError, systemImage: "exclamationmark.triangle.fill")
-                    .font(.callout)
-                    .foregroundStyle(.red)
-            }
-        }
-    }
-
-    private func compactPanel<Content: View>(
-        title: String,
-        systemImage: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            Label(title, systemImage: systemImage)
-                .font(.headline)
-
-            content()
-        }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
-    }
-
-    private func compactParameterRow(title: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(title)
-                .font(.callout.weight(.medium))
-
-            Spacer(minLength: Spacing.medium)
-
-            Text(value)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.trailing)
-        }
-        .padding(.vertical, Spacing.small)
-    }
-
-    private func settingsPanel<Content: View>(
-        title: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.large) {
-            Text(title)
-                .font(.title3.bold())
-
-            content()
-        }
-    }
-
-    private func promptDataSlot<Content: View>(
-        title: String,
-        systemImage: String,
-        isEnabled: Bool,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            HStack {
-                Label(title, systemImage: systemImage)
-                    .font(.headline)
-                    .foregroundStyle(isEnabled ? .primary : .secondary)
-
-                Spacer(minLength: 0)
-
-                Image(systemName: "questionmark.circle")
-                    .foregroundStyle(.tertiary)
-            }
-            .padding(.horizontal, Spacing.medium)
-            .padding(.vertical, Spacing.small)
-            .background(Color.tertiaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.large))
-
-            content()
-
-            Spacer(minLength: 0)
-        }
-        .padding()
-        .frame(maxWidth: .infinity, minHeight: 260, alignment: .topLeading)
-        .overlay {
-            RoundedRectangle(cornerRadius: CornerRadius.large)
-                .stroke(.quaternary, lineWidth: 1)
-        }
-    }
-
-    private func parameterRow(title: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(title)
-                .font(.callout.weight(.medium))
-                .frame(width: 170, alignment: .trailing)
-
-            Text(value)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, Spacing.large)
-        .padding(.vertical, Spacing.medium)
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
-    }
-
-    private var runsContent: some View {
-        Group {
-            if promptRuns.isEmpty, isRunningPromptTests {
-                runningPromptState
-            } else if promptRuns.isEmpty {
-                unavailableState(
-                    title: "Prompt runs unavailable",
-                    subtitle: "Set up the prompt source and run selected variants to view run progress."
-                )
-            } else {
-                VStack(alignment: .leading, spacing: Spacing.small) {
-                    ForEach(promptRuns) { run in
-                        runRow(run)
-                        Divider()
-                    }
-                }
-            }
-        }
-    }
-
-    private var runningPromptState: some View {
-        VStack(spacing: Spacing.medium) {
-            Spacer(minLength: 120)
-
-            ProgressView()
-                .controlSize(.large)
-
-            Text("Running selected variants")
-                .font(.headline)
-
-            Text("Results will appear here as soon as the first prompt run finishes.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-
-            Spacer(minLength: 120)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private func runRow(_ run: StudioPromptRun) -> some View {
-        Button {
-            selectedPromptRun = run
-        } label: {
-            HStack(alignment: .top, spacing: Spacing.large) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(run.variant.title)
-                        .font(.headline)
-                    Text(run.finishedAt, style: .time)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(width: 150, alignment: .leading)
-
-                Text(run.output)
-                    .font(.callout)
-                    .foregroundStyle(.primary)
-                    .lineLimit(3)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VStack(alignment: .trailing, spacing: 3) {
-                    Text(run.durationLabel)
-                        .font(.headline.monospacedDigit())
-                    Text(run.tokenLabel)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(width: 100, alignment: .trailing)
-            }
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        .padding(.vertical, Spacing.small)
-        .help("Show full prompt run")
-        .popover(
-            isPresented: Binding(
-                get: { selectedPromptRun?.id == run.id },
-                set: { isPresented in
-                    if !isPresented, selectedPromptRun?.id == run.id {
-                        selectedPromptRun = nil
-                    }
-                }
-            ),
-            arrowEdge: .trailing
-        ) {
-            runDetailPopover(run)
-                .presentationCompactAdaptation(.popover)
-        }
-    }
-
-    private func runDetailPopover(_ run: StudioPromptRun) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(run.variant.title)
-                        .font(.headline)
-                    Text(run.finishedAt, style: .time)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text(run.durationLabel)
-                        .font(.headline.monospacedDigit())
-                    Text(run.tokenLabel)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text("Prompt")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Text(run.prompt)
-                    .font(.callout)
-                    .textSelection(.enabled)
-            }
-
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text("Output")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                ScrollView {
-                    Text(run.output)
-                        .font(.body)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(maxHeight: 260)
-            }
-        }
-        .padding()
-        .frame(width: 420)
-    }
-
-    private var evaluationContent: some View {
-        Group {
-            if promptRuns.isEmpty {
-                unavailableState(
-                    title: "Evaluation unavailable",
-                    subtitle: "Run at least one variant to compare latency, tokens, and answer shape."
-                )
-            } else {
-                VStack(alignment: .leading, spacing: Spacing.large) {
-                    settingsPanel(title: "Comparison") {
-                        VStack(spacing: 0) {
-                            ForEach(promptRuns) { run in
-                                parameterRow(title: run.variant.title, value: "\(run.durationLabel) • \(run.tokenLabel)")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private var previewContent: some View {
-        Group {
-            if let latestRun = latestFinishedRun {
-                VStack(alignment: .leading, spacing: Spacing.medium) {
-                    Text(latestRun.variant.title)
-                        .font(.title3.bold())
-                    Text(latestRun.output)
-                        .font(.body)
-                        .textSelection(.enabled)
-                }
-            } else {
-                unavailableState(
-                    title: "Preview unavailable",
-                    subtitle: "Run a prompt variant to preview the most recent generated output."
-                )
-            }
-        }
-    }
-
-    private var outputContent: some View {
-        VStack(alignment: .leading, spacing: Spacing.large) {
-            settingsPanel(title: "Run Artifact") {
-                VStack(spacing: 0) {
-                    parameterRow(title: "Format", value: "Studio run summary")
-                    parameterRow(title: "Runs", value: "\(promptRuns.count)")
-                    parameterRow(title: "Status", value: promptRuns.isEmpty ? "No exportable runs" : "Ready")
-                }
-            }
-
-            Button {
-                selectedStage = .runs
-            } label: {
-                Label("Review Runs", systemImage: "doc.text.magnifyingglass")
-            }
-            .disabled(promptRuns.isEmpty)
-        }
-    }
-
-    private func unavailableState(title: String, subtitle: String) -> some View {
-        VStack(spacing: Spacing.medium) {
-            Spacer(minLength: 120)
-
-            Text(title)
-                .font(.headline)
-                .foregroundStyle(.secondary)
-
-            Text(subtitle)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-
-            Spacer(minLength: 120)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var activityInspector: some View {
-        VStack(spacing: 0) {
-            activityInspectorContent
-            Spacer(minLength: 0)
-        }
-        .background(Color.secondaryBackgroundColor.opacity(0.45))
-    }
-
-    @ViewBuilder
-    private var activityInspectorContent: some View {
-        if selectedWorkspace == .adapterComparison {
-            AdapterStudioInspector()
-        } else if selectedWorkspace == .benchmarkRuns {
-            AppBenchStudioInspector()
-        } else {
-            VStack(alignment: .leading, spacing: Spacing.large) {
-                inspectorMetrics
-
-                VStack(alignment: .leading, spacing: Spacing.small) {
-                    HStack {
-                        Text("Activity")
-                            .font(.headline)
-                        Spacer()
-                        Text(Date.now, style: .date)
-                            .font(.callout.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    }
-
-                    ForEach(activityEvents) { event in
-                        VStack(alignment: .leading, spacing: 2) {
-                            HStack(alignment: .firstTextBaseline) {
-                                Text(event.title)
-                                    .font(.callout)
-                                Spacer()
-                                Text(event.date, style: .time)
-                                    .font(.callout)
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            Text(event.detail)
-                                .font(.callout.weight(.semibold))
-                        }
-                        .padding(.vertical, Spacing.small)
-
-                        Divider()
-                    }
-                }
-            }
-            .padding(Spacing.large)
-        }
-    }
-
-    private var inspectorMetrics: some View {
-        HStack(spacing: 0) {
-            inspectorMetric(value: "\(promptRuns.count)", title: "Runs")
-            Divider()
-            inspectorMetric(value: averageDurationLabel, title: "Average")
-            Divider()
-            inspectorMetric(value: "\(selectedPromptVariants.count)", title: "Variants")
-        }
-        .frame(height: 52)
-    }
-
-    private func inspectorMetric(value: String, title: String) -> some View {
-        VStack(spacing: 2) {
-            Text(value)
-                .font(.headline.monospacedDigit())
-                .lineLimit(1)
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var compactWorkspacePicker: some View {
-        VStack(alignment: .leading, spacing: Spacing.xSmall) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Workspace")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                Spacer(minLength: Spacing.medium)
-
-                Menu {
-                    Picker("Workspace", selection: $selectedWorkspace) {
-                        ForEach(StudioWorkspace.allCases) { workspace in
-                            Label(workspace.title, systemImage: workspace.icon)
-                                .tag(workspace)
-                        }
-                    }
-                } label: {
-                    HStack(spacing: Spacing.xSmall) {
-                        Text(selectedWorkspace.title)
-                        Image(systemName: "chevron.up.chevron.down")
-                            .font(.caption2.weight(.semibold))
-                    }
-                    .font(.callout.weight(.medium))
-                }
-                .buttonStyle(.plain)
-            }
-
-            Text(selectedWorkspace.subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var statusBar: some View {
-        HStack(spacing: Spacing.small) {
-            Image(systemName: statusIcon)
-                .foregroundStyle(statusColor)
-
-            Text(statusText)
-                .font(.callout.weight(.medium))
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, Spacing.medium)
-        .padding(.vertical, Spacing.xSmall)
-        .background(.bar)
+    private var studioInspector: some View {
+        StudioActivityInspector(
+            workspace: selectedWorkspace,
+            promptRuns: promptRuns,
+            selectedVariantCount: selectedPromptVariants.count,
+            createdAt: studioCreatedAt
+        )
     }
 
     private var canRunPromptTests: Bool {
         selectedWorkspace == .promptTesting &&
         !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !selectedPromptVariants.isEmpty
-    }
-
-    private var averageDurationLabel: String {
-        guard !promptRuns.isEmpty else { return "--" }
-        let totalDuration = promptRuns.reduce(0) { $0 + $1.duration }
-        return (totalDuration / Double(promptRuns.count)).formatted(.number.precision(.fractionLength(2))) + "s"
-    }
-
-    private var latestFinishedRun: StudioPromptRun? {
-        promptRuns.max { $0.finishedAt < $1.finishedAt }
-    }
-
-    private var activityEvents: [StudioActivityEvent] {
-        if promptRuns.isEmpty {
-            return [
-                StudioActivityEvent(
-                    id: "studio-created",
-                    title: "Studio Created",
-                    detail: "Local Evaluation Studio",
-                    date: studioCreatedAt
-                )
-            ]
-        }
-
-        return promptRuns.prefix(6).map {
-            StudioActivityEvent(
-                id: $0.id.uuidString,
-                title: "Prompt Variant Completed",
-                detail: $0.variant.title,
-                date: $0.finishedAt
-            )
-        }
-    }
-
-    private var statusIcon: String {
-        if selectedWorkspace == .adapterComparison { return "shippingbox.fill" }
-        if selectedWorkspace == .benchmarkRuns { return "checkmark.circle.fill" }
-        if isRunningPromptTests { return "hourglass" }
-        if promptRuns.isEmpty { return "info.circle.fill" }
-        return "checkmark.circle.fill"
-    }
-
-    private var statusColor: Color {
-        if selectedWorkspace == .adapterComparison { return .blue }
-        if selectedWorkspace == .benchmarkRuns { return .green }
-        if isRunningPromptTests { return .orange }
-        if promptRuns.isEmpty { return .secondary }
-        return .green
-    }
-
-    private var statusText: String {
-        if selectedWorkspace == .adapterComparison {
-#if os(macOS)
-            return "Adapter comparison is available locally on this Mac"
-#else
-            return "Adapter comparison requires Foundation Lab for macOS"
-#endif
-        }
-        if selectedWorkspace == .benchmarkRuns {
-            return "AppBench is available through the Mac CLI and physical-device runner"
-        }
-        if isRunningPromptTests { return "Running selected prompt variants" }
-        if promptRuns.isEmpty { return "Prompt run required" }
-        return "\(promptRuns.count) prompt runs completed"
-    }
-
-    private func variantBinding(for variant: StudioPromptVariant) -> Binding<Bool> {
-        Binding {
-            selectedPromptVariants.contains(variant)
-        } set: { isSelected in
-            if isSelected {
-                selectedPromptVariants.insert(variant)
-            } else {
-                selectedPromptVariants.remove(variant)
-            }
-        }
-    }
-
-    private func togglePromptVariant(_ variant: StudioPromptVariant) {
-        if selectedPromptVariants.contains(variant) {
-            selectedPromptVariants.remove(variant)
-        } else {
-            selectedPromptVariants.insert(variant)
-        }
     }
 
     private func runPromptTests() {
@@ -1083,7 +152,7 @@ struct StudioView: View {
 
         do {
             for variant in variants {
-                let startedAt = Date()
+                let startedAt = Date.now
                 let result = try await generateTextUseCase.execute(
                     TextGenerationRequest(
                         prompt: trimmedPrompt,
@@ -1101,9 +170,9 @@ struct StudioView: View {
                         variant: variant,
                         prompt: trimmedPrompt,
                         output: result.content,
-                        duration: Date().timeIntervalSince(startedAt),
+                        duration: Date.now.timeIntervalSince(startedAt),
                         tokenCount: result.metadata.tokenCount,
-                        finishedAt: Date()
+                        finishedAt: Date.now
                     )
                 )
             }

--- a/Foundation Lab/Views/StudioView.swift
+++ b/Foundation Lab/Views/StudioView.swift
@@ -18,7 +18,7 @@ struct StudioView: View {
     @State private var promptTestError: String?
     @State private var studioCreatedAt = Date.now
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @State private var isShowingInspector = false
 #endif
 
@@ -43,7 +43,7 @@ struct StudioView: View {
         .navigationBarTitleDisplayMode(.inline)
 #endif
         .toolbar {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             if selectedWorkspace == .promptTesting {
                 ToolbarItem(placement: .primaryAction) {
                     Button(
@@ -56,13 +56,13 @@ struct StudioView: View {
             }
 
             ToolbarItem(placement: .secondaryAction) {
-                Button("Studio Details", systemImage: "sidebar.trailing") {
+                Button("More Options", systemImage: "sidebar.trailing") {
                     isShowingInspector.toggle()
                 }
             }
 #endif
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .inspector(isPresented: $isShowingInspector) {
             ScrollView {
                 studioInspector
@@ -82,7 +82,7 @@ struct StudioView: View {
             ContentUnavailableView(
                 selectedWorkspace.title,
                 systemImage: selectedWorkspace.icon,
-                description: Text("This workspace is planned for a future Foundation Lab update.")
+                description: Text(selectedWorkspace.subtitle)
             )
             .frame(maxWidth: .infinity, minHeight: 320)
         } else {

--- a/Foundation Lab/Views/StudioWorkbenchView.swift
+++ b/Foundation Lab/Views/StudioWorkbenchView.swift
@@ -1,0 +1,161 @@
+//
+//  StudioWorkbenchView.swift
+//  Foundation Lab
+//
+
+import SwiftUI
+
+struct StudioWorkbenchView<Content: View, Inspector: View>: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    @Binding var workspace: StudioWorkspace
+    @Binding var stage: StudioPipelineStage
+    @Binding var selectedPromptVariants: Set<StudioPromptVariant>
+
+    let isRunning: Bool
+    let canRun: Bool
+    let run: () -> Void
+    let content: Content
+    let inspector: Inspector
+
+    var body: some View {
+        if horizontalSizeClass == .compact {
+            compactLayout
+        } else {
+            workbenchLayout
+        }
+    }
+
+    private var workbenchLayout: some View {
+        Group {
+#if os(macOS)
+            ViewThatFits(in: .horizontal) {
+                HSplitView {
+                    primaryColumn
+                        .frame(minWidth: 600, idealWidth: 820, maxWidth: .infinity, maxHeight: .infinity)
+                        .layoutPriority(1)
+
+                    inspectorColumn
+                        .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
+                }
+
+                narrowLayout
+            }
+#else
+            HStack(spacing: 0) {
+                StudioSourceList(
+                    selectedWorkspace: $workspace,
+                    selectedPromptVariants: $selectedPromptVariants
+                )
+                .frame(width: 240)
+
+                Divider()
+
+                primaryColumn
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+#endif
+        }
+    }
+
+    private var primaryColumn: some View {
+        VStack(spacing: 0) {
+            stageBar(isCompact: false)
+            Divider()
+            mainWorkspace
+        }
+    }
+
+    private var narrowLayout: some View {
+        VStack(spacing: 0) {
+            stageBar(isCompact: false)
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.large) {
+                    workspaceHeader
+                    content
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var compactLayout: some View {
+        VStack(spacing: 0) {
+            stageBar(isCompact: true)
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.large) {
+                    compactWorkspacePicker
+                    content
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var mainWorkspace: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.xLarge) {
+                workspaceHeader
+                content
+            }
+            .padding(.horizontal, Spacing.xxLarge)
+            .padding(.vertical, Spacing.xLarge)
+            .frame(maxWidth: 960, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var workspaceHeader: some View {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            Text(workspace.title)
+                .font(.title2.bold())
+
+            Text(workspace.subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var compactWorkspacePicker: some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            Picker("Workspace", selection: $workspace) {
+                ForEach(StudioWorkspace.allCases) { workspace in
+                    Label(workspace.title, systemImage: workspace.icon)
+                        .tag(workspace)
+                }
+            }
+            .pickerStyle(.menu)
+
+            Text(workspace.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var inspectorColumn: some View {
+        VStack(spacing: 0) {
+            inspector
+            Spacer(minLength: 0)
+        }
+        .background(.background)
+    }
+
+    private func stageBar(isCompact: Bool) -> some View {
+        StudioStageBar(
+            workspace: $workspace,
+            stage: $stage,
+            isCompact: isCompact,
+            isRunning: isRunning,
+            canRun: canRun,
+            run: run
+        )
+    }
+}

--- a/Foundation Lab/Views/StudioWorkbenchView.swift
+++ b/Foundation Lab/Views/StudioWorkbenchView.swift
@@ -10,7 +10,6 @@ struct StudioWorkbenchView<Content: View, Inspector: View>: View {
 
     @Binding var workspace: StudioWorkspace
     @Binding var stage: StudioPipelineStage
-    @Binding var selectedPromptVariants: Set<StudioPromptVariant>
 
     let isRunning: Bool
     let canRun: Bool
@@ -43,10 +42,7 @@ struct StudioWorkbenchView<Content: View, Inspector: View>: View {
             }
 #else
             HStack(spacing: 0) {
-                StudioSourceList(
-                    selectedWorkspace: $workspace,
-                    selectedPromptVariants: $selectedPromptVariants
-                )
+                StudioSourceList(selectedWorkspace: $workspace)
                 .frame(width: 240)
 
                 Divider()


### PR DESCRIPTION
## What

- Rebuilds Studio around native source lists, stage pickers, inspectors, rows, and dividers.
- Extracts the monolithic Studio view into focused workbench, stage, settings, run-detail, source-list, and inspector views.
- Applies the same hierarchy to Adapter Studio and AppBench.
- Preserves prompt execution, variant selection, run history, adapter import, and benchmark guidance.
- Keeps the inspector reachable on iOS and visionOS and anchors run details to the selected row.

## Why

Studio had become a nested panel-and-card dashboard with duplicated controls. The new structure follows Apple workbench conventions and makes the active workspace, stage, content, and secondary detail visually distinct.

## Impact

UI architecture and accessibility only; generation and adapter execution paths are unchanged.

## Validation

- Strict SwiftLint: 0 violations across 19 changed Swift files
- Swift parser: passed, including the active visionOS compilation branch
- Diff check and independent cross-review: passed
- Xcode 26.5 build reaches only pre-existing Xcode 27 API failures in `VideoSegment` and `GeminiDeveloperVideoLanguageModel`
- A visionOS runtime is not installed locally, so simulator execution remains pending.