### PR TITLE
[codex] Make static walkthroughs explicit

### DIFF
--- a/Foundation Lab/Views/Examples/Xcode27/FMCLIPythonPlaygroundView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/FMCLIPythonPlaygroundView.swift
@@ -8,20 +8,30 @@
 import SwiftUI
 
 struct FMCLIPythonPlaygroundView: View {
-    @State private var currentPrompt = "Show how to prototype a Foundation Models workflow outside the app."
     @State private var surface = ScriptingSurface.cli
 
     var body: some View {
-        ExampleViewBase(
-            title: "fm Scripts",
-            description: "Prototype Foundation Models workflows with CLI and Python",
-            defaultPrompt: "Show how to prototype a Foundation Models workflow outside the app.",
-            currentPrompt: $currentPrompt,
-            codeExample: surface.code,
-            onRun: cycleSurface,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Label {
+                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                        Text("Reference playground")
+                            .bold()
+                        Text(
+                            "Nothing runs inside Foundation Lab. Copy a verified example and run it in Terminal "
+                                + "or a Python environment on a supported Mac."
+                        )
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "terminal")
+                        .foregroundStyle(.orange)
+                }
+                .font(.callout)
+                .padding(Spacing.medium)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.orange.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+
                 Picker("Surface", selection: $surface) {
                     ForEach(ScriptingSurface.allCases) { surface in
                         Text(surface.title).tag(surface)
@@ -36,21 +46,28 @@ struct FMCLIPythonPlaygroundView: View {
                             .foregroundStyle(.secondary)
 
                         Xcode27KeyValueList(items: surface.uses)
+
+                        Button("Inspect Next Surface", systemImage: "arrow.right", action: cycleSurface)
+                            .buttonStyle(.glassProminent)
                     }
                 }
+
+                CodeDisclosure(code: surface.code, language: surface.language)
             }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
         }
+        .navigationTitle("macOS Scripting")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Use Apple's fm CLI and Foundation Models SDK for Python")
+        #endif
     }
 
     private func cycleSurface() {
         let cases = ScriptingSurface.allCases
         guard let index = cases.firstIndex(of: surface) else { return }
         surface = cases[(index + 1) % cases.count]
-    }
-
-    private func reset() {
-        currentPrompt = ""
-        surface = .cli
     }
 }
 
@@ -65,29 +82,49 @@ private enum ScriptingSurface: String, CaseIterable, Identifiable {
         switch self {
         case .cli: return "CLI"
         case .python: return "Python"
-        case .evaluation: return "Eval"
+        case .evaluation: return "Evaluation"
         }
     }
 
     var explanation: String {
         switch self {
         case .cli:
-            return "Use the fm command to try prompts, PCC, schemas, and image inputs before building app UI."
+            return "The fm command ships with macOS 27. Use fm chat for interactive exploration "
+                + "and fm respond when a script needs a single response."
         case .python:
-            return "Use Python when the workflow needs datasets, batch processing, notebooks, or existing evaluation tooling."
+            return "The Foundation Models SDK for Python exposes the on-device model to Python 3.10+ "
+                + "on Apple silicon Macs with Xcode installed."
         case .evaluation:
-            return "Keep the script path close to the app behavior so prompt changes can be tested outside the UI loop."
+            return "Use the Python SDK with notebooks and data tools to run representative prompts, "
+                + "record outputs, and compare measurable quality criteria."
         }
     }
 
     var uses: [(String, String)] {
         switch self {
         case .cli:
-            return [("Best for", "quick probes"), ("Input", "files/images"), ("Output", "text/schema"), ("Runtime", "system/PCC")]
+            return [("Runs in", "Terminal on macOS 27"), ("Interactive", "fm chat"), ("Automation", "fm respond"), ("Help", "fm --help")]
         case .python:
-            return [("Best for", "pipelines"), ("Tools", "classes"), ("Schemas", "decorators"), ("Data", "batch")]
+            return [
+                ("Package", "apple_fm_sdk"),
+                ("Python", "3.10 or later"),
+                ("Hardware", "Apple silicon Mac"),
+                ("Setup", "Xcode installed")
+            ]
         case .evaluation:
-            return [("Best for", "regression"), ("Judge", "PCC"), ("Dataset", "JSONL"), ("Report", "metrics")]
+            return [
+                ("Input", "representative prompts"),
+                ("Output", "recorded responses"),
+                ("Measure", "feature-specific criteria"),
+                ("Compare", "prompt variants")
+            ]
+        }
+    }
+
+    var language: String {
+        switch self {
+        case .cli: "shell"
+        case .python, .evaluation: "python"
         }
     }
 
