### PR TITLE
[codex] Avoid blocking audio session work on main actor

### DIFF
--- a/Foundation Lab/Voice/Services/SpeechSynthesizer.swift
+++ b/Foundation Lab/Voice/Services/SpeechSynthesizer.swift
@@ -85,6 +85,7 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
     private let synthesizer = AVSpeechSynthesizer()
     private var currentUtterance: AVSpeechUtterance?
     private var pendingContinuation: CheckedContinuation<Void, Error>?
+    private var isSynthesisInFlight = false
     var speakingStateHandler: ((Bool) -> Void)?
     var errorHandler: ((SpeechSynthesizerError) -> Void)?
 
@@ -109,7 +110,7 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
             throw SpeechSynthesizerError.invalidInput
         }
 
-        guard !isSpeaking else {
+        guard !isSpeaking, !isSynthesisInFlight else {
             throw SpeechSynthesizerError.alreadySpeaking
         }
 
@@ -119,7 +120,11 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
             throw SpeechSynthesizerError.alreadySpeaking
         }
 
+        isSynthesisInFlight = true
+        defer { isSynthesisInFlight = false }
+
         await configurePlaybackSession()
+        try Task.checkCancellation()
 
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             self.pendingContinuation = continuation

--- a/Foundation Lab/Voice/Services/SpeechSynthesizer.swift
+++ b/Foundation Lab/Voice/Services/SpeechSynthesizer.swift
@@ -84,7 +84,6 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
     private let logger = VoiceLogging.synthesis
     private let synthesizer = AVSpeechSynthesizer()
     private var currentUtterance: AVSpeechUtterance?
-    private var audioSessionConfigured = false
     private var pendingContinuation: CheckedContinuation<Void, Error>?
     var speakingStateHandler: ((Bool) -> Void)?
     var errorHandler: ((SpeechSynthesizerError) -> Void)?
@@ -101,7 +100,6 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
         super.init()
 
         synthesizer.delegate = self
-        setupAudioSession()
         loadAvailableVoices()
         preWarmSynthesizer()
     }
@@ -121,6 +119,8 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
             throw SpeechSynthesizerError.alreadySpeaking
         }
 
+        await configurePlaybackSession()
+
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             self.pendingContinuation = continuation
 
@@ -129,29 +129,40 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
         }
     }
 
-    private func setupAudioSession() {
-        configurePlaybackSession()
-    }
-
     private func preWarmSynthesizer() {
         // Don't pre-warm automatically - it can cause audio engine conflicts
         // We'll initialize on first use instead
         logger.debug("Speech synthesizer ready for first use")
     }
 
-    private func configurePlaybackSession() {
+    private func configurePlaybackSession() async {
         #if os(iOS)
         do {
-            let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.playback, mode: .default, options: [.duckOthers])
-            try audioSession.setActive(true, options: [])
-            audioSessionConfigured = true
+            try await Self.activatePlaybackSession()
             logger.debug("Configured audio session for speech synthesis playback")
         } catch {
             logger.error("Failed to configure audio session for playback: \(error.localizedDescription, privacy: .public)")
         }
         #endif
     }
+
+    #if os(iOS)
+    /// `setActive` is synchronous, so keep it off the main actor to avoid blocking UI work.
+    private nonisolated static func activatePlaybackSession() async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .default, options: [.duckOthers])
+            try audioSession.setActive(true, options: [])
+        }.value
+    }
+
+    private nonisolated static func deactivatePlaybackSession() async throws {
+        try await Task.detached(priority: .utility) {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        }.value
+    }
+    #endif
 
     func loadAvailableVoices() {
         Task { @MainActor in
@@ -219,8 +230,7 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
         #if os(iOS)
         Task { @MainActor in
             do {
-                let audioSession = AVAudioSession.sharedInstance()
-                try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+                try await Self.deactivatePlaybackSession()
                 logger.debug("Deactivated audio session after speech synthesis")
             } catch {
                 logger.error("Failed to deactivate audio session: \(error.localizedDescription, privacy: .public)")
@@ -244,8 +254,7 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
 #if os(iOS)
         Task { @MainActor in
             do {
-                let audioSession = AVAudioSession.sharedInstance()
-                try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+                try await Self.deactivatePlaybackSession()
                 logger.debug("Deactivated audio session after speech synthesis error")
             } catch {
                 logger.error("Failed to deactivate audio session after error: \(error.localizedDescription, privacy: .public)")

--- a/Foundation Lab/Voice/Services/SpeechSynthesizer.swift
+++ b/Foundation Lab/Voice/Services/SpeechSynthesizer.swift
@@ -123,8 +123,13 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
         isSynthesisInFlight = true
         defer { isSynthesisInFlight = false }
 
-        await configurePlaybackSession()
-        try Task.checkCancellation()
+        let playbackSessionWasActivated = await configurePlaybackSession()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await deactivatePlaybackSessionAfterCancelledStartup(ifActivated: playbackSessionWasActivated)
+            throw error
+        }
 
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             self.pendingContinuation = continuation
@@ -140,13 +145,30 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesisService {
         logger.debug("Speech synthesizer ready for first use")
     }
 
-    private func configurePlaybackSession() async {
+    private func configurePlaybackSession() async -> Bool {
         #if os(iOS)
         do {
             try await Self.activatePlaybackSession()
             logger.debug("Configured audio session for speech synthesis playback")
+            return true
         } catch {
             logger.error("Failed to configure audio session for playback: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+        #else
+        return false
+        #endif
+    }
+
+    private func deactivatePlaybackSessionAfterCancelledStartup(ifActivated: Bool) async {
+        #if os(iOS)
+        guard ifActivated else { return }
+
+        do {
+            try await Self.deactivatePlaybackSession()
+            logger.debug("Deactivated audio session after cancelled speech startup")
+        } catch {
+            logger.error("Failed to deactivate audio session after cancelled startup: \(error.localizedDescription, privacy: .public)")
         }
         #endif
     }


### PR DESCRIPTION
## What changed

- configure the playback audio session immediately before synthesis instead of during the main-actor initializer
- run synchronous `AVAudioSession.setActive` activation and deactivation work outside the main actor
- use the same nonblocking path after successful, failed, or cancelled synthesis

## Why

`AVAudioSession.setActive` is synchronous and could block the main thread, producing an `AVAudioSession_iOS` UI-unresponsiveness warning during speech synthesizer initialization.

## Impact

Speech synthesis retains the existing behavior while avoiding synchronous audio-session activation on the UI thread.

## Validation

- `git diff --check`
- full generic iOS Simulator build passed with Xcode 27.0 beta (`27A5194q`): `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project FoundationLab.xcodeproj -scheme 'Foundation Lab' -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
