### PR TITLE
[codex] Clarify transcript context budgeting

### DIFF
--- a/Foundation Lab/Views/Examples/Components/ExampleViewBase.swift
+++ b/Foundation Lab/Views/Examples/Components/ExampleViewBase.swift
@@ -16,6 +16,7 @@ struct ExampleViewBase<Content: View>: View {
   let isRunning: Bool
   let errorMessage: String?
   let codeExample: String?
+  let runLabel: String
   let onRun: () -> Void
   let onReset: () -> Void
   let content: Content
@@ -28,6 +29,7 @@ struct ExampleViewBase<Content: View>: View {
     isRunning: Bool = false,
     errorMessage: String? = nil,
     codeExample: String? = nil,
+    runLabel: String = "Run",
     onRun: @escaping () -> Void,
     onReset: @escaping () -> Void,
     @ViewBuilder content: () -> Content
@@ -39,6 +41,7 @@ struct ExampleViewBase<Content: View>: View {
     self.isRunning = isRunning
     self.errorMessage = errorMessage
     self.codeExample = codeExample
+    self.runLabel = runLabel
     self.onRun = onRun
     self.onReset = onReset
     self.content = content()
@@ -116,7 +119,7 @@ struct ExampleViewBase<Content: View>: View {
               .scaleEffect(0.8)
               .tint(.white)
           }
-          Text(isRunning ? "Running..." : "Run")
+          Text(isRunning ? "Running..." : runLabel)
             .font(.callout)
             .fontWeight(.medium)
         }

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetEntryRow.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetEntryRow.swift
@@ -1,0 +1,51 @@
+//
+//  ContextBudgetEntryRow.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct ContextBudgetEntryRow: View {
+    let entry: ContextBudgetSimulation.Entry
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.medium) {
+            Image(systemName: entry.disposition.systemImage)
+                .foregroundStyle(dispositionColor)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text(entry.title)
+                    .font(.subheadline)
+                    .bold()
+
+                Text("\(entry.kind) · \(entry.disposition.title)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: Spacing.small)
+
+            VStack(alignment: .trailing, spacing: Spacing.xSmall) {
+                Text("\(entry.resultingTokens) tokens")
+                    .font(.footnote.monospacedDigit())
+
+                if entry.originalTokens != entry.resultingTokens {
+                    Text("was \(entry.originalTokens)")
+                        .font(.footnote.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(minHeight: 52)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var dispositionColor: Color {
+        switch entry.disposition {
+        case .kept: .green
+        case .summarized: .orange
+        case .dropped: .secondary
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetEntryRow.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetEntryRow.swift
@@ -27,11 +27,19 @@ struct ContextBudgetEntryRow: View {
             Spacer(minLength: Spacing.small)
 
             VStack(alignment: .trailing, spacing: Spacing.xSmall) {
-                Text("\(entry.resultingTokens) tokens")
-                    .font(.footnote.monospacedDigit())
+                if let resultingTokens = entry.resultingTokens {
+                    Text("\(resultingTokens) tokens")
+                        .font(.footnote.monospacedDigit())
+                } else {
+                    Text("Not measured")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
 
-                if entry.originalTokens != entry.resultingTokens {
-                    Text("was \(entry.originalTokens)")
+                if let originalTokens = entry.originalTokens,
+                   let resultingTokens = entry.resultingTokens,
+                   originalTokens != resultingTokens {
+                    Text("was \(originalTokens)")
                         .font(.footnote.monospacedDigit())
                         .foregroundStyle(.secondary)
                 }

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetPolicy.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetPolicy.swift
@@ -1,0 +1,41 @@
+//
+//  ContextBudgetPolicy.swift
+//  FoundationLab
+//
+
+import Foundation
+
+enum ContextBudgetPolicy: String, CaseIterable, Identifiable {
+    case preserveAll
+    case keepRecent
+    case summarizeEarlier
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .preserveAll: "Keep everything"
+        case .keepRecent: "Keep recent turns"
+        case .summarizeEarlier: "Summarize earlier turns"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .preserveAll: "text.document"
+        case .keepRecent: "clock.arrow.circlepath"
+        case .summarizeEarlier: "text.badge.checkmark"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .preserveAll:
+            "Send the transcript unchanged. This is lossless, but it can exceed the model’s context window."
+        case .keepRecent:
+            "Preserve instructions and the newest conversation entries. Older entries are removed by your app."
+        case .summarizeEarlier:
+            "Preserve instructions and recent turns, replacing older history with an app-generated summary."
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetSimulation.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetSimulation.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import FoundationModels
 
 struct ContextBudgetSimulation {
     struct Entry: Identifiable {
@@ -32,38 +33,103 @@ struct ContextBudgetSimulation {
         let id: String
         let title: String
         let kind: String
-        let originalTokens: Int
-        let resultingTokens: Int
+        let originalTokens: Int?
+        let resultingTokens: Int?
         let disposition: Disposition
     }
 
+    struct SourceEntry: Identifiable {
+        let id: String
+        let title: String
+        let kind: String
+        let transcriptEntry: Transcript.Entry
+    }
+
     let contextSize: Int
-    let promptTokens: Int
+    let promptTokens: Int?
+    let historyTokenCounts: [String: Int]?
     let responseReserve: Int
     let policy: ContextBudgetPolicy
 
-    private let sourceEntries = [
-        Entry(
-            id: "instructions", title: "System instructions", kind: "Instructions",
-            originalTokens: 360, resultingTokens: 360, disposition: .kept
+    static let sampleEntries: [SourceEntry] = [
+        SourceEntry(
+            id: "instructions",
+            title: "System instructions",
+            kind: "Instructions",
+            transcriptEntry: .instructions(
+                Transcript.Instructions(
+                    segments: [.text(Transcript.TextSegment(content: longInstructions))],
+                    toolDefinitions: []
+                )
+            )
         ),
-        Entry(
-            id: "old-plan", title: "Early architecture discussion", kind: "Prompt + response",
-            originalTokens: 780, resultingTokens: 780, disposition: .kept
+        SourceEntry(
+            id: "old-plan",
+            title: "Early architecture discussion",
+            kind: "Prompt",
+            transcriptEntry: .prompt(
+                Transcript.Prompt(segments: [.text(Transcript.TextSegment(content: earlyArchitecturePrompt))])
+            )
         ),
-        Entry(
-            id: "draft", title: "Discarded implementation draft", kind: "Prompt + response",
-            originalTokens: 920, resultingTokens: 920, disposition: .kept
+        SourceEntry(
+            id: "draft",
+            title: "Discarded implementation draft",
+            kind: "Response",
+            transcriptEntry: .response(
+                Transcript.Response(
+                    assetIDs: [],
+                    segments: [.text(Transcript.TextSegment(content: discardedDraft))]
+                )
+            )
         ),
-        Entry(
-            id: "tools", title: "Completed research tool output", kind: "Tool calls + output",
-            originalTokens: 1_100, resultingTokens: 1_100, disposition: .kept
+        SourceEntry(
+            id: "tools",
+            title: "Completed research output",
+            kind: "Tool output",
+            transcriptEntry: .toolOutput(
+                Transcript.ToolOutput(
+                    id: "sample-research",
+                    toolName: "documentationSearch",
+                    segments: [.text(Transcript.TextSegment(content: researchOutput))]
+                )
+            )
         ),
-        Entry(
-            id: "latest", title: "Latest decision and constraints", kind: "Prompt + response",
-            originalTokens: 620, resultingTokens: 620, disposition: .kept
+        SourceEntry(
+            id: "latest",
+            title: "Latest decision and constraints",
+            kind: "Prompt",
+            transcriptEntry: .prompt(
+                Transcript.Prompt(segments: [.text(Transcript.TextSegment(content: latestConstraints))])
+            )
         )
     ]
+
+    static let summaryEntry = SourceEntry(
+        id: "summary",
+        title: "Summary of earlier conversation",
+        kind: "App-generated prompt context",
+        transcriptEntry: .prompt(
+            Transcript.Prompt(segments: [.text(Transcript.TextSegment(content: compactedSummary))])
+        )
+    )
+
+    static var entriesToMeasure: [SourceEntry] {
+        sampleEntries + [summaryEntry]
+    }
+
+    private var sourceEntries: [Entry] {
+        Self.sampleEntries.map { source in
+            let tokens = historyTokenCounts?[source.id]
+            return Entry(
+                id: source.id,
+                title: source.title,
+                kind: source.kind,
+                originalTokens: tokens,
+                resultingTokens: tokens,
+                disposition: .kept
+            )
+        }
+    }
 
     var processedEntries: [Entry] {
         switch policy {
@@ -77,7 +143,7 @@ struct ContextBudgetSimulation {
                         title: entry.title,
                         kind: entry.kind,
                         originalTokens: entry.originalTokens,
-                        resultingTokens: 0,
+                        resultingTokens: entry.originalTokens == nil ? nil : 0,
                         disposition: .dropped
                     )
                 }
@@ -87,11 +153,11 @@ struct ContextBudgetSimulation {
             [
                 sourceEntries[0],
                 Entry(
-                    id: "summary",
-                    title: "Summary of earlier conversation",
-                    kind: "App-generated prompt context",
-                    originalTokens: sourceEntries[1...3].map(\.originalTokens).reduce(0, +),
-                    resultingTokens: 320,
+                    id: Self.summaryEntry.id,
+                    title: Self.summaryEntry.title,
+                    kind: Self.summaryEntry.kind,
+                    originalTokens: combinedEarlierTokens,
+                    resultingTokens: historyTokenCounts?[Self.summaryEntry.id],
                     disposition: .summarized
                 ),
                 sourceEntries[4]
@@ -99,49 +165,95 @@ struct ContextBudgetSimulation {
         }
     }
 
-    var historyTokensBeforePolicy: Int {
-        sourceEntries.map(\.originalTokens).reduce(0, +)
+    var historyTokensBeforePolicy: Int? {
+        sum(sourceEntries.map(\.originalTokens))
     }
 
-    var historyTokensAfterPolicy: Int {
-        processedEntries.map(\.resultingTokens).reduce(0, +)
+    var historyTokensAfterPolicy: Int? {
+        sum(processedEntries.map(\.resultingTokens))
     }
 
-    var totalBeforePolicy: Int {
-        historyTokensBeforePolicy + promptTokens + responseReserve
+    var totalBeforePolicy: Int? {
+        guard let historyTokensBeforePolicy, let promptTokens else { return nil }
+        return historyTokensBeforePolicy + promptTokens + responseReserve
     }
 
-    var totalAfterPolicy: Int {
-        historyTokensAfterPolicy + promptTokens + responseReserve
+    var totalAfterPolicy: Int? {
+        guard let historyTokensAfterPolicy, let promptTokens else { return nil }
+        return historyTokensAfterPolicy + promptTokens + responseReserve
     }
 
     var budgetEquation: String {
-        "\(historyTokensAfterPolicy) history + \(promptTokens) prompt + \(responseReserve) response"
+        guard let historyTokensAfterPolicy, let promptTokens else {
+            return "Waiting for tokenizer"
+        }
+        return "\(historyTokensAfterPolicy) history + \(promptTokens) prompt + \(responseReserve) response"
     }
 
-    var fitsAfterPolicy: Bool {
-        totalAfterPolicy <= contextSize
-    }
-
-    var remainingTokens: Int {
-        max(0, contextSize - totalAfterPolicy)
+    var fitsAfterPolicy: Bool? {
+        totalAfterPolicy.map { $0 <= contextSize }
     }
 
     var outcomeTitle: String {
-        fitsAfterPolicy ? "Fits with \(remainingTokens) tokens free" : "Over by \(totalAfterPolicy - contextSize) tokens"
+        guard let totalAfterPolicy else { return "Not measured" }
+        let difference = contextSize - totalAfterPolicy
+        return difference >= 0 ? "Fits with \(difference) tokens free" : "Over by \(-difference) tokens"
     }
 
     var outcomeIcon: String {
-        fitsAfterPolicy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        guard let fitsAfterPolicy else { return "ruler" }
+        return fitsAfterPolicy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
     }
 
     var recommendation: String {
-        if fitsAfterPolicy {
-            "Create the next LanguageModelSession with the prepared transcript, then send the prompt with the response limit."
-        } else if policy == .preserveAll {
-            "This request can trigger exceededContextWindowSize. Choose an app policy that reduces history before calling respond."
-        } else {
-            "The selected policy still leaves too little room. Reduce the response reserve, compact more history, or start a fresh session."
+        guard let fitsAfterPolicy else {
+            return "Measure the prompt and sample transcript before comparing policies."
         }
+        if fitsAfterPolicy {
+            return "Create the next LanguageModelSession with the prepared transcript, then send the prompt with the response limit."
+        }
+        if policy == .preserveAll {
+            return "This request can trigger exceededContextWindowSize. Choose an app policy that reduces history before calling respond."
+        }
+        return "Reduce the response reserve, compact more history, or start a fresh session."
+    }
+
+    private var combinedEarlierTokens: Int? {
+        sum([historyTokenCounts?["old-plan"], historyTokenCounts?["draft"], historyTokenCounts?["tools"]])
+    }
+
+    private func sum(_ values: [Int?]) -> Int? {
+        guard values.allSatisfy({ $0 != nil }) else { return nil }
+        return values.compactMap { $0 }.reduce(0, +)
     }
 }
+
+private let longInstructions = String(
+    repeating: "Be precise, preserve user constraints, cite the relevant framework behavior, and avoid inventing APIs. ",
+    count: 24
+)
+
+private let earlyArchitecturePrompt = String(
+    repeating: "Compare the session architecture, transcript lifecycle, tool definitions, and structured-generation requirements. ",
+    count: 34
+)
+
+private let discardedDraft = String(
+    repeating: "The first implementation explored several alternatives, recorded tradeoffs, and included code that was later rejected. ",
+    count: 42
+)
+
+private let researchOutput = String(
+    repeating: "Apple documentation confirms the model context, transcript entry, token counting, and response option behavior. ",
+    count: 48
+)
+
+private let latestConstraints = String(
+    repeating: "Keep the interface native, truthful, accessible, and focused on the exact behavior a developer controls. ",
+    count: 26
+)
+
+private let compactedSummary = """
+The user needs a native and truthful Foundation Models example. Preserve the latest constraints and use official APIs. Clearly separate
+framework behavior from app-owned transcript policy. Earlier alternatives were rejected.
+"""

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetSimulation.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetSimulation.swift
@@ -1,0 +1,147 @@
+//
+//  ContextBudgetSimulation.swift
+//  FoundationLab
+//
+
+import Foundation
+
+struct ContextBudgetSimulation {
+    struct Entry: Identifiable {
+        enum Disposition {
+            case kept
+            case summarized
+            case dropped
+
+            var title: String {
+                switch self {
+                case .kept: "Kept"
+                case .summarized: "Summary"
+                case .dropped: "Dropped"
+                }
+            }
+
+            var systemImage: String {
+                switch self {
+                case .kept: "checkmark.circle.fill"
+                case .summarized: "text.badge.checkmark"
+                case .dropped: "minus.circle"
+                }
+            }
+        }
+
+        let id: String
+        let title: String
+        let kind: String
+        let originalTokens: Int
+        let resultingTokens: Int
+        let disposition: Disposition
+    }
+
+    let contextSize: Int
+    let promptTokens: Int
+    let responseReserve: Int
+    let policy: ContextBudgetPolicy
+
+    private let sourceEntries = [
+        Entry(
+            id: "instructions", title: "System instructions", kind: "Instructions",
+            originalTokens: 360, resultingTokens: 360, disposition: .kept
+        ),
+        Entry(
+            id: "old-plan", title: "Early architecture discussion", kind: "Prompt + response",
+            originalTokens: 780, resultingTokens: 780, disposition: .kept
+        ),
+        Entry(
+            id: "draft", title: "Discarded implementation draft", kind: "Prompt + response",
+            originalTokens: 920, resultingTokens: 920, disposition: .kept
+        ),
+        Entry(
+            id: "tools", title: "Completed research tool output", kind: "Tool calls + output",
+            originalTokens: 1_100, resultingTokens: 1_100, disposition: .kept
+        ),
+        Entry(
+            id: "latest", title: "Latest decision and constraints", kind: "Prompt + response",
+            originalTokens: 620, resultingTokens: 620, disposition: .kept
+        )
+    ]
+
+    var processedEntries: [Entry] {
+        switch policy {
+        case .preserveAll:
+            sourceEntries
+        case .keepRecent:
+            sourceEntries.map { entry in
+                guard entry.id == "instructions" || entry.id == "tools" || entry.id == "latest" else {
+                    return Entry(
+                        id: entry.id,
+                        title: entry.title,
+                        kind: entry.kind,
+                        originalTokens: entry.originalTokens,
+                        resultingTokens: 0,
+                        disposition: .dropped
+                    )
+                }
+                return entry
+            }
+        case .summarizeEarlier:
+            [
+                sourceEntries[0],
+                Entry(
+                    id: "summary",
+                    title: "Summary of earlier conversation",
+                    kind: "App-generated prompt context",
+                    originalTokens: sourceEntries[1...3].map(\.originalTokens).reduce(0, +),
+                    resultingTokens: 320,
+                    disposition: .summarized
+                ),
+                sourceEntries[4]
+            ]
+        }
+    }
+
+    var historyTokensBeforePolicy: Int {
+        sourceEntries.map(\.originalTokens).reduce(0, +)
+    }
+
+    var historyTokensAfterPolicy: Int {
+        processedEntries.map(\.resultingTokens).reduce(0, +)
+    }
+
+    var totalBeforePolicy: Int {
+        historyTokensBeforePolicy + promptTokens + responseReserve
+    }
+
+    var totalAfterPolicy: Int {
+        historyTokensAfterPolicy + promptTokens + responseReserve
+    }
+
+    var budgetEquation: String {
+        "\(historyTokensAfterPolicy) history + \(promptTokens) prompt + \(responseReserve) response"
+    }
+
+    var fitsAfterPolicy: Bool {
+        totalAfterPolicy <= contextSize
+    }
+
+    var remainingTokens: Int {
+        max(0, contextSize - totalAfterPolicy)
+    }
+
+    var outcomeTitle: String {
+        fitsAfterPolicy ? "Fits with \(remainingTokens) tokens free" : "Over by \(totalAfterPolicy - contextSize) tokens"
+    }
+
+    var outcomeIcon: String {
+        fitsAfterPolicy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+    }
+
+    var recommendation: String {
+        if fitsAfterPolicy {
+            "Create the next LanguageModelSession with the prepared transcript, then send the prompt with the response limit."
+        } else if policy == .preserveAll {
+            "This request can trigger exceededContextWindowSize. Choose an app policy that reduces history before calling respond."
+        } else {
+            "The selected policy still leaves too little room. Reduce the response reserve, compact more history, or start a fresh session."
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetUsageView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetUsageView.swift
@@ -16,7 +16,7 @@ struct ContextBudgetUsageView: View {
                     title: "After app policy",
                     value: simulation.outcomeTitle,
                     systemImage: simulation.outcomeIcon,
-                    tint: simulation.fitsAfterPolicy ? .green : .red
+                    tint: outcomeColor
                 )
 
                 usageRow(
@@ -28,7 +28,7 @@ struct ContextBudgetUsageView: View {
                 usageRow(
                     title: "After",
                     usedTokens: simulation.totalAfterPolicy,
-                    tint: simulation.fitsAfterPolicy ? .green : .red
+                    tint: outcomeColor
                 )
 
                 LabeledContent("After-policy math") {
@@ -45,18 +45,33 @@ struct ContextBudgetUsageView: View {
         }
     }
 
-    private func usageRow(title: String, usedTokens: Int, tint: Color) -> some View {
+    private var outcomeColor: Color {
+        switch simulation.fitsAfterPolicy {
+        case true: .green
+        case false: .red
+        case nil: .secondary
+        }
+    }
+
+    private func usageRow(title: String, usedTokens: Int?, tint: Color) -> some View {
         VStack(alignment: .leading, spacing: Spacing.xSmall) {
             LabeledContent(title) {
-                Text("\(usedTokens) / \(simulation.contextSize) tokens")
-                    .monospacedDigit()
+                if let usedTokens {
+                    Text("\(usedTokens) / \(simulation.contextSize) tokens")
+                        .monospacedDigit()
+                } else {
+                    Text("Not measured")
+                        .foregroundStyle(.secondary)
+                }
             }
             .font(.footnote)
 
-            ProgressView(value: min(Double(usedTokens) / Double(simulation.contextSize), 1))
-                .tint(tint)
-                .accessibilityLabel("\(title) context usage")
-                .accessibilityValue("\(usedTokens) of \(simulation.contextSize) tokens")
+            if let usedTokens {
+                ProgressView(value: min(Double(usedTokens) / Double(simulation.contextSize), 1))
+                    .tint(tint)
+                    .accessibilityLabel("\(title) context usage")
+                    .accessibilityValue("\(usedTokens) of \(simulation.contextSize) tokens")
+            }
         }
     }
 }

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetUsageView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetUsageView.swift
@@ -1,0 +1,62 @@
+//
+//  ContextBudgetUsageView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct ContextBudgetUsageView: View {
+    let simulation: ContextBudgetSimulation
+    let measurementNote: String
+
+    var body: some View {
+        Xcode27Section("Budget result") {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                Xcode27StatusRow(
+                    title: "After app policy",
+                    value: simulation.outcomeTitle,
+                    systemImage: simulation.outcomeIcon,
+                    tint: simulation.fitsAfterPolicy ? .green : .red
+                )
+
+                usageRow(
+                    title: "Before",
+                    usedTokens: simulation.totalBeforePolicy,
+                    tint: .secondary
+                )
+
+                usageRow(
+                    title: "After",
+                    usedTokens: simulation.totalAfterPolicy,
+                    tint: simulation.fitsAfterPolicy ? .green : .red
+                )
+
+                LabeledContent("After-policy math") {
+                    Text(simulation.budgetEquation)
+                        .multilineTextAlignment(.trailing)
+                        .foregroundStyle(.secondary)
+                }
+                .font(.footnote.monospacedDigit())
+
+                Text(measurementNote)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func usageRow(title: String, usedTokens: Int, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            LabeledContent(title) {
+                Text("\(usedTokens) / \(simulation.contextSize) tokens")
+                    .monospacedDigit()
+            }
+            .font(.footnote)
+
+            ProgressView(value: min(Double(usedTokens) / Double(simulation.contextSize), 1))
+                .tint(tint)
+                .accessibilityLabel("\(title) context usage")
+                .accessibilityValue("\(usedTokens) of \(simulation.contextSize) tokens")
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetVisualizerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetVisualizerView.swift
@@ -16,14 +16,16 @@ struct ContextBudgetVisualizerView: View {
     @State private var policy = ContextBudgetPolicy.keepRecent
     @State private var responseReserve = 640.0
     @State private var measuredPromptTokens: Int?
-    @State private var measurementNote = "Run to measure this prompt with the model tokenizer."
+    @State private var measuredHistoryTokens: [String: Int]?
+    @State private var measurementNote = "Measure the prompt and sample transcript with the model tokenizer."
     @State private var isRunning = false
     @State private var activeMeasurementID: UUID?
 
     private var simulation: ContextBudgetSimulation {
         ContextBudgetSimulation(
             contextSize: SystemLanguageModel.default.contextSize,
-            promptTokens: measuredPromptTokens ?? estimatedPromptTokens(for: currentPrompt),
+            promptTokens: measuredPromptTokens,
+            historyTokenCounts: measuredHistoryTokens,
             responseReserve: Int(responseReserve),
             policy: policy
         )
@@ -37,7 +39,7 @@ struct ContextBudgetVisualizerView: View {
             currentPrompt: $currentPrompt,
             isRunning: isRunning,
             codeExample: codeExample,
-            runLabel: "Measure Prompt",
+            runLabel: "Measure Budget",
             onRun: runSimulation,
             onReset: reset
         ) {
@@ -49,8 +51,8 @@ struct ContextBudgetVisualizerView: View {
                 Xcode27Section("Sample transcript after policy") {
                     VStack(alignment: .leading, spacing: Spacing.small) {
                         Text(
-                            "These entries and their history counts are a fixed teaching sample. "
-                            + "Measure Prompt tokenizes only the prompt above."
+                            "This is a synthetic long conversation for comparing app-owned policies. "
+                            + "Its displayed counts come from the same model tokenizer as your prompt."
                         )
                             .font(.footnote)
                             .foregroundStyle(.secondary)
@@ -70,7 +72,7 @@ struct ContextBudgetVisualizerView: View {
                 Xcode27Section("What happens next") {
                     Label(simulation.recommendation, systemImage: simulation.outcomeIcon)
                         .font(.callout)
-                        .foregroundStyle(simulation.fitsAfterPolicy ? Color.primary : Color.red)
+                        .foregroundStyle(simulation.fitsAfterPolicy == false ? Color.red : Color.primary)
                 }
             }
         }
@@ -133,34 +135,37 @@ struct ContextBudgetVisualizerView: View {
     private func runSimulation() {
         let prompt = currentPrompt
         let measurementID = UUID()
-        let fallback = estimatedPromptTokens(for: prompt)
-
         activeMeasurementID = measurementID
         isRunning = true
         measuredPromptTokens = nil
-        measurementNote = "Measuring prompt tokens…"
+        measuredHistoryTokens = nil
+        measurementNote = "Measuring prompt and sample transcript…"
 
         Task { @MainActor in
-            let tokens: Int
-            let note: String
-
             do {
                 if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *) {
-                    tokens = try await SystemLanguageModel.default.tokenCount(for: Prompt(prompt))
-                    note = "Prompt measured with SystemLanguageModel.tokenCount(for:)."
+                    let model = SystemLanguageModel.default
+                    let promptTokens = try await model.tokenCount(for: Prompt(prompt))
+                    var historyTokens: [String: Int] = [:]
+
+                    for sample in ContextBudgetSimulation.entriesToMeasure {
+                        historyTokens[sample.id] = try await model.tokenCount(for: [sample.transcriptEntry])
+                    }
+
+                    guard activeMeasurementID == measurementID, currentPrompt == prompt else { return }
+
+                    measuredPromptTokens = promptTokens
+                    measuredHistoryTokens = historyTokens
+                    measurementNote = "Measured with SystemLanguageModel.tokenCount(for:)."
                 } else {
-                    tokens = fallback
-                    note = "Prompt estimated because model token counting requires version 26.4 or later."
+                    measurementNote = "Model token counting requires version 26.4 or later; no estimates are shown."
                 }
             } catch {
-                tokens = fallback
-                note = "Prompt estimated because the model tokenizer was unavailable."
+                measurementNote = "The model tokenizer is unavailable; no estimates are shown."
             }
 
             guard activeMeasurementID == measurementID, currentPrompt == prompt else { return }
 
-            measuredPromptTokens = tokens
-            measurementNote = note
             isRunning = false
             activeMeasurementID = nil
         }
@@ -173,20 +178,18 @@ struct ContextBudgetVisualizerView: View {
         policy = .keepRecent
         responseReserve = 640
         measuredPromptTokens = nil
-        measurementNote = "Enter a prompt, then run to measure it with the model tokenizer."
+        measuredHistoryTokens = nil
+        measurementNote = "Enter a prompt, then measure it with the sample transcript."
     }
 
     private func invalidatePromptMeasurement() {
         activeMeasurementID = nil
         isRunning = false
         measuredPromptTokens = nil
+        measuredHistoryTokens = nil
         measurementNote = currentPrompt.isEmpty
-            ? "Enter a prompt, then run to measure it with the model tokenizer."
-            : "Prompt changed. Run to measure it with the model tokenizer."
-    }
-
-    private func estimatedPromptTokens(for prompt: String) -> Int {
-        max(1, Int(ceil(Double(prompt.count) / 4.5)))
+            ? "Enter a prompt, then measure it with the sample transcript."
+            : "Prompt changed. Measure again to update the budget."
     }
 
     private var codeExample: String {

--- a/Foundation Lab/Views/Examples/Xcode27/ContextBudgetVisualizerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ContextBudgetVisualizerView.swift
@@ -5,197 +5,210 @@
 //  Created by Codex on 6/8/26.
 //
 
+import Foundation
+import FoundationModels
 import SwiftUI
 
 struct ContextBudgetVisualizerView: View {
-    @State private var currentPrompt = "Visualize which transcript entries survive compaction."
-    @State private var strategy = BudgetStrategy.balanced
+    private static let defaultPrompt = "Use the latest research and our earlier decisions to propose the next three implementation steps."
 
-    private var entries: [BudgetEntry] {
-        BudgetEntry.samples.map { entry in entry.applying(strategy) }
-    }
+    @State private var currentPrompt = defaultPrompt
+    @State private var policy = ContextBudgetPolicy.keepRecent
+    @State private var responseReserve = 640.0
+    @State private var measuredPromptTokens: Int?
+    @State private var measurementNote = "Run to measure this prompt with the model tokenizer."
+    @State private var isRunning = false
+    @State private var activeMeasurementID: UUID?
 
-    private var keptTokens: Int {
-        entries.filter { $0.state != .dropped }.map(\.displayTokens).reduce(0, +)
+    private var simulation: ContextBudgetSimulation {
+        ContextBudgetSimulation(
+            contextSize: SystemLanguageModel.default.contextSize,
+            promptTokens: measuredPromptTokens ?? estimatedPromptTokens(for: currentPrompt),
+            responseReserve: Int(responseReserve),
+            policy: policy
+        )
     }
 
     var body: some View {
         ExampleViewBase(
-            title: "Budget Visualizer",
-            description: "See what gets kept, summarized, or dropped",
-            defaultPrompt: "Visualize which transcript entries survive compaction.",
+            title: "Transcript Budget Lab",
+            description: "Decide what your app keeps before a session runs out of context",
+            defaultPrompt: Self.defaultPrompt,
             currentPrompt: $currentPrompt,
-            codeExample: strategy.code,
-            onRun: cycleStrategy,
+            isRunning: isRunning,
+            codeExample: codeExample,
+            runLabel: "Measure Prompt",
+            onRun: runSimulation,
             onReset: reset
         ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Strategy", selection: $strategy) {
-                    ForEach(BudgetStrategy.allCases) { strategy in
-                        Text(strategy.title).tag(strategy)
-                    }
-                }
-                .pickerStyle(.segmented)
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                frameworkBoundary
+                policyControls
+                ContextBudgetUsageView(simulation: simulation, measurementNote: measurementNote)
 
-                Xcode27StatusRow(
-                    title: "Compacted Prompt",
-                    value: "\(keptTokens) tokens kept",
-                    systemImage: "chart.pie",
-                    tint: strategy.tint
-                )
+                Xcode27Section("Sample transcript after policy") {
+                    VStack(alignment: .leading, spacing: Spacing.small) {
+                        Text(
+                            "These entries and their history counts are a fixed teaching sample. "
+                            + "Measure Prompt tokenizes only the prompt above."
+                        )
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
 
-                Xcode27Section("Transcript Entries") {
-                    VStack(spacing: 0) {
-                        ForEach(entries) { entry in
-                            BudgetEntryRow(entry: entry)
+                        VStack(spacing: 0) {
+                            ForEach(simulation.processedEntries) { entry in
+                                ContextBudgetEntryRow(entry: entry)
 
-                            if entry.id != entries.last?.id {
-                                Divider()
+                                if entry.id != simulation.processedEntries.last?.id {
+                                    Divider()
+                                }
                             }
                         }
                     }
                 }
+
+                Xcode27Section("What happens next") {
+                    Label(simulation.recommendation, systemImage: simulation.outcomeIcon)
+                        .font(.callout)
+                        .foregroundStyle(simulation.fitsAfterPolicy ? Color.primary : Color.red)
+                }
             }
+        }
+        .onChange(of: currentPrompt) {
+            invalidatePromptMeasurement()
         }
     }
 
-    private func cycleStrategy() {
-        let cases = BudgetStrategy.allCases
-        guard let index = cases.firstIndex(of: strategy) else { return }
-        strategy = cases[(index + 1) % cases.count]
+    private var frameworkBoundary: some View {
+        Xcode27Section("Framework boundary") {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                Text(
+                    "Foundation Models can report the context limit and count tokens. "
+                    + "It does not choose a ‘balanced’ or ‘aggressive’ compaction strategy for your app."
+                )
+                    .font(.callout)
+
+                Label("Framework: context size, token counts, transcript, and overflow error", systemImage: "apple.intelligence")
+                Label("Your app: response reserve and which history to keep, summarize, or drop", systemImage: "slider.horizontal.3")
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
     }
 
-    private func reset() {
-        currentPrompt = ""
-        strategy = .balanced
-    }
-}
+    private var policyControls: some View {
+        Xcode27Section("App-owned policy") {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                LabeledContent("Transcript policy") {
+                    Picker("Transcript policy", selection: $policy) {
+                        ForEach(ContextBudgetPolicy.allCases) { policy in
+                            Label(policy.title, systemImage: policy.systemImage)
+                                .tag(policy)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                }
 
-private struct BudgetEntryRow: View {
-    let entry: BudgetEntry
+                Text(policy.explanation)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
 
-    var body: some View {
-        HStack(spacing: Spacing.medium) {
-            Image(systemName: entry.state.icon)
-                .foregroundStyle(entry.state.tint)
-                .frame(width: 26)
+                Xcode27ValueSlider(
+                    title: "Response reserve",
+                    valueText: "\(Int(responseReserve)) tokens",
+                    systemImage: "arrow.down.doc",
+                    value: $responseReserve,
+                    range: 256...1_024,
+                    step: 64
+                )
 
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text(entry.title)
-                    .font(.subheadline)
-                    .bold()
-                Text(entry.state.description)
+                Text("The reserve mirrors GenerationOptions.maximumResponseTokens: space held back for the model’s answer.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
-
-            Spacer()
-
-            Text("\(entry.displayTokens) tokens")
-                .font(.footnote.monospacedDigit())
-                .foregroundStyle(.secondary)
-        }
-        .frame(minHeight: 44)
-        .accessibilityElement(children: .combine)
-    }
-}
-
-private struct BudgetEntry: Identifiable {
-    let id = UUID()
-    let title: String
-    let originalTokens: Int
-    let priority: Int
-    var state: BudgetEntryState = .kept
-
-    var displayTokens: Int {
-        switch state {
-        case .kept: return originalTokens
-        case .summarized: return max(80, originalTokens / 5)
-        case .dropped: return 0
         }
     }
 
-    func applying(_ strategy: BudgetStrategy) -> BudgetEntry {
-        var copy = self
-        switch strategy {
-        case .lossless:
-            copy.state = .kept
-        case .balanced:
-            copy.state = priority >= 4 ? .kept : priority >= 2 ? .summarized : .dropped
-        case .aggressive:
-            copy.state = priority >= 5 ? .kept : priority >= 3 ? .summarized : .dropped
-        }
-        return copy
-    }
+    private func runSimulation() {
+        let prompt = currentPrompt
+        let measurementID = UUID()
+        let fallback = estimatedPromptTokens(for: prompt)
 
-    static let samples = [
-        BudgetEntry(title: "Initial instructions", originalTokens: 420, priority: 5),
-        BudgetEntry(title: "User preferences", originalTokens: 680, priority: 5),
-        BudgetEntry(title: "Old brainstorming", originalTokens: 1_800, priority: 2),
-        BudgetEntry(title: "Tool results", originalTokens: 2_400, priority: 3),
-        BudgetEntry(title: "Recent question", originalTokens: 160, priority: 5),
-        BudgetEntry(title: "Stale retry loop", originalTokens: 900, priority: 1)
-    ]
-}
+        activeMeasurementID = measurementID
+        isRunning = true
+        measuredPromptTokens = nil
+        measurementNote = "Measuring prompt tokens…"
 
-private enum BudgetEntryState {
-    case kept
-    case summarized
-    case dropped
+        Task { @MainActor in
+            let tokens: Int
+            let note: String
 
-    var icon: String {
-        switch self {
-        case .kept: return "checkmark.circle"
-        case .summarized: return "text.badge.checkmark"
-        case .dropped: return "minus.circle"
-        }
-    }
+            do {
+                if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *) {
+                    tokens = try await SystemLanguageModel.default.tokenCount(for: Prompt(prompt))
+                    note = "Prompt measured with SystemLanguageModel.tokenCount(for:)."
+                } else {
+                    tokens = fallback
+                    note = "Prompt estimated because model token counting requires version 26.4 or later."
+                }
+            } catch {
+                tokens = fallback
+                note = "Prompt estimated because the model tokenizer was unavailable."
+            }
 
-    var tint: Color {
-        switch self {
-        case .kept: return .green
-        case .summarized: return .orange
-        case .dropped: return .red
+            guard activeMeasurementID == measurementID, currentPrompt == prompt else { return }
+
+            measuredPromptTokens = tokens
+            measurementNote = note
+            isRunning = false
+            activeMeasurementID = nil
         }
     }
 
-    var description: String {
-        switch self {
-        case .kept: return "Kept verbatim"
-        case .summarized: return "Replaced by compact memory"
-        case .dropped: return "Removed before model call"
-        }
-    }
-}
-
-private enum BudgetStrategy: String, CaseIterable, Identifiable {
-    case lossless
-    case balanced
-    case aggressive
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .lossless: return "Lossless"
-        case .balanced: return "Balanced"
-        case .aggressive: return "Aggressive"
-        }
+    private func reset() {
+        activeMeasurementID = nil
+        isRunning = false
+        currentPrompt = ""
+        policy = .keepRecent
+        responseReserve = 640
+        measuredPromptTokens = nil
+        measurementNote = "Enter a prompt, then run to measure it with the model tokenizer."
     }
 
-    var tint: Color {
-        switch self {
-        case .lossless: return .green
-        case .balanced: return .orange
-        case .aggressive: return .red
-        }
+    private func invalidatePromptMeasurement() {
+        activeMeasurementID = nil
+        isRunning = false
+        measuredPromptTokens = nil
+        measurementNote = currentPrompt.isEmpty
+            ? "Enter a prompt, then run to measure it with the model tokenizer."
+            : "Prompt changed. Run to measure it with the model tokenizer."
     }
 
-    var code: String {
+    private func estimatedPromptTokens(for prompt: String) -> Int {
+        max(1, Int(ceil(Double(prompt.count) / 4.5)))
+    }
+
+    private var codeExample: String {
         """
-        .historyTransform { entries in
-            ContextBudgetManager(strategy: .\(rawValue))
-                .compact(entries)
+        let model = SystemLanguageModel.default
+        let contextSize = model.contextSize
+        let historyTokens = try await model.tokenCount(for: session.transcript)
+        let promptTokens = try await model.tokenCount(for: Prompt(prompt))
+
+        let options = GenerationOptions(maximumResponseTokens: \(Int(responseReserve)))
+        let requiredTokens = historyTokens + promptTokens + \(Int(responseReserve))
+
+        if requiredTokens > contextSize {
+            // App policy: rebuild a smaller Transcript before creating the next session.
+            let compactedEntries = preparedEntries(from: session.transcript)
+            session = LanguageModelSession(transcript: Transcript(entries: compactedEntries))
+        }
+
+        do {
+            try await session.respond(to: prompt, options: options)
+        } catch LanguageModelSession.GenerationError.exceededContextWindowSize {
+            // Reduce history or start a fresh session, then retry intentionally.
         }
         """
     }


### PR DESCRIPTION
## What changed

- replaces the invented Lossless / Balanced / Aggressive modes with explicitly app-owned transcript policies
- measures both the entered prompt and every synthetic transcript entry with `SystemLanguageModel.tokenCount(for:)`
- shows “Not measured” until tokenization succeeds instead of presenting estimated or fixture values with runtime-looking precision
- shows the full before/after budget equation: transcript history + prompt + reserved response tokens versus `contextSize`
- clearly labels the transcript as a synthetic teaching sample rather than live framework state
- explains which sample entries an app policy would keep, summarize, or drop and what the app should do next
- replaces the non-existent `.historyTransform` sample with code based on real Foundation Models APIs
- labels the primary action “Measure Budget” so it describes the result

## Why

The previous screen looked like it exposed model-level compaction strategies, but those options were canned demo states and clicking Run merely cycled between them. Foundation Models exposes the context size, model token counting, session transcript, response-token limit, and the context-window overflow error. Transcript compaction remains an application policy.

This change makes that framework boundary explicit and turns the screen into a useful policy lab rather than a decorative state switcher. The follow-up anti-slop pass also removes hard-coded token counts, so illustrative data no longer appears to be live telemetry.

## Developer impact

Developers can now see how prompt size, response reserve, and transcript preparation interact before `LanguageModelSession.respond` is called. Every displayed token count comes from the framework tokenizer, while the UI clearly identifies the transcript content itself as synthetic.

## Validation

- `swiftlint` passes for the changed Swift files
- `git diff --check` passes
- API signatures were checked against Apple documentation and the installed FoundationModels SDK interface
- full app build reaches the app target, then remains blocked by existing Xcode 27-only APIs in `VideoSegment.swift` and `GeminiDeveloperVideoLanguageModel.swift` because the installed toolchain is Xcode 26.5; those errors are unrelated to this PR

## Official API references

- https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/contextsize
- https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/tokencount(for:)
- https://developer.apple.com/documentation/foundationmodels/languagemodelsession/transcript
- https://developer.apple.com/documentation/foundationmodels/generationoptions/maximumresponsetokens
- https://developer.apple.com/documentation/foundationmodels/languagemodelsession/generationerror/exceededcontextwindowsize(_:)