@@ -95,25 +132,35 @@ private enum ScriptingSurface: String, CaseIterable, Identifiable {
         switch self {
         case .cli:
             return """
-            fm respond "Summarize this file" --model pcc < notes.md
-            fm schema object --name FileTriage --string final_files --array
+            fm --help
+            fm chat
+            fm respond "Summarize this document." < notes.md
             """
         case .python:
             return """
             import apple_fm_sdk as fm
 
-            session = fm.LanguageModelSession(
-                instructions="Classify support messages."
-            )
-            result = await session.respond(prompt)
+            model = fm.SystemLanguageModel()
+            is_available, reason = model.is_available()
+
+            if is_available:
+                session = fm.LanguageModelSession(model=model)
+                response = await session.respond(prompt="Hello!")
+                print(response)
             """
         case .evaluation:
             return """
-            dataset = load_samples("samples.jsonl")
-            report = await evaluate(
-                dataset,
-                judge=fm.PrivateCloudComputeLanguageModel()
-            )
+            import apple_fm_sdk as fm
+
+            async def collect_results(prompts: list[str]) -> list[dict[str, str]]:
+                session = fm.LanguageModelSession(instructions="Summarize clearly.")
+                results = []
+
+                for prompt in prompts:
+                    response = await session.respond(prompt)
+                    results.append({"prompt": prompt, "response": str(response)})
+
+                return results
             """
         }
     }

