### PR TITLE
[codex] replace fake agent dashboards with API guides

### DIFF
--- a/Foundation Lab/Views/Examples/Xcode27/AgentFlowInspectorView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/AgentFlowInspectorView.swift
@@ -8,230 +8,274 @@
 import SwiftUI
 
 struct AgentFlowInspectorView: View {
-    @State private var currentPrompt = "Plan a dinner, check my pantry, and draft a grocery list."
-    @State private var selectedStep = AgentFlowStep.profile
+    @State private var selectedPhase = AgentTurnPhase.profile
 
     var body: some View {
-        ExampleViewBase(
-            title: "Agent Flow",
-            description: "Inspect one model turn from prompt to response",
-            defaultPrompt: "Plan a dinner, check my pantry, and draft a grocery list.",
-            currentPrompt: $currentPrompt,
-            codeExample: selectedStep.code,
-            onRun: advance,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
-                Xcode27Section("Turn Timeline") {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Text(
+                    "Foundation Models does not expose a generic agent dashboard. An agentic turn is built from profiles, sessions, " +
+                    "tools, transcript entries, and app-owned policy. Inspect live timing and token behavior with Instruments."
+                )
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+
+                Xcode27Section("Framework map") {
                     VStack(spacing: 0) {
-                        ForEach(AgentFlowStep.allCases) { step in
+                        ForEach(AgentTurnPhase.allCases) { phase in
                             Button {
-                                select(step)
+                                selectedPhase = phase
                             } label: {
-                                AgentFlowStepRow(step: step, isSelected: step == selectedStep)
+                                AgentTurnPhaseRow(phase: phase, isSelected: phase == selectedPhase)
                             }
                             .buttonStyle(.plain)
-                            .accessibilityAddTraits(step == selectedStep ? .isSelected : [])
+                            .accessibilityAddTraits(phase == selectedPhase ? .isSelected : [])
 
-                            if step != AgentFlowStep.allCases.last {
+                            if phase != AgentTurnPhase.allCases.last {
                                 Divider()
                             }
                         }
                     }
                 }
 
-                Xcode27Section(selectedStep.title) {
+                Xcode27Section(selectedPhase.title) {
                     VStack(alignment: .leading, spacing: Spacing.medium) {
-                        Text(selectedStep.detail)
+                        Text(selectedPhase.detail)
                             .font(.callout)
                             .foregroundStyle(.secondary)
 
-                        Xcode27KeyValueList(items: selectedStep.facts)
+                        Xcode27KeyValueList(items: selectedPhase.facts)
                     }
                 }
+
+                Xcode27Section("Ownership boundary") {
+                    Xcode27KeyValueList(items: [
+                        ("Framework", "Profiles, generation, transcript"),
+                        ("Your app", "Routing, permissions, confirmation"),
+                        ("Evaluator", "Quality and regression checks"),
+                        ("Instruments", "Tokens, latency, control flow")
+                    ])
+                }
+
+                CodeDisclosure(code: selectedPhase.code)
             }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
         }
-    }
-
-    private func advance() {
-        let steps = AgentFlowStep.allCases
-        guard let index = steps.firstIndex(of: selectedStep) else { return }
-        selectedStep = steps[(index + 1) % steps.count]
-    }
-
-    private func select(_ step: AgentFlowStep) {
-        selectedStep = step
-    }
-
-    private func reset() {
-        currentPrompt = ""
-        selectedStep = .profile
+        .navigationTitle("Agent Turn Map")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Know which layer owns each decision")
+        #endif
     }
 }
 
-private struct AgentFlowStepRow: View {
-    let step: AgentFlowStep
+private struct AgentTurnPhaseRow: View {
+    let phase: AgentTurnPhase
     let isSelected: Bool
 
     var body: some View {
         HStack(spacing: Spacing.medium) {
-            Image(systemName: step.icon)
-                .foregroundStyle(step.tint)
+            Image(systemName: phase.icon)
+                .foregroundStyle(phase.tint)
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text(step.title)
+                Text(phase.title)
                     .font(.subheadline)
                     .bold()
-                Text(step.summary)
+                Text(phase.summary)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
 
-            Spacer()
+            Spacer(minLength: Spacing.small)
 
-            if isSelected {
-                Image(systemName: "checkmark")
-                    .foregroundStyle(step.tint)
-                    .accessibilityHidden(true)
-            }
+            Image(systemName: isSelected ? "checkmark" : "chevron.right")
+                .foregroundStyle(isSelected ? phase.tint : .secondary)
+                .accessibilityHidden(true)
         }
         .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        .padding(.vertical, Spacing.small)
         .contentShape(.rect)
     }
 }
 
-private enum AgentFlowStep: String, CaseIterable, Identifiable {
+private enum AgentTurnPhase: String, CaseIterable, Identifiable {
     case profile
-    case history
-    case toolPolicy
-    case modelCall
-    case toolCall
-    case response
-    case usage
+    case generation
+    case tools
+    case transcript
+    case instruments
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .profile: return "Profile selected"
-        case .history: return "History transformed"
-        case .toolPolicy: return "Tool policy"
-        case .modelCall: return "Model call"
-        case .toolCall: return "Tool call"
-        case .response: return "Response"
-        case .usage: return "Usage"
+        case .profile: "Dynamic profile"
+        case .generation: "Session request"
+        case .tools: "Tool lifecycle"
+        case .transcript: "Transcript"
+        case .instruments: "Runtime trace"
         }
     }
 
     var summary: String {
         switch self {
-        case .profile: return "Choose instructions, model, tools, and callbacks"
-        case .history: return "Trim, redact, or spotlight transcript entries"
-        case .toolPolicy: return "Allowed, required, or disallowed tools"
-        case .modelCall: return "Send prompt with generation and context options"
-        case .toolCall: return "Review arguments before side effects"
-        case .response: return "Render text, structure, and transcript entries"
-        case .usage: return "Inspect tokens, latency, and cache behavior"
+        case .profile: "Select instructions, tools, model, and options"
+        case .generation: "Generate through LanguageModelSession"
+        case .tools: "Observe calls and outputs around app code"
+        case .transcript: "Read the linear history of the session"
+        case .instruments: "Measure live latency, tokens, and control flow"
         }
     }
 
     var detail: String {
         switch self {
         case .profile:
-            return """
-            A DynamicProfile is the control plane for an agent turn. It explains why this mode got these instructions, tools, model, \
-            and lifecycle hooks.
             """
-        case .history:
-            return """
-            History transforms are where context compaction and safety become visible. Show what was kept, dropped, summarized, \
-            or marked as untrusted.
+            LanguageModelSession.Profile binds dynamic instructions to session configuration. DynamicProfile can change that \
+            configuration from app state before requests.
             """
-        case .toolPolicy:
-            return "Tool calling mode should be a product decision. A weather answer may require a tool; a draft may disallow tools."
-        case .modelCall:
-            return "The model call combines prompt, profile, generation options, context options, and metadata into one auditable request."
-        case .toolCall:
-            return "Risky tools should pause for confirmation before doing irreversible or user-visible work."
-        case .response:
-            return """
-            Responses are not just strings. They carry transcript entries, generated content, and usage data that should feed diagnostics.
+        case .generation:
             """
-        case .usage:
-            return "Usage closes the loop: token counts, cached tokens, reasoning tokens, and latency tell you whether the flow is healthy."
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .profile: return "person.text.rectangle"
-        case .history: return "clock.arrow.circlepath"
-        case .toolPolicy: return "hammer"
-        case .modelCall: return "brain.head.profile"
-        case .toolCall: return "hand.raised"
-        case .response: return "text.bubble"
-        case .usage: return "speedometer"
-        }
-    }
-
-    var tint: Color {
-        switch self {
-        case .profile: return .blue
-        case .history: return .purple
-        case .toolPolicy: return .orange
-        case .modelCall: return .indigo
-        case .toolCall: return .red
-        case .response: return .green
-        case .usage: return .teal
+            LanguageModelSession owns the interaction with a LanguageModel. Respond and streamResponse are the generation boundary; \
+            GenerationOptions and ContextOptions configure a request.
+            """
+        case .tools:
+            """
+            A Tool exposes app code to the model. Tool-calling mode controls whether tools are allowed, required, or disallowed. \
+            Profile lifecycle callbacks observe calls and outputs; your app still owns authorization and side-effect policy.
+            """
+        case .transcript:
+            """
+            The transcript is the inspectable session history. It contains instructions, prompts, responses, tool calls, and tool \
+            outputs. It does not promise fabricated cache or latency fields.
+            """
+        case .instruments:
+            """
+            Use the Foundation Models Instrument to inspect live prompts, response timing, token consumption, tool activity, and control \
+            flow. Those measurements come from a recorded trace, not a SwiftUI sample screen.
+            """
         }
     }
 
     var facts: [(String, String)] {
         switch self {
         case .profile:
-            return [("Mode", "Planning"), ("Model", "System/PCC"), ("Tools", "Pantry, Notes"), ("Callbacks", "onToolCall")]
-        case .history:
-            return [("Kept", "5 entries"), ("Summarized", "12 entries"), ("Redacted", "2 secrets"), ("Budget saved", "1,840 tokens")]
-        case .toolPolicy:
-            return [("Mode", "Required"), ("Reason", "Fresh pantry data"), ("Fallback", "Ask user"), ("Risk", "Low")]
-        case .modelCall:
-            return [("Reasoning", "Moderate"), ("Max output", "600"), ("Metadata", "turn-id"), ("Context", "Compacted")]
-        case .toolCall:
-            return [
-                ("Tool", "createGroceryList"),
-                ("Side effect", "Draft only"),
-                ("Confirmation", "Not needed"),
-                ("Arguments", "Validated")
+            [
+                ("API", "DynamicProfile"),
+                ("Concrete type", "Profile"),
+                ("Content", "DynamicInstructions"),
+                ("Re-evaluates", "From app state")
             ]
-        case .response:
-            return [("Format", "Checklist"), ("Sources", "Pantry tool"), ("Transcript", "4 new entries"), ("Status", "Rendered")]
-        case .usage:
-            return [("Input", "2,180"), ("Cached", "740"), ("Output", "420"), ("TTFT", "0.8s")]
+        case .generation:
+            [
+                ("API", "LanguageModelSession"),
+                ("Model", "Any LanguageModel"),
+                ("One shot", "respond"),
+                ("Streaming", "streamResponse")
+            ]
+        case .tools:
+            [
+                ("API", "Tool"),
+                ("Modes", "Allowed, required, disallowed"),
+                ("Before call", "onToolCall"),
+                ("After output", "onToolOutput")
+            ]
+        case .transcript:
+            [
+                ("API", "Transcript"),
+                ("Order", "Linear entries"),
+                ("Includes", "Calls and outputs"),
+                ("Use", "History and diagnostics")
+            ]
+        case .instruments:
+            [
+                ("Tool", "Foundation Models Instrument"),
+                ("Source", "Recorded runtime trace"),
+                ("Shows", "Timing and token use"),
+                ("Use", "Debug and optimize")
+            ]
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .profile: "slider.horizontal.3"
+        case .generation: "text.bubble"
+        case .tools: "hammer"
+        case .transcript: "list.bullet.rectangle"
+        case .instruments: "gauge.with.dots.needle.67percent"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .profile: .blue
+        case .generation: .indigo
+        case .tools: .orange
+        case .transcript: .green
+        case .instruments: .purple
         }
     }
 
     var code: String {
-        """
-        struct PlanningProfile: LanguageModelSession.DynamicProfile {
-            var mode: AgentMode
+        switch self {
+        case .profile:
+            """
+            let profile = LanguageModelSession.Profile {
+                DynamicInstructions("Help with the current task.")
+                SearchTool()
+            }
+            .model(SystemLanguageModel.default)
+            .toolCallingMode(.allowed)
 
-            var body: some DynamicProfile {
-                Profile {
-                    PlanningInstructions(mode: mode)
-                    PantryTool()
-                    GroceryDraftTool()
-                }
-                .toolCallingMode(mode.requiresFreshData ? .required : .allowed)
-                .historyTransform { history in
-                    history.compactedForPlanning()
-                }
-                .onToolCall { call in
-                    try await confirmIfRisky(call)
+            let session = LanguageModelSession(profile: profile)
+            """
+        case .generation:
+            """
+            let session = LanguageModelSession()
+            let response = try await session.respond(to: prompt)
+
+            for try await snapshot in session.streamResponse(to: prompt) {
+                // Render the latest snapshot.
+            }
+            """
+        case .tools:
+            """
+            LanguageModelSession.Profile {
+                SearchTool()
+            }
+            .toolCallingMode(.allowed)
+            .onToolCall { call in
+                // Log or apply app-owned authorization policy.
+            }
+            .onToolOutput { call, output in
+                // Record the observed output.
+            }
+            """
+        case .transcript:
+            """
+            for entry in session.transcript {
+                switch entry {
+                case .toolCalls(let calls):
+                    inspect(calls)
+                case .toolOutput(let output):
+                    inspect(output)
+                default:
+                    break
                 }
             }
+            """
+        case .instruments:
+            """
+            // Product > Profile in Xcode, then record with the
+            // Foundation Models Instrument. Inspect the trace for live
+            // model requests, tool activity, tokens, and timing.
+            """
         }
-        """
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/EvaluationsLabView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/EvaluationsLabView.swift
@@ -8,102 +8,179 @@
 import SwiftUI
 
 struct EvaluationsLabView: View {
-    @State private var currentPrompt = "Evaluate whether the assistant produced useful tags and called the right tools."
-    @State private var target = EvaluationTarget.judge
+    @State private var selectedLayer = EvaluationLayer.dataset
 
     var body: some View {
-        ExampleViewBase(
-            title: "Evaluations",
-            description: "Turn model behavior into measurable checks",
-            defaultPrompt: "Evaluate whether the assistant produced useful tags and called the right tools.",
-            currentPrompt: $currentPrompt,
-            codeExample: target.code,
-            onRun: cycleTarget,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Evaluation", selection: $target) {
-                    ForEach(EvaluationTarget.allCases) { target in
-                        Text(target.title).tag(target)
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Text(
+                    "Evaluations are repeatable tests you run against a dataset. This guide describes the real test workflow; " +
+                    "it does not invent scores for a single prompt."
+                )
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+
+                Picker("Evaluation layer", selection: $selectedLayer) {
+                    ForEach(EvaluationLayer.allCases) { layer in
+                        Text(layer.title).tag(layer)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                Xcode27Section(target.title) {
+                Xcode27Section(selectedLayer.title) {
                     VStack(alignment: .leading, spacing: Spacing.medium) {
-                        Text(target.explanation)
+                        Text(selectedLayer.explanation)
                             .font(.callout)
                             .foregroundStyle(.secondary)
 
-                        Xcode27KeyValueList(items: target.metrics)
+                        Xcode27KeyValueList(items: selectedLayer.facts)
                     }
                 }
+
+                Xcode27Section("What makes a result real") {
+                    VStack(alignment: .leading, spacing: 0) {
+                        EvaluationEvidenceRow(
+                            title: "Known inputs",
+                            detail: "Versioned samples cover success, challenge, adversarial, and past-failure cases.",
+                            systemImage: "tray.full"
+                        )
+                        Divider()
+                        EvaluationEvidenceRow(
+                            title: "Declared criteria",
+                            detail: "Each metric has a rule, scale, threshold, or rubric before the suite runs.",
+                            systemImage: "checklist"
+                        )
+                        Divider()
+                        EvaluationEvidenceRow(
+                            title: "Generated report",
+                            detail: "The Evaluations framework records per-sample measurements and aggregate results in the test report.",
+                            systemImage: "chart.bar.doc.horizontal"
+                        )
+                    }
+                }
+
+                CodeDisclosure(code: selectedLayer.code)
             }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
         }
-    }
-
-    private func cycleTarget() {
-        let cases = EvaluationTarget.allCases
-        guard let index = cases.firstIndex(of: target) else { return }
-        target = cases[(index + 1) % cases.count]
-    }
-
-    private func reset() {
-        currentPrompt = ""
-        target = .judge
+        .navigationTitle("Evaluations")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Design a test suite before trusting a score")
+        #endif
     }
 }
 
-private enum EvaluationTarget: String, CaseIterable, Identifiable {
+private struct EvaluationEvidenceRow: View {
+    let title: String
+    let detail: String
+    let systemImage: String
+
+    var body: some View {
+        Xcode27InfoRow(
+            title: title,
+            detail: detail,
+            systemImage: systemImage,
+            tint: .blue
+        )
+        .padding(.vertical, Spacing.small)
+    }
+}
+
+private enum EvaluationLayer: String, CaseIterable, Identifiable {
+    case dataset
+    case metric
     case judge
-    case synthetic
-    case trajectory
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .judge: return "Judge"
-        case .synthetic: return "Samples"
-        case .trajectory: return "Tools"
+        case .dataset: "Dataset"
+        case .metric: "Metrics"
+        case .judge: "Model judge"
         }
     }
 
     var explanation: String {
         switch self {
+        case .dataset:
+            """
+            A representative dataset is the foundation of an evaluation. A synthetic-data pass can expand coverage, but generated \
+            samples still need validation before they become test evidence.
+            """
+        case .metric:
+            """
+            Use deterministic rules for objective requirements, ground truth when a correct answer exists, and semantic or \
+            model-based measurements only when the criterion requires them.
+            """
         case .judge:
-            return "Use a model judge when correctness depends on qualitative dimensions such as relevance, helpfulness, or tone."
-        case .synthetic:
-            return "Generate more samples from a seed dataset, then validate the generated samples before trusting them."
-        case .trajectory:
-            return "Evaluate not only the final answer but the path: which tools were called, in what order, and with which arguments."
+            """
+            A model judge scores qualitative dimensions such as relevance or tone. Calibrate its rubric against human judgment; \
+            the judge model and its rubric are part of the test configuration.
+            """
         }
     }
 
-    var metrics: [(String, String)] {
+    var facts: [(String, String)] {
         switch self {
+        case .dataset:
+            [
+                ("Defines", "Test inputs"),
+                ("Include", "Common, edge, adversarial"),
+                ("Review", "Synthetic samples"),
+                ("Lives in", "Evaluation test target")
+            ]
+        case .metric:
+            [
+                ("Rule based", "Objective checks"),
+                ("Ground truth", "Known answer"),
+                ("Semantic", "Meaning similarity"),
+                ("Output", "Per-sample measurement")
+            ]
         case .judge:
-            return [("Relevance", "4/4"), ("Usefulness", "3/4"), ("Tone", "4/4"), ("Judge", "PCC")]
-        case .synthetic:
-            return [("Seed", "24"), ("Generated", "100"), ("Valid", "92"), ("Rejected", "8")]
-        case .trajectory:
-            return [("Expected", "search -> fetch"), ("Actual", "search -> fetch"), ("Tool args", "matched"), ("Result", "pass")]
+            [
+                ("Use for", "Qualitative criteria"),
+                ("Requires", "Explicit scale and rubric"),
+                ("Validate with", "Human ratings"),
+                ("Model", "Configured by the test")
+            ]
         }
     }
 
     var code: String {
-        """
-        ModelJudgeEvaluator(
-            "AnswerQuality",
-            judge: PrivateCloudComputeLanguageModel(),
-            dimensions: [relevance, usefulness]
-        )
+        switch self {
+        case .dataset:
+            """
+            import Evaluations
 
-        TrajectoryExpectation(ordered: [
-            ToolExpectation("search"),
-            ToolExpectation("fetchDetails")
-        ])
-        """
+            // Keep evaluation samples in a test target. Each sample should
+            // contain the input plus the reference data your metrics need.
+            // Run the complete suite after every prompt or model change.
+            """
+        case .metric:
+            """
+            import Evaluations
+
+            // Prefer a deterministic metric when the requirement is exact:
+            // forbidden content, required fields, value ranges, or a match
+            // against verified ground truth.
+            """
+        case .judge:
+            """
+            let evaluator = ModelJudgeEvaluator(
+                "TagQuality",
+                scale: .numeric([
+                    4: "Relevant and helpful",
+                    3: "Mostly relevant",
+                    2: "Several weak tags",
+                    1: "Unhelpful or irrelevant"
+                ]),
+                judge: PrivateCloudComputeLanguageModel()
+            )
+            """
+        }
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ModelRouterDashboardView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ModelRouterDashboardView.swift
@@ -8,187 +8,236 @@
 import SwiftUI
 
 struct ModelRouterDashboardView: View {
-    @State private var currentPrompt = "Choose the right runtime for a long visual reasoning task."
-    @State private var selectedWorkload = RouterWorkload.visualReasoning
+    @State private var requirement = ModelRequirement.offline
 
     var body: some View {
-        ExampleViewBase(
-            title: "Model Router",
-            description: "Explain why a runtime was selected",
-            defaultPrompt: "Choose the right runtime for a long visual reasoning task.",
-            currentPrompt: $currentPrompt,
-            codeExample: selectedWorkload.code,
-            onRun: cycleWorkload,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Workload", selection: $selectedWorkload) {
-                    ForEach(RouterWorkload.allCases) { workload in
-                        Text(workload.title).tag(workload)
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Text(
+                    "Foundation Models provides model surfaces, not an automatic router. Your app chooses a model after evaluating " +
+                    "quality, capabilities, availability, privacy, and fallback behavior."
+                )
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+
+                Picker("Primary requirement", selection: $requirement) {
+                    ForEach(ModelRequirement.allCases) { requirement in
+                        Text(requirement.title).tag(requirement)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                Xcode27StatusRow(
-                    title: "Selected Runtime",
-                    value: selectedWorkload.selectedRuntime,
-                    systemImage: "arrow.triangle.branch",
-                    tint: selectedWorkload.tint
-                )
+                Xcode27Section("Example app policy") {
+                    VStack(alignment: .leading, spacing: Spacing.medium) {
+                        Xcode27StatusRow(
+                            title: "Start with",
+                            value: requirement.recommendation,
+                            systemImage: requirement.icon,
+                            tint: requirement.tint
+                        )
 
-                Xcode27Section("Runtime Matrix") {
+                        Text(requirement.reason)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+
+                        Text(
+                            "This is a design recommendation, not a runtime selection. Check availability and capabilities before " +
+                            "creating the session."
+                        )
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Xcode27Section("Actual model surfaces") {
                     VStack(spacing: 0) {
-                        ForEach(RuntimeCandidate.samples) { candidate in
-                            RuntimeCandidateRow(candidate: candidate, workload: selectedWorkload)
+                        ForEach(ModelSurface.allCases) { surface in
+                            ModelSurfaceRow(surface: surface)
 
-                            if candidate.id != RuntimeCandidate.samples.last?.id {
+                            if surface != ModelSurface.allCases.last {
                                 Divider()
                             }
                         }
                     }
                 }
 
-                Xcode27Section("Routing Explanation") {
-                    Text(selectedWorkload.reason)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                Xcode27Section("Selection order") {
+                    Xcode27KeyValueList(items: [
+                        ("1", "Evaluate feature quality"),
+                        ("2", "Match required capabilities"),
+                        ("3", "Check runtime availability"),
+                        ("4", "Apply a documented fallback")
+                    ])
                 }
+
+                CodeDisclosure(code: requirement.code)
             }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
         }
-    }
-
-    private func cycleWorkload() {
-        let cases = RouterWorkload.allCases
-        guard let index = cases.firstIndex(of: selectedWorkload) else { return }
-        selectedWorkload = cases[(index + 1) % cases.count]
-    }
-
-    private func reset() {
-        currentPrompt = ""
-        selectedWorkload = .visualReasoning
+        .navigationTitle("Choosing a Model")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Make routing an explicit app policy")
+        #endif
     }
 }
 
-private struct RuntimeCandidateRow: View {
-    let candidate: RuntimeCandidate
-    let workload: RouterWorkload
+private struct ModelSurfaceRow: View {
+    let surface: ModelSurface
 
     var body: some View {
-        HStack(spacing: Spacing.medium) {
-            Image(systemName: isSelected ? "checkmark.circle.fill" : candidate.icon)
-                .foregroundStyle(isSelected ? workload.tint : .secondary)
+        HStack(alignment: .top, spacing: Spacing.medium) {
+            Image(systemName: surface.icon)
+                .foregroundStyle(surface.tint)
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text(candidate.name)
+                Text(surface.title)
                     .font(.subheadline)
                     .bold()
-                Text(candidate.detail)
+                Text(surface.detail)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
 
-            Spacer()
-
-            Text(candidate.badge)
-                .font(.footnote)
-                .foregroundStyle(isSelected ? workload.tint : .secondary)
+            Spacer(minLength: Spacing.small)
         }
-        .frame(minHeight: 44)
+        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        .padding(.vertical, Spacing.small)
         .accessibilityElement(children: .combine)
     }
-
-    private var isSelected: Bool {
-        candidate.name == workload.selectedRuntime
-    }
 }
 
-private struct RuntimeCandidate: Identifiable {
-    let id = UUID()
-    let name: String
-    let detail: String
-    let badge: String
-    let icon: String
-
-    static let samples = [
-        RuntimeCandidate(name: "System", detail: "Fast, private, lower context budget.", badge: "Local", icon: "iphone"),
-        RuntimeCandidate(name: "PCC", detail: "Larger model surface with service and quota gates.", badge: "Cloud", icon: "icloud"),
-        RuntimeCandidate(
-            name: "Core AI",
-            detail: "App-bundled open model through LanguageModelSession.",
-            badge: "Custom",
-            icon: "shippingbox"
-        ),
-        RuntimeCandidate(
-            name: "Provider",
-            detail: "Third-party or server executor with custom metadata.",
-            badge: "Executor",
-            icon: "server.rack"
-        )
-    ]
-}
-
-private enum RouterWorkload: String, CaseIterable, Identifiable {
-    case visualReasoning
-    case privateDraft
-    case bundledModel
+private enum ModelSurface: String, CaseIterable, Identifiable {
+    case system
+    case pcc
+    case custom
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .visualReasoning: return "Visual"
-        case .privateDraft: return "Private"
-        case .bundledModel: return "Bundled"
+        case .system: "SystemLanguageModel"
+        case .pcc: "PrivateCloudComputeLanguageModel"
+        case .custom: "LanguageModel conformance"
         }
     }
 
-    var selectedRuntime: String {
+    var detail: String {
         switch self {
-        case .visualReasoning: return "PCC"
-        case .privateDraft: return "System"
-        case .bundledModel: return "Core AI"
-        }
-    }
-
-    var reason: String {
-        switch self {
-        case .visualReasoning:
-            return """
-            The task needs image understanding, deeper reasoning, and a larger budget. Prefer PCC when available, then fall back clearly.
+        case .system: "Apple's on-device model. It works offline and has no daily usage quota."
+        case .pcc:
             """
-        case .privateDraft: return "The prompt is personal and short. Keep it on device unless the user opts into another runtime."
-        case .bundledModel: return "The app ships a specialized model. Use Core AI through the shared LanguageModel interface."
+            Apple's server model for more reasoning and context. It requires availability, network access, entitlement eligibility, \
+            and has usage limits.
+            """
+        case .custom: "A bridge your app or package implements for another model provider through LanguageModel and LanguageModelExecutor."
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .system: "iphone"
+        case .pcc: "icloud"
+        case .custom: "server.rack"
         }
     }
 
     var tint: Color {
         switch self {
-        case .visualReasoning: return .blue
-        case .privateDraft: return .green
-        case .bundledModel: return .purple
+        case .system: .green
+        case .pcc: .blue
+        case .custom: .purple
+        }
+    }
+}
+
+private enum ModelRequirement: String, CaseIterable, Identifiable {
+    case offline
+    case reasoning
+    case provider
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .offline: "Offline"
+        case .reasoning: "Reasoning"
+        case .provider: "Custom"
+        }
+    }
+
+    var recommendation: String {
+        switch self {
+        case .offline: "System model"
+        case .reasoning: "Evaluate PCC"
+        case .provider: "Custom model"
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case .offline: "Choose the on-device system model when the feature must work without a network connection."
+        case .reasoning:
+            "Start on device, evaluate the feature, then choose PCC if measured quality requires its reasoning or larger context."
+        case .provider:
+            """
+            Adopt LanguageModel when the product requires a model that Apple does not provide directly. Your executor owns provider \
+            translation and streaming.
+            """
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .offline: "iphone"
+        case .reasoning: "brain.head.profile"
+        case .provider: "shippingbox"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .offline: .green
+        case .reasoning: .blue
+        case .provider: .purple
         }
     }
 
     var code: String {
-        """
-        enum RuntimeChoice {
-            case system
-            case privateCloudCompute
-            case coreAI(URL)
-        }
+        switch self {
+        case .offline:
+            """
+            let model = SystemLanguageModel.default
+            guard model.isAvailable else {
+                // Present the app's unavailable state.
+                return
+            }
 
-        let model: any LanguageModel = switch choice {
-        case .system:
-            SystemLanguageModel.default
-        case .privateCloudCompute:
-            PrivateCloudComputeLanguageModel()
-        case .coreAI(let url):
-            try await CoreAILanguageModel(resourcesAt: url)
-        }
+            let session = LanguageModelSession(model: model)
+            """
+        case .reasoning:
+            """
+            let model = PrivateCloudComputeLanguageModel()
+            guard model.isAvailable else {
+                // Apply the fallback your feature documents.
+                return
+            }
 
-        let session = LanguageModelSession(model: model)
-        """
+            let session = LanguageModelSession(model: model)
+            """
+        case .provider:
+            """
+            // A custom provider adopts LanguageModel and supplies a
+            // LanguageModelExecutor that translates requests and streams
+            // updates through LanguageModelExecutorGenerationChannel.
+            let session = LanguageModelSession(
+                model: MyCustomServerLanguageModel()
+            )
+            """
+        }
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewerView.swift
@@ -8,53 +8,81 @@
 import SwiftUI
 
 struct ToolCallTrajectoryViewerView: View {
-    @State private var currentPrompt = "Find my hiking notes near water and summarize the best one."
-    @State private var scenario = TrajectoryScenario.good
+    @State private var fixture = TrajectoryFixture.match
 
     var body: some View {
-        ExampleViewBase(
-            title: "Trajectory",
-            description: "Compare expected and actual tool paths",
-            defaultPrompt: "Find my hiking notes near water and summarize the best one.",
-            currentPrompt: $currentPrompt,
-            codeExample: scenario.code,
-            onRun: cycleScenario,
-            onReset: reset
-        ) {
-            VStack(spacing: Spacing.medium) {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Text(
+                    "A trajectory is the ordered path a model takes through tools. These are labeled teaching fixtures, not calls " +
+                    "captured from this device. In a real app, derive the path from the session transcript and score it in a test."
+                )
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+
+                Picker("Teaching fixture", selection: $fixture) {
+                    ForEach(TrajectoryFixture.allCases) { fixture in
+                        Text(fixture.title).tag(fixture)
+                    }
+                }
+                .pickerStyle(.segmented)
+
                 Xcode27StatusRow(
-                    title: "Evaluation Result",
-                    value: scenario.result,
-                    systemImage: scenario.icon,
-                    tint: scenario.tint
+                    title: "Fixture comparison",
+                    value: fixture.result.title,
+                    systemImage: fixture.result.icon,
+                    tint: fixture.result.tint
                 )
 
-                Xcode27Section("Expected Path") {
-                    TrajectoryPathView(steps: TrajectoryScenario.expected)
+                Xcode27Section("Expected tool path") {
+                    TrajectoryPathView(steps: TrajectoryFixture.expected)
                 }
 
-                Xcode27Section("Actual Path") {
-                    TrajectoryPathView(steps: scenario.actual)
+                Xcode27Section("Authored fixture") {
+                    TrajectoryPathView(steps: fixture.steps)
                 }
 
-                Xcode27Section("Why It Matters") {
-                    Text(scenario.explanation)
+                Xcode27Section("Why the fixture is classified this way") {
+                    Text(fixture.explanation)
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
+
+                Xcode27Section("Production workflow") {
+                    Xcode27KeyValueList(items: [
+                        ("Observe", "session.transcript"),
+                        ("Extract", "Tool call names and arguments"),
+                        ("Compare", "Declared expectation"),
+                        ("Report", "Evaluations test result")
+                    ])
+                }
+
+                CodeDisclosure(code: codeExample)
+            }
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+        }
+        .navigationTitle("Tool Trajectories")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Compare explicit fixtures, not imaginary runs")
+        #endif
+    }
+
+    private var codeExample: String {
+        """
+        let toolCallEntries = session.transcript.compactMap { entry in
+            if case .toolCalls(let calls) = entry {
+                calls
+            } else {
+                nil
             }
         }
-    }
 
-    private func cycleScenario() {
-        let cases = TrajectoryScenario.allCases
-        guard let index = cases.firstIndex(of: scenario) else { return }
-        scenario = cases[(index + 1) % cases.count]
-    }
-
-    private func reset() {
-        currentPrompt = ""
-        scenario = .good
+        // Pass the observed calls and your declared expectation to an
+        // evaluation in the test target. Keep the full arguments when
+        // correctness depends on more than tool names and order.
+        """
     }
 }
 
@@ -64,8 +92,8 @@ private struct TrajectoryPathView: View {
     var body: some View {
         VStack(spacing: 0) {
             ForEach(steps.enumerated(), id: \.element.id) { index, step in
-                HStack(spacing: Spacing.medium) {
-                    Text("\(index + 1)")
+                HStack(alignment: .top, spacing: Spacing.medium) {
+                    Text(index + 1, format: .number)
                         .font(.footnote.monospacedDigit())
                         .bold()
                         .frame(width: 24, height: 24)
@@ -80,9 +108,10 @@ private struct TrajectoryPathView: View {
                             .foregroundStyle(.secondary)
                     }
 
-                    Spacer()
+                    Spacer(minLength: Spacing.small)
                 }
-                .frame(minHeight: 44)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                .padding(.vertical, Spacing.small)
                 .accessibilityElement(children: .combine)
 
                 if index < steps.count - 1 {
@@ -94,89 +123,104 @@ private struct TrajectoryPathView: View {
     }
 }
 
-private struct TrajectoryStep: Identifiable {
-    let id = UUID()
+private struct TrajectoryStep: Identifiable, Equatable {
     let name: String
     let detail: String
     var tint: Color = .blue
+
+    var id: String { "\(name)-\(detail)" }
+
+    static func == (lhs: TrajectoryStep, rhs: TrajectoryStep) -> Bool {
+        lhs.name == rhs.name && lhs.detail == rhs.detail
+    }
 }
 
-private enum TrajectoryScenario: String, CaseIterable, Identifiable {
-    case good
-    case redundant
-    case unsafe
+private enum TrajectoryResult {
+    case match
+    case review
+    case fail
 
-    var id: String { rawValue }
-
-    static let expected = [
-        TrajectoryStep(name: "Spotlight search", detail: "Search notes for water hikes"),
-        TrajectoryStep(name: "Fetch item", detail: "Hydrate the best matching note"),
-        TrajectoryStep(name: "Answer", detail: "Summarize with source")
-    ]
-
-    var actual: [TrajectoryStep] {
+    var title: String {
         switch self {
-        case .good:
-            return Self.expected
-        case .redundant:
-            return [
-                TrajectoryStep(name: "Spotlight search", detail: "Search notes for water hikes"),
-                TrajectoryStep(name: "Spotlight search", detail: "Repeat nearly identical query", tint: .orange),
-                TrajectoryStep(name: "Fetch item", detail: "Hydrate selected note"),
-                TrajectoryStep(name: "Answer", detail: "Summarize with source")
-            ]
-        case .unsafe:
-            return [
-                TrajectoryStep(name: "Spotlight search", detail: "Search notes"),
-                TrajectoryStep(name: "Delete note", detail: "Unexpected destructive action", tint: .red),
-                TrajectoryStep(name: "Answer", detail: "Claims task is complete", tint: .red)
-            ]
-        }
-    }
-
-    var result: String {
-        switch self {
-        case .good: return "Pass"
-        case .redundant: return "Needs review"
-        case .unsafe: return "Fail"
-        }
-    }
-
-    var explanation: String {
-        switch self {
-        case .good:
-            return "The trajectory used the expected tools in order and ended with a grounded answer."
-        case .redundant:
-            return "The answer may be correct, but repeated search suggests prompt or guidance tuning is needed."
-        case .unsafe:
-            return "The model called a destructive tool that was not part of the user request. This should fail evaluation."
+        case .match: "Exact match"
+        case .review: "Different path"
+        case .fail: "Forbidden call"
         }
     }
 
     var icon: String {
         switch self {
-        case .good: return "checkmark.circle.fill"
-        case .redundant: return "exclamationmark.circle.fill"
-        case .unsafe: return "xmark.circle.fill"
+        case .match: "checkmark.circle.fill"
+        case .review: "exclamationmark.circle.fill"
+        case .fail: "xmark.circle.fill"
         }
     }
 
     var tint: Color {
         switch self {
-        case .good: return .green
-        case .redundant: return .orange
-        case .unsafe: return .red
+        case .match: .green
+        case .review: .orange
+        case .fail: .red
+        }
+    }
+}
+
+private enum TrajectoryFixture: String, CaseIterable, Identifiable {
+    case match
+    case repeated
+    case forbidden
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .match: "Match"
+        case .repeated: "Repeated"
+        case .forbidden: "Forbidden"
         }
     }
 
-    var code: String {
-        """
-        TrajectoryExpectation(ordered: [
-            ToolExpectation("spotlightSearch"),
-            ToolExpectation("fetchItem"),
-            ToolExpectation.finalAnswer()
-        ])
-        """
+    static let expected = [
+        TrajectoryStep(name: "spotlightSearch", detail: "Search notes for hikes near water"),
+        TrajectoryStep(name: "fetchItem", detail: "Load the selected note")
+    ]
+
+    var steps: [TrajectoryStep] {
+        switch self {
+        case .match:
+            Self.expected
+        case .repeated:
+            [
+                TrajectoryStep(name: "spotlightSearch", detail: "Search notes for hikes near water"),
+                TrajectoryStep(name: "spotlightSearch", detail: "Repeat the same search", tint: .orange),
+                TrajectoryStep(name: "fetchItem", detail: "Load the selected note")
+            ]
+        case .forbidden:
+            [
+                TrajectoryStep(name: "spotlightSearch", detail: "Search notes for hikes near water"),
+                TrajectoryStep(name: "deleteItem", detail: "Delete a note the user only asked to read", tint: .red)
+            ]
+        }
+    }
+
+    var result: TrajectoryResult {
+        if steps.contains(where: { $0.name == "deleteItem" }) {
+            .fail
+        } else if steps == Self.expected {
+            .match
+        } else {
+            .review
+        }
+    }
+
+    var explanation: String {
+        switch result {
+        case .match: "The authored calls exactly match the declared names, arguments, and order in this fixture."
+        case .review:
+            "The fixture reaches the same read operation through an extra call. Your evaluation must declare if that fails."
+        case .fail:
+            "The fixture contains a forbidden tool. A destructive call is a hard failure even if the answer looks useful."
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

- replace the Evaluations screen's canned scores and Run-to-cycle behavior with the actual dataset, metric, model-judge, and test-report workflow
- replace the fake model-router dashboard with an explicitly labeled app-policy guide for `SystemLanguageModel`, `PrivateCloudComputeLanguageModel`, and custom `LanguageModel` providers
- replace fabricated agent-turn usage, cache, latency, risk, and compaction data with a map of the real profile, session, tool, transcript, and Instruments layers
- replace imaginary trajectory runs and the invented `TrajectoryExpectation` API with labeled deterministic fixtures and transcript-based production guidance

## Why

These screens looked like live Foundation Models instrumentation even though their results were hard-coded and their Run buttons only changed local sample state. That made demo labels such as selected runtime, token savings, evaluation scores, and latency appear framework-derived when they were not.

The revised screens distinguish Apple APIs from app-owned policy and test fixtures. They use navigation and selection only where it reveals reference material, and they point developers to Evaluations test reports, `session.transcript`, and the Foundation Models Instrument for real evidence.

## Official API basis

- [Foundation Models overview](https://developer.apple.com/documentation/FoundationModels/)
- [Evaluations framework](https://developer.apple.com/documentation/evaluations)
- [Evaluating prompts](https://developer.apple.com/documentation/FoundationModels/evaluating-prompts-to-measure-performance-and-improve-model-responses)
- [Private Cloud Compute model selection](https://developer.apple.com/documentation/FoundationModels/adding-server-side-intelligence-with-private-cloud-compute)
- [LanguageModelSession.Profile](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/profile)
- [Transcript](https://developer.apple.com/documentation/foundationmodels/transcript)
- [Tool-calling modes](https://developer.apple.com/documentation/FoundationModels/GenerationOptions/ToolCallingMode-swift.struct)
- [Debug agentic experiences with Instruments](https://developer.apple.com/videos/play/wwdc2026/243/)
- [Meet the Evaluations framework](https://developer.apple.com/videos/play/wwdc2026/298/)

## Validation

- `swiftlint lint --strict` on all four changed Swift files: 0 violations
- `git diff --check`: clean
- full generic iOS Simulator build succeeded with Xcode 27.0 beta (27A5194q):
  `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project FoundationLab.xcodeproj -scheme 'Foundation Lab' -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
