### PR TITLE
[codex] Make runtime telemetry truthful

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -95,7 +95,7 @@ enum ExampleType: String, CaseIterable, Identifiable {
         case .foundationModelsSecurityPlayground:
             return "Agent Security"
         case .usagePerformanceTrace:
-            return "Usage Trace"
+            return "Response Usage"
         case .spotlightRAGExplorer:
             return "Spotlight RAG"
         case .providerBridgeWalkthrough:
@@ -132,7 +132,7 @@ enum ExampleType: String, CaseIterable, Identifiable {
         case .generationOptions:
             return "Experiment with model parameters"
         case .modelRuntime:
-            return "Compare system and cloud model surfaces"
+            return "Inspect this device's system model and tokenizer"
         case .contextWindowInspector:
             return "Inspect context size and token budget"
         case .privateCloudCompute:
@@ -164,7 +164,7 @@ enum ExampleType: String, CaseIterable, Identifiable {
         case .foundationModelsSecurityPlayground:
             return "Make untrusted context and action boundaries visible"
         case .usagePerformanceTrace:
-            return "Read tokens, latency, cache, and reasoning metrics"
+            return "Measure streaming time and inspect reported token usage"
         case .spotlightRAGExplorer:
             return "Explore Core Spotlight grounded answers"
         case .providerBridgeWalkthrough:

--- a/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
@@ -11,123 +11,147 @@ import SwiftUI
 
 struct ModelRuntimeView: View {
     @State private var currentPrompt = "Inspect the current Foundation Models runtime."
-    @State private var report = ModelRuntimeReport.placeholder
+    @State private var report: ModelRuntimeReport?
     @State private var isInspecting = false
+    @State private var errorMessage: String?
+    @State private var inspectionID = UUID()
 
     var body: some View {
         ExampleViewBase(
-            title: "Model Runtime",
-            description: "Compare the system model with Xcode 27 runtime capabilities",
+            title: "System Model",
+            description: "Inspect this device's model and tokenize the prompt",
             defaultPrompt: "Inspect the current Foundation Models runtime.",
             currentPrompt: $currentPrompt,
             isRunning: isInspecting,
-            errorMessage: nil,
+            errorMessage: errorMessage,
             codeExample: codeExample,
             onRun: inspectRuntime,
             onReset: reset
         ) {
-            VStack(spacing: Spacing.medium) {
-                Xcode27Section("System Model") {
-                    VStack(spacing: 0) {
-                        Xcode27StatusRow(
-                            title: "Context",
-                            value: "\(report.systemContextSize) tokens",
-                            systemImage: "text.page"
-                        )
-
-                        Divider()
-
-                        Xcode27StatusRow(
-                            title: "Availability",
-                            value: report.systemAvailability,
-                            systemImage: report.systemAvailable ? "checkmark.circle.fill" : "xmark.circle.fill",
-                            tint: report.systemAvailable ? .green : .orange
-                        )
-                    }
-                }
-
-                Xcode27Section("Capabilities") {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(report.capabilities, id: \.name) { capability in
-                            Xcode27InfoRow(
-                                title: capability.name,
-                                detail: capability.isSupported ? "Supported by this model surface." : "Not reported by this model surface.",
-                                systemImage: capability.isSupported ? "checkmark.circle" : "circle",
-                                tint: capability.isSupported ? .green : .secondary
+            VStack(spacing: Spacing.large) {
+                if let report {
+                    Xcode27Section("Current Device") {
+                        VStack(spacing: 0) {
+                            Xcode27StatusRow(
+                                title: "Availability",
+                                value: report.availability,
+                                systemImage: report.isAvailable ? "checkmark.circle.fill" : "exclamationmark.circle.fill",
+                                tint: report.isAvailable ? .green : .orange
                             )
-                            .padding(.vertical, Spacing.small)
 
-                            if capability.name != report.capabilities.last?.name {
-                                Divider()
+                            Divider()
+
+                            Xcode27StatusRow(
+                                title: "Context size",
+                                value: tokenLabel(report.contextSize),
+                                systemImage: "text.page"
+                            )
+
+                            Divider()
+
+                            Xcode27StatusRow(
+                                title: "This prompt",
+                                value: report.promptTokenDescription,
+                                systemImage: "number"
+                            )
+                        }
+                    }
+
+                    Xcode27Section("Model Capabilities") {
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(report.capabilities) { capability in
+                                Xcode27InfoRow(
+                                    title: capability.name,
+                                    detail: capability.detail,
+                                    systemImage: capability.systemImage,
+                                    tint: capability.tint
+                                )
+                                .padding(.vertical, Spacing.small)
+
+                                if capability.id != report.capabilities.last?.id {
+                                    Divider()
+                                }
                             }
                         }
                     }
+                } else {
+                    ContentUnavailableView {
+                        Label("Runtime Not Inspected", systemImage: "cpu")
+                    } description: {
+                        Text("Run the prompt to read availability, context size, tokenizer output, and capabilities from the system model.")
+                    }
                 }
 
-                Xcode27Section("Runtime Note") {
-                    Text(report.runtimeNote)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                Xcode27Section("Scope") {
+                    Text(
+                        "These values describe SystemLanguageModel.default on this device. Private Cloud Compute is a separate " +
+                        "language model with its own availability, quota, supported languages, and asynchronous context size."
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
-            }
-            .task {
-                inspectRuntime()
             }
         }
     }
 
     private func inspectRuntime() {
+        let id = UUID()
+        inspectionID = id
         isInspecting = true
-        defer { isInspecting = false }
+        errorMessage = nil
 
-        let systemModel = SystemLanguageModel.default
-        let availability = systemModel.availability
-        let availabilityText: String
-        let isAvailable: Bool
+        Task { @MainActor in
+            defer {
+                if inspectionID == id {
+                    isInspecting = false
+                }
+            }
 
-        switch availability {
-        case .available:
-            availabilityText = "Available"
-            isAvailable = true
-        case .unavailable(let reason):
-            availabilityText = unavailableReasonDescription(reason)
-            isAvailable = false
+            let model = SystemLanguageModel.default
+            let availability = availabilityDescription(model.availability)
+            let promptTokenDescription: String
+
+            if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *) {
+                do {
+                    let promptTokens = try await model.tokenCount(for: currentPrompt)
+                    promptTokenDescription = tokenLabel(promptTokens)
+                } catch {
+                    promptTokenDescription = "Tokenization failed"
+                    errorMessage = "The runtime was inspected, but the prompt could not be tokenized: \(error.localizedDescription)"
+                }
+            } else {
+                promptTokenDescription = "Requires OS 26.4"
+            }
+
+            guard inspectionID == id else { return }
+            report = ModelRuntimeReport(
+                contextSize: model.contextSize,
+                availability: availability.text,
+                isAvailable: availability.isAvailable,
+                promptTokenDescription: promptTokenDescription,
+                capabilities: capabilityRows(for: model)
+            )
         }
-
-        var capabilities = [
-            ModelCapabilityRow(name: "Vision", isSupported: false),
-            ModelCapabilityRow(name: "Guided generation", isSupported: false),
-            ModelCapabilityRow(name: "Reasoning", isSupported: false),
-            ModelCapabilityRow(name: "Tool calling", isSupported: false)
-        ]
-
-        #if compiler(>=6.4)
-        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
-            let modelCapabilities = systemModel.capabilities
-            capabilities = [
-                ModelCapabilityRow(name: "Vision", isSupported: modelCapabilities.contains(.vision)),
-                ModelCapabilityRow(name: "Guided generation", isSupported: modelCapabilities.contains(.guidedGeneration)),
-                ModelCapabilityRow(name: "Reasoning", isSupported: modelCapabilities.contains(.reasoning)),
-                ModelCapabilityRow(name: "Tool calling", isSupported: modelCapabilities.contains(.toolCalling))
-            ]
-        }
-        #endif
-
-        report = ModelRuntimeReport(
-            systemContextSize: systemModel.contextSize,
-            systemAvailability: availabilityText,
-            systemAvailable: isAvailable,
-            capabilities: capabilities,
-            runtimeNote: """
-            PrivateCloudComputeLanguageModel is inspected separately because its context size is async and may require macOS/iOS 27 \
-            runtime support plus service eligibility.
-            """
-        )
     }
 
     private func reset() {
+        inspectionID = UUID()
+        isInspecting = false
         currentPrompt = ""
-        report = .placeholder
+        report = nil
+        errorMessage = nil
+    }
+
+    private func availabilityDescription(
+        _ availability: SystemLanguageModel.Availability
+    ) -> (text: String, isAvailable: Bool) {
+        switch availability {
+        case .available:
+            ("Available", true)
+        case .unavailable(let reason):
+            (unavailableReasonDescription(reason), false)
+        }
     }
 
     private func unavailableReasonDescription(
@@ -135,23 +159,50 @@ struct ModelRuntimeView: View {
     ) -> String {
         switch reason {
         case .deviceNotEligible:
-            return "Device not eligible"
+            "Device not eligible"
         case .appleIntelligenceNotEnabled:
-            return "Apple Intelligence not enabled"
+            "Apple Intelligence not enabled"
         case .modelNotReady:
-            return "Model not ready"
+            "Model not ready"
         @unknown default:
-            return "Unavailable"
+            "Unavailable"
         }
+    }
+
+    private func capabilityRows(for model: SystemLanguageModel) -> [ModelCapabilityRow] {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            let capabilities = model.capabilities
+            return [
+                ModelCapabilityRow(name: "Vision", isSupported: capabilities.contains(.vision)),
+                ModelCapabilityRow(name: "Guided generation", isSupported: capabilities.contains(.guidedGeneration)),
+                ModelCapabilityRow(name: "Reasoning", isSupported: capabilities.contains(.reasoning)),
+                ModelCapabilityRow(name: "Tool calling", isSupported: capabilities.contains(.toolCalling))
+            ]
+        }
+        #endif
+
+        return [
+            ModelCapabilityRow(name: "Vision", isSupported: nil),
+            ModelCapabilityRow(name: "Guided generation", isSupported: nil),
+            ModelCapabilityRow(name: "Reasoning", isSupported: nil),
+            ModelCapabilityRow(name: "Tool calling", isSupported: nil)
+        ]
+    }
+
+    private func tokenLabel(_ count: Int) -> String {
+        count.formatted() + (count == 1 ? " token" : " tokens")
     }
 
     private var codeExample: String {
         """
-        let systemModel = SystemLanguageModel.default
-        let contextSize = systemModel.contextSize
+        let model = SystemLanguageModel.default
+        let availability = model.availability
+        let contextSize = model.contextSize
+        let promptTokens = try await model.tokenCount(for: prompt)
 
         if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
-            let capabilities = systemModel.capabilities
+            let capabilities = model.capabilities
             capabilities.contains(.toolCalling)
             capabilities.contains(.vision)
         }
@@ -160,29 +211,45 @@ struct ModelRuntimeView: View {
 }
 
 private struct ModelRuntimeReport {
-    var systemContextSize: Int
-    var systemAvailability: String
-    var systemAvailable: Bool
-    var capabilities: [ModelCapabilityRow]
-    var runtimeNote: String
-
-    static let placeholder = ModelRuntimeReport(
-        systemContextSize: 4_096,
-        systemAvailability: "Not inspected yet",
-        systemAvailable: false,
-        capabilities: [
-            ModelCapabilityRow(name: "Vision", isSupported: false),
-            ModelCapabilityRow(name: "Guided generation", isSupported: false),
-            ModelCapabilityRow(name: "Reasoning", isSupported: false),
-            ModelCapabilityRow(name: "Tool calling", isSupported: false)
-        ],
-        runtimeNote: "Tap Run to inspect the local runtime."
-    )
+    let contextSize: Int
+    let availability: String
+    let isAvailable: Bool
+    let promptTokenDescription: String
+    let capabilities: [ModelCapabilityRow]
 }
 
-private struct ModelCapabilityRow {
+private struct ModelCapabilityRow: Identifiable {
     let name: String
-    let isSupported: Bool
+    let isSupported: Bool?
+
+    var id: String { name }
+
+    var detail: String {
+        switch isSupported {
+        case true:
+            "Reported by this model."
+        case false:
+            "Not reported by this model."
+        case nil:
+            "Capability inspection requires the Xcode 27 SDK and an OS 27 runtime."
+        }
+    }
+
+    var systemImage: String {
+        switch isSupported {
+        case true: "checkmark.circle"
+        case false: "xmark.circle"
+        case nil: "questionmark.circle"
+        }
+    }
+
+    var tint: Color {
+        switch isSupported {
+        case true: .green
+        case false: .secondary
+        case nil: .secondary
+        }
+    }
 }
 
 #Preview {

--- a/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
@@ -100,6 +100,7 @@ struct ModelRuntimeView: View {
         inspectionID = id
         isInspecting = true
         errorMessage = nil
+        report = nil
 
         Task { @MainActor in
             defer {

--- a/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ModelRuntimeView.swift
@@ -118,6 +118,7 @@ struct ModelRuntimeView: View {
                     let promptTokens = try await model.tokenCount(for: currentPrompt)
                     promptTokenDescription = tokenLabel(promptTokens)
                 } catch {
+                    guard inspectionID == id else { return }
                     promptTokenDescription = "Tokenization failed"
                     errorMessage = "The runtime was inspected, but the prompt could not be tokenized: \(error.localizedDescription)"
                 }

--- a/Foundation Lab/Views/Examples/Xcode27/UsagePerformanceTraceView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/UsagePerformanceTraceView.swift
@@ -5,141 +5,185 @@
 //  Created by Codex on 6/8/26.
 //
 
+import Foundation
+import FoundationModels
 import SwiftUI
 
 struct UsagePerformanceTraceView: View {
-    @State private var currentPrompt = "Profile the model turn and explain which metric needs attention."
-    @State private var trace = UsageTrace.good
+    @State private var currentPrompt = "Explain how Foundation Models reports token usage in two short paragraphs."
+    @State private var report: UsagePerformanceReport?
+    @State private var isRunning = false
+    @State private var errorMessage: String?
+    @State private var runID = UUID()
 
     var body: some View {
         ExampleViewBase(
-            title: "Usage Trace",
-            description: "Read a model turn like an Instruments trace",
-            defaultPrompt: "Profile the model turn and explain which metric needs attention.",
+            title: "Response Usage",
+            description: "Run a real streamed response and inspect its reported usage",
+            defaultPrompt: "Explain how Foundation Models reports token usage in two short paragraphs.",
             currentPrompt: $currentPrompt,
+            isRunning: isRunning,
+            errorMessage: errorMessage,
             codeExample: codeExample,
-            onRun: cycleTrace,
+            onRun: runTrace,
             onReset: reset
         ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Trace", selection: $trace) {
-                    ForEach(UsageTrace.allCases) { trace in
-                        Text(trace.title).tag(trace)
+            VStack(spacing: Spacing.large) {
+                if let report {
+                    Xcode27Section("Framework-Reported Usage") {
+                        Xcode27KeyValueList(items: [
+                            ("Input", tokenLabel(report.inputTokens)),
+                            ("Cached input", tokenLabel(report.cachedInputTokens)),
+                            ("Output", tokenLabel(report.outputTokens)),
+                            ("Reasoning output", tokenLabel(report.reasoningTokens)),
+                            ("Total", tokenLabel(report.totalTokens))
+                        ])
+                    }
+
+                    Xcode27Section("App-Observed Timing") {
+                        Xcode27KeyValueList(items: [
+                            ("First stream update", durationLabel(report.timeToFirstUpdate)),
+                            ("End to end", durationLabel(report.totalDuration))
+                        ])
+                    }
+
+                    Xcode27Section("Response") {
+                        Text(report.response)
+                            .font(.body)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                    }
+                } else {
+                    ContentUnavailableView {
+                        Label("No Response Measured", systemImage: "waveform.path.ecg")
+                    } description: {
+                        Text("Run the prompt to create a new session, stream one response, and read that response's actual usage.")
                     }
                 }
-                .pickerStyle(.segmented)
 
-                Xcode27Section("Measurements") {
-                    Xcode27KeyValueList(items: [
-                        ("Time to first token", trace.ttft),
-                        ("Total latency", trace.latency),
-                        ("Input tokens", trace.inputTokens),
-                        ("Reasoning tokens", trace.reasoningTokens)
-                    ])
-                }
-
-                Xcode27Section("Diagnosis") {
-                    Text(trace.diagnosis)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                Xcode27Section("What These Numbers Mean") {
+                    Text(
+                        "Token counts come from LanguageModelSession.Response.Usage. Timing is measured by this app with " +
+                        "ContinuousClock; Foundation Models does not attribute latency to prompts, tools, caching, or reasoning."
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
     }
 
-    private func cycleTrace() {
-        let cases = UsageTrace.allCases
-        guard let index = cases.firstIndex(of: trace) else { return }
-        trace = cases[(index + 1) % cases.count]
+    private func runTrace() {
+        let id = UUID()
+        runID = id
+        isRunning = true
+        errorMessage = nil
+        report = nil
+
+        Task { @MainActor in
+            defer {
+                if runID == id {
+                    isRunning = false
+                }
+            }
+
+            #if compiler(>=6.4)
+            guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else {
+                guard runID == id else { return }
+                errorMessage = "Response usage requires an OS 27 runtime."
+                return
+            }
+
+            do {
+                let session = LanguageModelSession()
+                let clock = ContinuousClock()
+                let startedAt = clock.now
+                var firstUpdateAt: ContinuousClock.Instant?
+                let stream = session.streamResponse(
+                    to: currentPrompt,
+                    contextOptions: ContextOptions(reasoningLevel: .moderate),
+                    metadata: ["example": "response-usage"]
+                )
+
+                for try await _ in stream where firstUpdateAt == nil {
+                    firstUpdateAt = clock.now
+                }
+
+                let response = try await stream.collect()
+                let finishedAt = clock.now
+                guard runID == id else { return }
+
+                report = UsagePerformanceReport(
+                    response: response.content,
+                    inputTokens: response.usage.input.totalTokenCount,
+                    cachedInputTokens: response.usage.input.cachedTokenCount,
+                    outputTokens: response.usage.output.totalTokenCount,
+                    reasoningTokens: response.usage.output.reasoningTokenCount,
+                    totalTokens: response.usage.totalTokenCount,
+                    timeToFirstUpdate: firstUpdateAt.map { startedAt.duration(to: $0) },
+                    totalDuration: startedAt.duration(to: finishedAt)
+                )
+            } catch {
+                guard runID == id else { return }
+                errorMessage = error.localizedDescription
+            }
+            #else
+            guard runID == id else { return }
+            errorMessage = "Response usage requires the Xcode 27 SDK."
+            #endif
+        }
     }
 
     private func reset() {
+        runID = UUID()
+        isRunning = false
         currentPrompt = ""
-        trace = .good
+        report = nil
+        errorMessage = nil
+    }
+
+    private func tokenLabel(_ count: Int) -> String {
+        count.formatted() + (count == 1 ? " token" : " tokens")
+    }
+
+    private func durationLabel(_ duration: Duration?) -> String {
+        guard let duration else { return "No update received" }
+        let components = duration.components
+        let seconds = Double(components.seconds) + Double(components.attoseconds) / 1e18
+        return seconds.formatted(.number.precision(.fractionLength(2))) + " s"
     }
 
     private var codeExample: String {
         """
-        let response = try await session.respond(
-            to: prompt,
-            contextOptions: ContextOptions(reasoningLevel: .moderate),
-            metadata: ["turn": turnID]
-        )
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        var firstUpdateAt: ContinuousClock.Instant?
+        let stream = session.streamResponse(to: prompt)
 
+        for try await _ in stream {
+            firstUpdateAt = firstUpdateAt ?? clock.now
+        }
+
+        let response = try await stream.collect()
         print(response.usage.input.totalTokenCount)
         print(response.usage.input.cachedTokenCount)
+        print(response.usage.output.totalTokenCount)
         print(response.usage.output.reasoningTokenCount)
+        print(startedAt.duration(to: firstUpdateAt ?? clock.now))
         """
     }
 }
 
-private enum UsageTrace: String, CaseIterable, Identifiable {
-    case good
-    case highInput
-    case slowTools
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .good: return "Healthy"
-        case .highInput: return "Input"
-        case .slowTools: return "Tools"
-        }
-    }
-
-    var ttft: String {
-        switch self {
-        case .good: return "0.7s"
-        case .highInput: return "1.9s"
-        case .slowTools: return "0.8s"
-        }
-    }
-
-    var latency: String {
-        switch self {
-        case .good: return "2.4s"
-        case .highInput: return "6.8s"
-        case .slowTools: return "9.1s"
-        }
-    }
-
-    var inputTokens: String {
-        switch self {
-        case .good: return "1.8k"
-        case .highInput: return "7.4k"
-        case .slowTools: return "2.1k"
-        }
-    }
-
-    var reasoningTokens: String {
-        switch self {
-        case .good: return "180"
-        case .highInput: return "340"
-        case .slowTools: return "210"
-        }
-    }
-
-    var diagnosis: String {
-        switch self {
-        case .good:
-            return "The trace has a short prompt, cached context, and low tool overhead."
-        case .highInput:
-            return "Most latency comes from oversized input. Add history compaction or narrower tool guidance."
-        case .slowTools:
-            return """
-            Model streaming starts quickly, but the end-to-end turn waits on slow tools. Inspect tool duration before tuning prompts.
-            """
-        }
-    }
-
-    var tint: Color {
-        switch self {
-        case .good: return .green
-        case .highInput: return .orange
-        case .slowTools: return .red
-        }
-    }
+private struct UsagePerformanceReport {
+    let response: String
+    let inputTokens: Int
+    let cachedInputTokens: Int
+    let outputTokens: Int
+    let reasoningTokens: Int
+    let totalTokens: Int
+    let timeToFirstUpdate: Duration?
+    let totalDuration: Duration
 }
 
 #Preview {


### PR DESCRIPTION
## What changed

- replaces the canned Healthy/Input/Tools carousel with a real streamed `LanguageModelSession` response
- shows token counts from `LanguageModelSession.Response.Usage`, including input, cached input, output, reasoning output, and total usage
- measures first stream update and end-to-end duration locally with `ContinuousClock`, explicitly separating app-observed timing from framework telemetry
- makes the system-model prompt functional by passing it to `SystemLanguageModel.tokenCount(for:)`
- removes the fake 4,096-token placeholder and false capability states; the runtime screen now shows a truthful empty state until inspection
- labels OS/SDK-gated fields as unavailable instead of presenting them as unsupported model capabilities
- updates navigation copy to describe the behavior users actually get

## Why

The previous screens presented fabricated latency, token, cache, and diagnostic values as though they came from Foundation Models. Run only rotated among hard-coded scenarios, and the runtime prompt was ignored. That made the examples misleading precisely where developers expect an API inspection tool.

Apple's API separates these concerns: response usage provides token counts, response streams provide partial snapshots, and app code can separately measure elapsed time. The framework does not diagnose why a turn was slow.

## Impact

Developers now get a reproducible live measurement from the active runtime, with clear provenance for every number. Unsupported SDK/runtime combinations produce an explicit explanation rather than invented data.

## Official API references

- [Response usage](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/response/usage)
- [LanguageModelSession.Usage](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/usage-swift.struct)
- [ResponseStream](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/responsestream)
- [ResponseStream.collect()](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/responsestream/collect())
- [SystemLanguageModel.contextSize](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/contextsize)
- [SystemLanguageModel.tokenCount(for:)](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/tokencount(for:))
- [LanguageModel capabilities](https://developer.apple.com/documentation/foundationmodels/languagemodel/capabilities)

## Validation

- `swiftlint lint --config .swiftlint.yml --strict` passes for both changed runtime views
- `git diff --check` passes
- full iOS Simulator build passes with Xcode 27.0 beta (`27A5194q`): `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project FoundationLab.xcodeproj -scheme 'Foundation Lab' -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/foundation-lab-runtime-xcode27-derived build CODE_SIGNING_ALLOWED=NO`