--- a/Foundation Lab/Views/Examples/Xcode27/ProviderBridgeWalkthroughView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ProviderBridgeWalkthroughView.swift
@@ -8,20 +8,27 @@
 import SwiftUI
 
 struct ProviderBridgeWalkthroughView: View {
-    @State private var currentPrompt = "Explain how a custom model becomes a LanguageModelSession backend."
     @State private var selectedLayer = ProviderBridgeLayer.protocols
 
     var body: some View {
-        ExampleViewBase(
-            title: "Provider Bridge",
-            description: "Map custom models into LanguageModelSession",
-            defaultPrompt: "Explain how a custom model becomes a LanguageModelSession backend.",
-            currentPrompt: $currentPrompt,
-            codeExample: selectedLayer.code,
-            onRun: nextLayer,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Label {
+                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                        Text("Reference walkthrough")
+                            .bold()
+                        Text("No model is loaded and no request is sent. Select a layer to inspect the provider contract.")
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "book.pages")
+                        .foregroundStyle(.purple)
+                }
+                .font(.callout)
+                .padding(Spacing.medium)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.purple.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+
                 Xcode27Section("Bridge Layers") {
                     VStack(spacing: 0) {
                         ForEach(ProviderBridgeLayer.allCases) { layer in
@@ -56,12 +63,26 @@ struct ProviderBridgeWalkthroughView: View {
                 }
 
                 Xcode27Section(selectedLayer.title) {
-                    Text(selectedLayer.explanation)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: Spacing.medium) {
+                        Text(selectedLayer.explanation)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+
+                        Button("Inspect Next Layer", systemImage: "arrow.down", action: nextLayer)
+                            .buttonStyle(.glassProminent)
+                    }
                 }
+
+                CodeDisclosure(code: selectedLayer.code)
             }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
         }
+        .navigationTitle("Provider Bridge")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("How a custom LanguageModel executes session requests")
+        #endif
     }
 
     private func nextLayer() {
@@ -73,19 +94,14 @@ struct ProviderBridgeWalkthroughView: View {
     private func select(_ layer: ProviderBridgeLayer) {
         selectedLayer = layer
     }
-
-    private func reset() {
-        currentPrompt = ""
-        selectedLayer = .protocols
-    }
 }
 
 private enum ProviderBridgeLayer: String, CaseIterable, Identifiable {
     case protocols
     case prewarm
+    case request
     case transcript
     case streaming
-    case metadata
 
     var id: String { rawValue }
 
@@ -95,7 +111,7 @@ private enum ProviderBridgeLayer: String, CaseIterable, Identifiable {
         case .prewarm: return "Prewarm"
         case .transcript: return "Transcript"
         case .streaming: return "Streaming"
-        case .metadata: return "Metadata"
+        case .request: return "Request Mapping"
         }
     }
 
@@ -105,24 +121,27 @@ private enum ProviderBridgeLayer: String, CaseIterable, Identifiable {
         case .prewarm: return "Load resources before the user waits."
         case .transcript: return "Map transcript entries to provider messages."
         case .streaming: return "Send tokens and tool output through the channel."
-        case .metadata: return "Attach provider diagnostics to responses."
+        case .request: return "Translate the transcript and options for the backend."
         }
     }
 
     var explanation: String {
         switch self {
         case .protocols:
-            return "A provider bridge should make a custom backend feel like any other LanguageModelSession model."
+            return "A custom model adopts LanguageModel and pairs itself with one LanguageModelExecutor type. "
+                + "LanguageModelSession continues to own the public prompting API."
         case .prewarm:
-            return "Prewarm is where package authors hide weight loading, connection setup, or KV cache preparation."
+            return "The framework calls the executor's prewarm hook when a session is prewarmed. "
+                + "Providers can load assets or prepare cached state before generation begins."
         case .transcript:
-            return "The executor owns the translation from Foundation Models transcript entries to its provider's message format."
+            return "The executor receives the session transcript and is responsible for mapping its entries "
+                + "to the provider's request format."
         case .streaming:
-            return "Streaming should preserve cancellation, partial output, tool calls, and errors without blocking UI state."
-        case .metadata:
-            return """
-            Metadata makes custom providers inspectable: model id, cache hits, latency, safety filters, and provider-specific usage.
-            """
+            return "The executor sends incremental generation events through LanguageModelExecutorGenerationChannel. "
+                + "The channel finishes when respond returns or throws."
+        case .request:
+            return "LanguageModelExecutorGenerationRequest carries the transcript plus generation and context options. "
+                + "A provider maps supported options and defines deliberate fallbacks for unsupported ones."
         }
     }
 
@@ -132,21 +151,54 @@ private enum ProviderBridgeLayer: String, CaseIterable, Identifiable {
         case .prewarm: return "flame"
         case .transcript: return "list.bullet.rectangle.portrait"
         case .streaming: return "waveform"
-        case .metadata: return "tag"
+        case .request: return "arrow.left.arrow.right"
         }
     }
 
     var code: String {
-        """
-        public struct MyLanguageModel: LanguageModel {
-            public typealias Executor = MyLanguageModelExecutor
-            public var capabilities: LanguageModelCapabilities
-            public var executorConfiguration: Executor.Configuration
-        }
+        switch self {
+        case .protocols:
+            return """
+            struct MyLanguageModel: LanguageModel {
+                typealias Executor = MyLanguageModelExecutor
 
-        let custom = try await CoreAILanguageModel(resourcesAt: modelURL)
-        let session = LanguageModelSession(model: custom)
-        """
+                let capabilities: LanguageModelCapabilities
+                let executorConfiguration: Executor.Configuration
+            }
+
+            let session = LanguageModelSession(model: myModel)
+            """
+        case .prewarm:
+            return """
+            func prewarm(
+                model: MyLanguageModel,
+                transcript: Transcript
+            ) {
+                // Load assets or prepare cached state.
+            }
+            """
+        case .transcript, .request:
+            return """
+            func respond(
+                to request: LanguageModelExecutorGenerationRequest,
+                model: MyLanguageModel,
+                streamingInto channel: LanguageModelExecutorGenerationChannel
+            ) async throws {
+                // Map request.transcript and the requested options.
+            }
+            """
+        case .streaming:
+            return """
+            func respond(
+                to request: LanguageModelExecutorGenerationRequest,
+                model: MyLanguageModel,
+                streamingInto channel: LanguageModelExecutorGenerationChannel
+            ) async throws {
+                // Send incremental generation events to channel.
+                // Returning or throwing finishes the channel.
+            }
+            """
+        }
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGExplorerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGExplorerView.swift
@@ -8,20 +8,36 @@
 import SwiftUI
 
 struct SpotlightRAGExplorerView: View {
-    @State private var currentPrompt = "What did I decide about the Kyoto itinerary?"
-    @State private var selectedStage = SpotlightRAGStage.search
+    @State private var selectedStage = SpotlightRAGStage.index
 
     var body: some View {
-        ExampleViewBase(
-            title: "Spotlight RAG",
-            description: "Explain search-grounded Foundation Models answers",
-            defaultPrompt: "What did I decide about the Kyoto itinerary?",
-            currentPrompt: $currentPrompt,
-            codeExample: selectedStage.code,
-            onRun: nextStage,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Label {
+                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                        Text("Architecture walkthrough")
+                            .bold()
+                        Text(
+                            "This screen does not query Spotlight or a language model. "
+                                + "It explains how SpotlightSearchTool grounds a real session in content your app has indexed."
+                        )
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "book.pages")
+                        .foregroundStyle(.blue)
+                }
+                .font(.callout)
+                .padding(Spacing.medium)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.blue.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+
+                Xcode27Section("Example Question") {
+                    Text("“What did I decide about the Kyoto itinerary?”")
+                        .font(.callout)
+                        .textSelection(.enabled)
+                }
+
                 Xcode27Section("Pipeline") {
                     VStack(spacing: 0) {
                         ForEach(SpotlightRAGStage.allCases) { stage in
@@ -56,12 +72,26 @@ struct SpotlightRAGExplorerView: View {
                 }
 
                 Xcode27Section(selectedStage.title) {
-                    Text(selectedStage.explanation)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: Spacing.medium) {
+                        Text(selectedStage.explanation)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+
+                        Button("Inspect Next Stage", systemImage: "arrow.down", action: nextStage)
+                            .buttonStyle(.glassProminent)
+                    }
                 }
+
+                CodeDisclosure(code: selectedStage.code)
             }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
         }
+        .navigationTitle("Spotlight RAG")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Ground a session in your app's indexed content")
+        #endif
     }
 
     private func nextStage() {
@@ -73,85 +103,96 @@ struct SpotlightRAGExplorerView: View {
     private func select(_ stage: SpotlightRAGStage) {
         selectedStage = stage
     }
-
-    private func reset() {
-        currentPrompt = ""
-        selectedStage = .search
-    }
 }
 
 private enum SpotlightRAGStage: String, CaseIterable, Identifiable {
-    case search
-    case hydrate
-    case guide
-    case answer
+    case index
+    case tool
+    case prompt
     case evaluate
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .search: return "Search"
-        case .hydrate: return "Hydrate"
-        case .guide: return "Guide"
-        case .answer: return "Answer"
+        case .index: return "Index Content"
+        case .tool: return "Add Search Tool"
+        case .prompt: return "Prompt Session"
         case .evaluate: return "Evaluate"
         }
     }
 
     var detail: String {
         switch self {
-        case .search: return "Use SpotlightSearchTool against indexed app content."
-        case .hydrate: return "Fetch complete objects for selected results."
-        case .guide: return "Constrain attributes and date/person matching."
-        case .answer: return "Respond with grounded source references."
-        case .evaluate: return "Check trajectory and answer quality."
+        case .index: return "Maintain a Core Spotlight index for your app's content."
+        case .tool: return "Make that index available to LanguageModelSession."
+        case .prompt: return "Ask a question that requires indexed knowledge."
+        case .evaluate: return "Test retrieval relevance and answer quality."
         }
     }
 
     var explanation: String {
         switch self {
-        case .search:
-            return "Search should return enough candidates to ground the answer without stuffing the whole index into context."
-        case .hydrate:
-            return "Hydration lets the model start with compact search hits, then request full data only when needed."
-        case .guide:
-            return "Guidance profiles teach the search tool which attributes matter for a task, such as dates, titles, or people."
-        case .answer:
-            return "The answer should name the source or explain when the index did not contain enough evidence."
+        case .index:
+            return "SpotlightSearchTool searches content already indexed by your app. "
+                + "Index useful metadata and keep the index synchronized as content changes."
+        case .tool:
+            return "Add SpotlightSearchTool to the tools passed to LanguageModelSession. "
+                + "The model can then search the local index when a prompt requires app-specific knowledge."
+        case .prompt:
+            return "Call respond on the session as usual. Tool calling lets the model retrieve relevant indexed content "
+                + "and use it as additional context for the answer."
         case .evaluate:
-            return """
-            Evaluate both result relevance and the tool-call path. A good answer with the wrong trajectory can still hide a fragile flow.
-            """
+            return "Use representative questions and verify retrieval relevance, honest handling of missing evidence, "
+                + "and answers that stay grounded in the index."
         }
     }
 
     var icon: String {
         switch self {
-        case .search: return "magnifyingglass"
-        case .hydrate: return "tray.and.arrow.down"
-        case .guide: return "slider.horizontal.3"
-        case .answer: return "quote.bubble"
+        case .index: return "square.stack.3d.up"
+        case .tool: return "wrench.and.screwdriver"
+        case .prompt: return "text.bubble"
         case .evaluate: return "checklist.checked"
         }
     }
 
     var code: String {
-        """
-        import CoreSpotlight
-        import FoundationModels
+        switch self {
+        case .index:
+            return """
+            import CoreSpotlight
+            import UniformTypeIdentifiers
 
-        let tool = SpotlightSearchTool(
-            configuration: .init(
-                guide: .init(level: .dynamic(profile))
+            let attributes = CSSearchableItemAttributeSet(contentType: .text)
+            attributes.title = "Kyoto itinerary"
+            attributes.contentDescription = "Dinner in Gion on Friday."
+
+            let item = CSSearchableItem(
+                uniqueIdentifier: "trip.kyoto",
+                domainIdentifier: "travel",
+                attributeSet: attributes
             )
-        )
-        let session = LanguageModelSession(
-            model: SystemLanguageModel.default,
-            tools: [tool],
-            instructions: instructions
-        )
-        """
+            try await CSSearchableIndex.default().indexSearchableItems([item])
+            """
+        case .tool, .prompt:
+            return """
+            import CoreSpotlight
+            import FoundationModels
+
+            let tool = SpotlightSearchTool()
+            let session = LanguageModelSession(tools: [tool])
+            let response = try await session.respond(
+                to: "What did I decide about the Kyoto itinerary?"
+            )
+            """
+        case .evaluate:
+            return """
+            // Exercise questions with relevant, missing, and ambiguous evidence.
+            // Inspect retrieval and final-answer quality with Instruments
+            // and your evaluation suite.
+            """
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

- replace the fake prompt-and-Run controls in Provider Bridge, Spotlight RAG, and macOS Scripting with explicit reference-only notices
- relabel the only state-changing actions as Inspect Next Layer, Inspect Next Stage, and Inspect Next Surface
- rewrite the walkthroughs around Apple-documented concepts and remove invented metadata, hydration, and evaluation API claims
- update code samples for `LanguageModelExecutor`, `SpotlightSearchTool`, the `fm` CLI, and `apple_fm_sdk`

## Why

These screens only rotated canned reference content, but their shared prompt editor and Run button implied that Foundation Lab was executing a model request. The new UI states that no request is sent and describes exactly where the examples run.

## Official API references

- [Foundation Models framework](https://developer.apple.com/documentation/FoundationModels/)
- [LanguageModelExecutor](https://developer.apple.com/documentation/foundationmodels/languagemodelexecutor)
- [Spotlight search tool](https://developer.apple.com/documentation/corespotlight/spotlight-search-tool)
- [Build AI-powered scripts with the fm CLI and Python SDK](https://developer.apple.com/videos/play/wwdc2026/334/)

## Validation

- full generic iOS Simulator build with Xcode 27.0 (`27A5194q`) and fresh derived data: passed
- `swiftlint lint --config .swiftlint.yml` on all three changed files: 0 violations
- `xcrun swiftc -parse` on all three changed files: passed
- `git diff --check`: passed
