### PR TITLE
[codex] Make reference-only examples truthful

### DIFF
--- a/Foundation Lab/Views/Examples/Components/ReferenceExampleView.swift
+++ b/Foundation Lab/Views/Examples/Components/ReferenceExampleView.swift
@@ -1,0 +1,50 @@
+//
+//  ReferenceExampleView.swift
+//  FoundationLab
+//
+//  Created by Codex on 6/18/26.
+//
+
+import SwiftUI
+
+/// A documentation-only example that exposes no model execution controls.
+struct ReferenceExampleView<Content: View>: View {
+    let title: String
+    let description: String
+    let codeExample: String?
+    let referenceNote: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Label {
+                    VStack(alignment: .leading, spacing: Spacing.small) {
+                        Text("Reference, not a live run")
+                            .bold()
+                        Text(referenceNote)
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "book.pages")
+                        .foregroundStyle(.blue)
+                }
+                .font(.callout)
+                .accessibilityElement(children: .combine)
+
+                content
+
+                if let codeExample {
+                    CodeDisclosure(code: codeExample)
+                }
+            }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+        }
+        .navigationTitle(title)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle(description)
+        #endif
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/DynamicProfileBuilderView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/DynamicProfileBuilderView.swift
@@ -8,21 +8,17 @@
 import SwiftUI
 
 struct DynamicProfileBuilderView: View {
-    @State private var currentPrompt = "Summarize this release note for developers."
     @State private var temperature = 0.4
     @State private var maxTokens = 240.0
     @State private var reasoningLevel = ReasoningLevelChoice.moderate
     @State private var toolMode = DynamicToolMode.allowed
 
     var body: some View {
-        ExampleViewBase(
+        ReferenceExampleView(
             title: "Dynamic Profile",
-            description: "Compose Xcode 27 session profile options",
-            defaultPrompt: "Summarize this release note for developers.",
-            currentPrompt: $currentPrompt,
+            description: "Compose a LanguageModelSession.Profile recipe",
             codeExample: codeExample,
-            onRun: run,
-            onReset: reset
+            referenceNote: "Adjust the controls to generate a profile recipe. This page does not create a session or send a prompt."
         ) {
             VStack(spacing: Spacing.medium) {
                 Xcode27Section("Profile Controls") {
@@ -79,8 +75,6 @@ struct DynamicProfileBuilderView: View {
         """
     }
 
-    private func run() {}
-
     private var codeExample: String {
         """
         if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
@@ -97,13 +91,6 @@ struct DynamicProfileBuilderView: View {
         """
     }
 
-    private func reset() {
-        currentPrompt = ""
-        temperature = 0.4
-        maxTokens = 240
-        reasoningLevel = .moderate
-        toolMode = .allowed
-    }
 }
 
 private enum ReasoningLevelChoice: String, CaseIterable, Identifiable {

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
@@ -8,18 +8,16 @@
 import SwiftUI
 
 struct ImageInputPlaygroundView: View {
-    @State private var currentPrompt = "Turn this screenshot into a concise bug report."
     @State private var selectedRecipe = ImageInputRecipe.altText
 
     var body: some View {
-        ExampleViewBase(
-            title: "Image Input",
-            description: "Explore image attachments, references, and empirical resolution boundaries",
-            defaultPrompt: "Turn this screenshot into a concise bug report.",
-            currentPrompt: $currentPrompt,
+        ReferenceExampleView(
+            title: "Image Input Reference",
+            description: "Inspect image attachment recipes and measured resolution boundaries",
             codeExample: selectedRecipe.code,
-            onRun: run,
-            onReset: reset
+            referenceNote: """
+            Choose a recipe to update the sample prompt and code. No image is attached and no model request is sent on this page.
+            """
         ) {
             VStack(spacing: Spacing.medium) {
                 Xcode27Section("Attachment Flow") {
@@ -72,18 +70,13 @@ struct ImageInputPlaygroundView: View {
                         .padding(.top, Spacing.small)
                 }
 
-                ResultDisplay(
-                    result: selectedRecipe.resultPreview,
-                    isSuccess: true
-                )
+                Xcode27Section("Response focus") {
+                    Text(selectedRecipe.responseFocus)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
-    }
-
-    private func run() {}
-
-    private func reset() {
-        currentPrompt = ""
     }
 }
 
@@ -116,14 +109,14 @@ private enum ImageInputRecipe: String, CaseIterable, Identifiable {
         }
     }
 
-    var resultPreview: String {
+    var responseFocus: String {
         switch self {
         case .altText:
-            return "Example output: A compact description of the image suitable for accessibility labels and summaries."
+            return "Ask for a compact description suitable for accessibility labels and summaries."
         case .screenshotBug:
-            return "Example output: Title, observed behavior, expected behavior, visible evidence, and repro hints."
+            return "Ask for a title, observed behavior, expected behavior, visible evidence, and reproduction hints."
         case .uiAudit:
-            return "Example output: Layout, hierarchy, contrast, spacing, text clipping, and actionable fixes."
+            return "Ask the model to inspect layout, hierarchy, contrast, spacing, text clipping, and actionable fixes."
         }
     }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonView.swift
@@ -8,18 +8,17 @@
 import SwiftUI
 
 struct ReasoningLevelComparisonView: View {
-    @State private var currentPrompt = "Plan a migration from an Xcode 26 Foundation Models app to Xcode 27."
     @State private var selectedLevel = ReasoningComparisonLevel.moderate
 
     var body: some View {
-        ExampleViewBase(
+        ReferenceExampleView(
             title: "Reasoning Levels",
-            description: "Compare light, moderate, and deep reasoning contexts",
-            defaultPrompt: "Plan a migration from an Xcode 26 Foundation Models app to Xcode 27.",
-            currentPrompt: $currentPrompt,
+            description: "Inspect light, moderate, and deep ContextOptions",
             codeExample: selectedLevel.code,
-            onRun: run,
-            onReset: reset
+            referenceNote: """
+            Choose a level to inspect its ContextOptions recipe. This page describes the requested reasoning budget; it does not run a \
+            comparison.
+            """
         ) {
             VStack(spacing: Spacing.medium) {
                 Picker("Reasoning level", selection: $selectedLevel) {
@@ -35,10 +34,11 @@ struct ReasoningLevelComparisonView: View {
                             .font(.callout)
                             .foregroundStyle(.secondary)
 
-                        ResultDisplay(
-                            result: selectedLevel.expectedShape,
-                            isSuccess: true
-                        )
+                        LabeledContent("Framework effect") {
+                            Text(selectedLevel.frameworkEffect)
+                                .multilineTextAlignment(.trailing)
+                        }
+                        .font(.callout)
                     }
                 }
 
@@ -56,11 +56,6 @@ struct ReasoningLevelComparisonView: View {
         }
     }
 
-    private func run() {}
-
-    private func reset() {
-        currentPrompt = ""
-    }
 }
 
 private enum ReasoningComparisonLevel: String, CaseIterable, Identifiable {
@@ -85,14 +80,14 @@ private enum ReasoningComparisonLevel: String, CaseIterable, Identifiable {
         }
     }
 
-    var expectedShape: String {
+    var frameworkEffect: String {
         switch self {
         case .light:
-            return "Expected output: short, direct, low-latency answer with minimal planning."
+            return "Allows less thinking before the response."
         case .moderate:
-            return "Expected output: structured answer with a few explicit steps and tradeoffs."
+            return "Allows a moderate amount of thinking before the response."
         case .deep:
-            return "Expected output: fuller plan with assumptions, risks, sequencing, and validation."
+            return "Allows more thinking before the response."
         }
     }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabView.swift
@@ -9,18 +9,14 @@ import FoundationModels
 import SwiftUI
 
 struct ToolCallingModeLabView: View {
-    @State private var currentPrompt = "What is the weather in Cupertino?"
     @State private var selectedMode = ToolModeExample.allowed
 
     var body: some View {
-        ExampleViewBase(
-            title: "Tool Modes",
-            description: "Compare allowed, required, and disallowed tool calling",
-            defaultPrompt: "What is the weather in Cupertino?",
-            currentPrompt: $currentPrompt,
+        ReferenceExampleView(
+            title: "Tool Calling Modes",
+            description: "Inspect allowed, required, and disallowed tool behavior",
             codeExample: selectedMode.code,
-            onRun: run,
-            onReset: reset
+            referenceNote: "Choose a mode to inspect the corresponding GenerationOptions recipe. This page does not call a model or tool."
         ) {
             VStack(spacing: Spacing.medium) {
                 Picker("Tool mode", selection: $selectedMode) {
@@ -66,11 +62,6 @@ struct ToolCallingModeLabView: View {
         }
     }
 
-    private func run() {}
-
-    private func reset() {
-        currentPrompt = ""
-    }
 }
 
 private enum ToolModeExample: String, CaseIterable, Identifiable {

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
@@ -8,18 +8,14 @@
 import SwiftUI
 
 struct TranscriptExplorerView: View {
-    @State private var currentPrompt = "Browse the Xcode 27 transcript segment types."
     @State private var selectedSegment = TranscriptSegmentExample.reasoning
 
     var body: some View {
-        ExampleViewBase(
+        ReferenceExampleView(
             title: "Transcript Explorer",
-            description: "Browse new reasoning, attachment, and custom segment cases",
-            defaultPrompt: "Browse the Xcode 27 transcript segment types.",
-            currentPrompt: $currentPrompt,
+            description: "Inspect reasoning, attachment, and custom transcript cases",
             codeExample: codeExample,
-            onRun: run,
-            onReset: reset
+            referenceNote: "Choose a segment to inspect its API case and code path. This page does not create a session or transcript."
         ) {
             VStack(spacing: Spacing.medium) {
                 Picker("Segment", selection: $selectedSegment) {
@@ -70,12 +66,6 @@ struct TranscriptExplorerView: View {
                 }
             }
         }
-    }
-
-    private func run() {}
-
-    private func reset() {
-        currentPrompt = ""
     }
 
     private var codeExample: String {


### PR DESCRIPTION
## What changed

- add a dedicated `ReferenceExampleView` scaffold with no prompt editor or Run button
- move Transcript Explorer, Tool Calling Modes, Dynamic Profile, Reasoning Levels, and Image Input onto that reference-only surface
- state plainly on every page what its controls inspect and that no session, tool, image attachment, or model request is executed
- replace the Image Input fake-success result with response-focus guidance
- replace deterministic-looking Reasoning output predictions with the framework's actual contract: the option controls how much thinking is allowed before a response

## Why

These five pages reused `ExampleViewBase`, so each displayed a primary Run button even though its handler was literally empty. That made real Xcode 27 API concepts look like broken demos.

The underlying concepts are real Foundation Models APIs: [tool-calling mode](https://developer.apple.com/documentation/foundationmodels/generationoptions/toolcallingmode), [reasoning level](https://developer.apple.com/documentation/foundationmodels/contextoptions/reasoninglevel), [dynamic profiles](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/profile), [transcripts](https://developer.apple.com/documentation/foundationmodels/transcript), and [image attachment content](https://developer.apple.com/documentation/foundationmodels/imageattachmentcontent). A reference browser should say what it is instead of pretending to execute those APIs.

## Impact

Developers can now distinguish live labs from API recipe/reference pages immediately. The remaining controls still update inspectable explanations and code samples, but there is no dead primary action or canned result masquerading as generated output.

## Validation

- strict SwiftLint on all six changed Swift files: 0 violations
- `git diff --check`
- full generic iOS Simulator build succeeded with Xcode 27.0 (`27A5194q`) and a PR-specific derived-data directory

## Remaining audit findings

These screens still label canned state cycling as Run and deserve the same follow-up treatment or real instrumentation:

- `UsagePerformanceTraceView`
- `ProviderBridgeWalkthroughView`
- `SpotlightRAGExplorerView`
- `FMCLIPythonPlaygroundView`
- `EvaluationsLabView`
- `ModelRouterDashboardView`
- `AgentFlowInspectorView`
- `ToolCallTrajectoryViewerView`

Context-budget/history and security/tool-confirmation surfaces are intentionally excluded because separate focused work is already addressing them.
