### PR TITLE
[codex] Gate Xcode 27 APIs for stable CI

### DIFF
--- a/.github/workflows/foundation-lab-testflight.yml
+++ b/.github/workflows/foundation-lab-testflight.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.5'
 
       - name: Install asc
         env:

--- a/Foundation Lab/Models/VideoSegment.swift
+++ b/Foundation Lab/Models/VideoSegment.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 
+#if compiler(>=6.4)
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -29,3 +30,4 @@ struct VideoSegment: Transcript.CustomSegment {
         content = Content(data: data, mimeType: mimeType)
     }
 }
+#endif

--- a/Foundation Lab/Services/GeminiDeveloperVideoLanguageModel.swift
+++ b/Foundation Lab/Services/GeminiDeveloperVideoLanguageModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 
+#if compiler(>=6.4)
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -431,3 +432,4 @@ enum GeminiDeveloperAPIError: LocalizedError, Sendable {
         }
     }
 }
+#endif

--- a/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
+++ b/Foundation Lab/ViewModels/GeminiVideoInputViewModel.swift
@@ -10,6 +10,7 @@ import FoundationModels
 import Observation
 import UniformTypeIdentifiers
 
+#if compiler(>=6.4)
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -211,3 +212,4 @@ private enum GeminiVideoInputError: LocalizedError {
         }
     }
 }
+#endif

--- a/Foundation Lab/Views/Examples/ExampleType+Destination.swift
+++ b/Foundation Lab/Views/Examples/ExampleType+Destination.swift
@@ -41,7 +41,7 @@ extension ExampleType {
                 GeminiVideoInputView()
             } else {
                 ContentUnavailableView(
-                    "Xcode 27 Required",
+                    "OS 27 Required",
                     systemImage: "video.slash",
                     description: Text("Custom LanguageModel executors require iOS, macOS, or visionOS 27.")
                 )

--- a/Foundation Lab/Views/Examples/Xcode27/GeminiVideoInputView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/GeminiVideoInputView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+#if compiler(>=6.4)
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -223,3 +224,15 @@ private struct GeminiAPIKeySheet: View {
         }
     }
 }
+#else
+struct GeminiVideoInputView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "Xcode 27 Required",
+            systemImage: "video.slash",
+            description: Text("Build with Xcode 27 to use custom LanguageModel executors.")
+        )
+        .navigationTitle("Gemini Video")
+    }
+}
+#endif


### PR DESCRIPTION
## What changed

- gates the Xcode 27 custom `LanguageModel` executor implementation with `#if compiler(>=6.4)`
- keeps the existing iOS/macOS/visionOS 27 runtime availability checks
- supplies an explicit fallback screen for builds made with older stable compilers
- distinguishes the compiler requirement from the runtime OS 27 requirement in the UI
- pins the TestFlight workflow to Xcode 26.5 instead of `latest-stable`, which currently resolves to Xcode 26.3

## Why

The Adapter Studio workflow runs on Xcode 26.5 and was failing while parsing Xcode 27-only APIs such as `Transcript.CustomSegment`, `LanguageModel`, and `LanguageModelExecutor`. Those declarations need a compile-time gate; runtime `@available` annotations cannot hide unknown symbols from an older compiler.

The TestFlight workflow had a separate toolchain mismatch: `latest-stable` selected Xcode 26.3, which does not include the context measurement APIs already used by the app. Pinning 26.5 makes the workflow deterministic and preserves those supported APIs while excluding only the Xcode 27 experiment.

## Validation

- Xcode 26.5 macOS build: passed
- Xcode 27 iOS Simulator build: passed
- strict SwiftLint for all changed Swift files: passed
- `git diff --check`: passed

## Remaining external blocker

The current TestFlight run also reports that the Apple Developer account has reached its certificate limit and cannot create a provisioning profile for `com.rudrankriyam.foundationlab`. This PR fixes the repository/toolchain failure, but an obsolete Apple Development certificate still needs to be revoked before TestFlight signing can succeed.
