### PR TITLE
Add provenance-aware token accounting to afm

### DIFF
--- a/Foundation Lab/Health/ViewModels/HealthChatViewModel.swift
+++ b/Foundation Lab/Health/ViewModels/HealthChatViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationLabCore
 import FoundationModels
+import FoundationModelsKit
 import Observation
 import OSLog
 import SwiftData
@@ -34,6 +35,7 @@ final class HealthChatViewModel {
     // MARK: - Token Usage Tracking
 
     private(set) var currentTokenCount: Int = 0
+    private(set) var currentTokenUsage: ModelTokenUsage?
     private(set) var maxContextSize: Int = AppConfiguration.TokenManagement.defaultMaxTokens
 
     var tokenUsageFraction: Double {
@@ -198,6 +200,7 @@ private extension HealthChatViewModel {
     func syncConversationState() {
         session = conversationEngine.session
         currentTokenCount = conversationEngine.currentTokenCount
+        currentTokenUsage = conversationEngine.currentTokenUsage
         maxContextSize = conversationEngine.maxContextSize
         isSummarizing = conversationEngine.isSummarizing
         sessionCount = conversationEngine.sessionCount

--- a/Foundation Lab/ViewModels/ChatViewModel.swift
+++ b/Foundation Lab/ViewModels/ChatViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationLabCore
 import FoundationModels
+import FoundationModelsKit
 import Observation
 import Speech
 
@@ -50,6 +51,7 @@ final class ChatViewModel {
     // MARK: - Token Usage Tracking
 
     private(set) var currentTokenCount: Int = 0
+    private(set) var currentTokenUsage: ModelTokenUsage?
     private(set) var maxContextSize: Int = AppConfiguration.TokenManagement.defaultMaxTokens
 
     var tokenUsageFraction: Double {
@@ -323,6 +325,7 @@ extension ChatViewModel {
         selectedModelRuntime = conversationEngine.modelRuntime
         selectedReasoningLevel = conversationEngine.reasoningLevel
         currentTokenCount = conversationEngine.currentTokenCount
+        currentTokenUsage = conversationEngine.currentTokenUsage
         maxContextSize = conversationEngine.maxContextSize
         isSummarizing = conversationEngine.isSummarizing
         isApplyingWindow = conversationEngine.isApplyingWindow

--- a/Foundation Lab/Views/Playground/PlaygroundView.swift
+++ b/Foundation Lab/Views/Playground/PlaygroundView.swift
@@ -198,6 +198,7 @@ private extension PlaygroundView {
             provider: "Apple Foundation Models",
             modelIdentifier: modelIdentifier(for: configuration.modelRuntime),
             tokenCount: viewModel.currentTokenCount,
+            tokenUsage: viewModel.currentTokenUsage,
             errorMessage: errorMessage,
             status: status,
             events: events
@@ -265,6 +266,7 @@ private extension PlaygroundView {
                 provider: "Apple Foundation Models",
                 modelIdentifier: modelIdentifier(for: configuration.modelRuntime),
                 tokenCount: viewModel.currentTokenCount,
+                tokenUsage: viewModel.currentTokenUsage,
                 events: capturedRunEvents()
             )
         )

--- a/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabExperimentRun.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabExperimentRun.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationModelsKit
 
 public struct FoundationLabExperimentRun: Codable, Hashable, Sendable, Identifiable {
     public enum Status: String, Codable, Hashable, Sendable {
@@ -17,6 +18,7 @@ public struct FoundationLabExperimentRun: Codable, Hashable, Sendable, Identifia
         case provider
         case modelIdentifier
         case tokenCount
+        case tokenUsage
         case errorMessage
         case status
         case events
@@ -31,6 +33,7 @@ public struct FoundationLabExperimentRun: Codable, Hashable, Sendable, Identifia
     public let provider: String
     public let modelIdentifier: String
     public let tokenCount: Int?
+    public let tokenUsage: ModelTokenUsage?
     public let errorMessage: String?
     public let status: Status
     public let events: [FoundationLabExperimentEvent]
@@ -49,6 +52,7 @@ public struct FoundationLabExperimentRun: Codable, Hashable, Sendable, Identifia
         provider: String,
         modelIdentifier: String,
         tokenCount: Int? = nil,
+        tokenUsage: ModelTokenUsage? = nil,
         errorMessage: String? = nil,
         status: Status? = nil,
         events: [FoundationLabExperimentEvent]? = nil
@@ -69,6 +73,7 @@ public struct FoundationLabExperimentRun: Codable, Hashable, Sendable, Identifia
             ? Self.defaultModelIdentifier(for: configurationSnapshot.modelRuntime)
             : modelIdentifier
         self.tokenCount = tokenCount.flatMap { $0 >= 0 ? $0 : nil }
+        self.tokenUsage = tokenUsage
         self.errorMessage = errorMessage
         self.status = status ?? (errorMessage == nil ? .succeeded : .failed)
         self.events = events ?? Self.defaultEvents(
@@ -97,6 +102,7 @@ public struct FoundationLabExperimentRun: Codable, Hashable, Sendable, Identifia
             modelIdentifier: (try? container.decode(String.self, forKey: .modelIdentifier))
                 ?? Self.defaultModelIdentifier(for: configuration.modelRuntime),
             tokenCount: try? container.decode(Int.self, forKey: .tokenCount),
+            tokenUsage: try? container.decode(ModelTokenUsage.self, forKey: .tokenUsage),
             errorMessage: try? container.decode(String.self, forKey: .errorMessage),
             status: try? container.decode(Status.self, forKey: .status),
             events: try? container.decode([FoundationLabExperimentEvent].self, forKey: .events)

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
@@ -265,17 +265,18 @@ private extension FoundationLabConversationEngine {
 
         session = LanguageModelSession(model: model, transcript: transcript)
         sessionCount += 1
-        await updateTokenCount()
+        await updateTokenCount(usageSource: .context)
 
         isApplyingWindow = false
         notifyStateChange()
     }
 
-    func updateTokenCount() async {
+    func updateTokenCount(usageSource: FoundationLabConversationTokenUsageSource = .accumulatedSession) async {
         let snapshot = await foundationLabConversationTokenSnapshot(
             session: session,
             model: model,
-            runtime: configuration.modelRuntime
+            runtime: configuration.modelRuntime,
+            usageSource: usageSource
         )
         currentTokenCount = snapshot.legacyTokenCount
         currentTokenUsage = snapshot.usage

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
@@ -8,6 +8,7 @@ public final class FoundationLabConversationEngine {
     public private(set) var session: LanguageModelSession
     public private(set) var sessionCount: Int = 1
     public private(set) var currentTokenCount: Int = 0
+    public private(set) var currentTokenUsage: ModelTokenUsage?
     public private(set) var maxContextSize: Int
     public private(set) var isSummarizing: Bool = false
     public private(set) var isApplyingWindow: Bool = false
@@ -224,6 +225,7 @@ private extension FoundationLabConversationEngine {
         cancelActiveResponse()
         sessionCount = 1
         currentTokenCount = 0
+        currentTokenUsage = nil
         isSummarizing = false
         isApplyingWindow = false
         session = FoundationLabSessionFactory.makeSession(
@@ -270,12 +272,13 @@ private extension FoundationLabConversationEngine {
     }
 
     func updateTokenCount() async {
-        switch configuration.modelRuntime {
-        case .onDevice:
-            currentTokenCount = await session.transcript.tokenCount(using: model)
-        case .privateCloudCompute:
-            currentTokenCount = session.transcript.estimatedTokenCount
-        }
+        let snapshot = await foundationLabConversationTokenSnapshot(
+            session: session,
+            model: model,
+            runtime: configuration.modelRuntime
+        )
+        currentTokenCount = snapshot.legacyTokenCount
+        currentTokenUsage = snapshot.usage
         notifyStateChange()
     }
 
@@ -550,6 +553,7 @@ private extension FoundationLabConversationEngine {
         )
         sessionCount += 1
         currentTokenCount = 0
+        currentTokenUsage = nil
         notifyStateChange()
     }
 
@@ -562,6 +566,7 @@ private extension FoundationLabConversationEngine {
         )
         sessionCount += 1
         currentTokenCount = 0
+        currentTokenUsage = nil
         notifyStateChange()
     }
 

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationTokenAccounting.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationTokenAccounting.swift
@@ -1,0 +1,38 @@
+import FoundationModels
+import FoundationModelsKit
+
+struct FoundationLabConversationTokenSnapshot {
+    let legacyTokenCount: Int
+    let usage: ModelTokenUsage
+}
+
+func foundationLabConversationTokenSnapshot(
+    session: LanguageModelSession,
+    model: SystemLanguageModel,
+    runtime: FoundationLabModelRuntime
+) async -> FoundationLabConversationTokenSnapshot {
+    let contextUsage: ModelTokenUsage
+    switch runtime {
+    case .onDevice:
+        contextUsage = await session.transcript.tokenUsage(using: model)
+    case .privateCloudCompute:
+        contextUsage = ModelTokenUsage(
+            inputTokenCount: session.transcript.estimatedTokenCount,
+            measurement: .estimated
+        )
+    }
+
+    #if compiler(>=6.4)
+    if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+        return FoundationLabConversationTokenSnapshot(
+            legacyTokenCount: contextUsage.totalTokenCount,
+            usage: ModelTokenUsage(observing: session.usage, scope: .session)
+        )
+    }
+    #endif
+
+    return FoundationLabConversationTokenSnapshot(
+        legacyTokenCount: contextUsage.totalTokenCount,
+        usage: contextUsage
+    )
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationTokenAccounting.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationTokenAccounting.swift
@@ -6,10 +6,16 @@ struct FoundationLabConversationTokenSnapshot {
     let usage: ModelTokenUsage
 }
 
+enum FoundationLabConversationTokenUsageSource {
+    case context
+    case accumulatedSession
+}
+
 func foundationLabConversationTokenSnapshot(
     session: LanguageModelSession,
     model: SystemLanguageModel,
-    runtime: FoundationLabModelRuntime
+    runtime: FoundationLabModelRuntime,
+    usageSource: FoundationLabConversationTokenUsageSource = .accumulatedSession
 ) async -> FoundationLabConversationTokenSnapshot {
     let contextUsage: ModelTokenUsage
     switch runtime {
@@ -22,17 +28,43 @@ func foundationLabConversationTokenSnapshot(
         )
     }
 
-    #if compiler(>=6.4)
-    if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-        return FoundationLabConversationTokenSnapshot(
-            legacyTokenCount: contextUsage.totalTokenCount,
-            usage: ModelTokenUsage(observing: session.usage, scope: .session)
-        )
+    let observedSessionUsage: ModelTokenUsage?
+    switch usageSource {
+    case .context:
+        observedSessionUsage = nil
+    case .accumulatedSession:
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            observedSessionUsage = ModelTokenUsage(observing: session.usage, scope: .session)
+        } else {
+            observedSessionUsage = nil
+        }
+        #else
+        observedSessionUsage = nil
+        #endif
     }
-    #endif
+
+    return foundationLabConversationTokenSnapshot(
+        contextUsage: contextUsage,
+        observedSessionUsage: observedSessionUsage,
+        usageSource: usageSource
+    )
+}
+
+func foundationLabConversationTokenSnapshot(
+    contextUsage: ModelTokenUsage,
+    observedSessionUsage: ModelTokenUsage?,
+    usageSource: FoundationLabConversationTokenUsageSource
+) -> FoundationLabConversationTokenSnapshot {
+    let resolvedUsage = switch usageSource {
+    case .context:
+        contextUsage
+    case .accumulatedSession:
+        observedSessionUsage ?? contextUsage
+    }
 
     return FoundationLabConversationTokenSnapshot(
         legacyTokenCount: contextUsage.totalTokenCount,
-        usage: contextUsage
+        usage: resolvedUsage
     )
 }

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabConversationTokenAccountingTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabConversationTokenAccountingTests.swift
@@ -1,0 +1,29 @@
+import FoundationModelsKit
+import Testing
+@testable import FoundationLabCore
+
+@Test("A recreated session publishes context usage until generation completes")
+func recreatedSessionPublishesContextUsage() {
+    let contextUsage = ModelTokenUsage(
+        inputTokenCount: 42,
+        measurement: .tokenized,
+        scope: .context
+    )
+    let emptyObservedUsage = ModelTokenUsage(
+        input: .init(totalTokenCount: 0),
+        output: .init(totalTokenCount: 0),
+        measurement: .observed,
+        scope: .session
+    )
+
+    let snapshot = foundationLabConversationTokenSnapshot(
+        contextUsage: contextUsage,
+        observedSessionUsage: emptyObservedUsage,
+        usageSource: .context
+    )
+
+    #expect(snapshot.legacyTokenCount == 42)
+    #expect(snapshot.usage == contextUsage)
+    #expect(snapshot.usage.measurement == .tokenized)
+    #expect(snapshot.usage.scope == .context)
+}

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabExperimentResilienceTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabExperimentResilienceTests.swift
@@ -105,6 +105,7 @@ final class FoundationLabExperimentResilienceTests: XCTestCase {
         XCTAssertEqual(run.configuration.prompt, "Hello")
         XCTAssertEqual(run.duration, 0)
         XCTAssertEqual(run.provider, "Apple Foundation Models")
+        XCTAssertNil(run.tokenUsage)
         XCTAssertEqual(run.events.map(\.role), [.user, .assistant])
     }
 

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabExperimentTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabExperimentTests.swift
@@ -97,7 +97,13 @@ final class FoundationLabExperimentTests: XCTestCase {
             duration: 0.75,
             provider: "Apple",
             modelIdentifier: "system-language-model",
-            tokenCount: 11
+            tokenCount: 11,
+            tokenUsage: .init(
+                input: .init(totalTokenCount: 8, cachedTokenCount: 2),
+                output: .init(totalTokenCount: 3, reasoningTokenCount: 1),
+                measurement: .observed,
+                scope: .response
+            )
         )
         let failedRun = FoundationLabExperimentRun(
             configuration: configuration,
@@ -118,6 +124,8 @@ final class FoundationLabExperimentTests: XCTestCase {
         let data = try JSONEncoder().encode(successfulRun)
         let decoded = try JSONDecoder().decode(FoundationLabExperimentRun.self, from: data)
         XCTAssertEqual(decoded, successfulRun)
+        XCTAssertEqual(decoded.tokenUsage?.input.cachedTokenCount, 2)
+        XCTAssertEqual(decoded.tokenUsage?.output?.reasoningTokenCount, 1)
     }
 
     func testCancelledRunRoundTripAndLegacyStatusInference() throws {

--- a/Packages/FoundationModelsKit/README.md
+++ b/Packages/FoundationModelsKit/README.md
@@ -678,8 +678,19 @@ FoundationModelsTools provides comprehensive token counting and context window m
 #### Features
 
 **Estimation Methods:**
-- `estimatedTokenCount` - Basic token counting using Apple's 4.5 characters per token ratio
+- `estimatedTokenCount` - Calibrated token estimation using 4.75 characters per token
 - `safeEstimatedTokenCount` - Conservative estimate with 25% buffer + 100 token overhead
+- `tokenUsage(using:)` - Exact tokenization on OS 26.4+, with an explicitly labeled estimate fallback
+
+`ModelTokenUsage` is the stable `Codable`, `Hashable`, and `Sendable` projection
+used for automation and persisted evidence. Its measurement is `observed`,
+`tokenized`, or `estimated`; its scope is `response`, `session`, or `context`.
+Cached-input and reasoning-output counts remain optional because older APIs do
+not expose them.
+
+On systems that need the estimator fallback, instruction counts include tool
+definition names, descriptions, and conservative framing overhead. Generation
+schema internals are left to Apple's tokenizer where that API is available.
 
 **Context Management:**
 - `isApproachingLimit(threshold:maxTokens:)` - Check if approaching context limits
@@ -717,6 +728,18 @@ let transcript = Transcript(entries: [
 // Get token estimate
 let tokens = transcript.estimatedTokenCount
 print("Estimated tokens: \(tokens)")
+
+// Prefer exact model tokenization on OS 26.4+, with provenance-aware fallback.
+let usage = await transcript.tokenUsage()
+print("\(usage.totalTokenCount) tokens (\(usage.measurement.rawValue))")
+
+#if compiler(>=6.4)
+if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+    let response = try await LanguageModelSession().respond(to: "Hello")
+    let observed = ModelTokenUsage(observing: response.usage)
+    print("\(observed.input.totalTokenCount) in, \(observed.output?.totalTokenCount ?? 0) out")
+}
+#endif
 
 // Get safe estimate with buffer
 let safeTokens = transcript.safeEstimatedTokenCount

--- a/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Extensions/SystemLanguageModel+TokenUsage.swift
+++ b/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Extensions/SystemLanguageModel+TokenUsage.swift
@@ -1,0 +1,79 @@
+import FoundationModels
+
+public extension SystemLanguageModel {
+  /// Counts a prompt with Apple's tokenizer when available, otherwise uses the
+  /// package's calibrated text estimator.
+  func tokenUsage(
+    for prompt: Prompt,
+    estimatedFrom fallbackText: String
+  ) async -> ModelTokenUsage {
+    #if compiler(>=6.3)
+    if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *),
+       let count = try? await tokenCount(for: prompt) {
+      return ModelTokenUsage(inputTokenCount: count, measurement: .tokenized)
+    }
+    #endif
+
+    return ModelTokenUsage(
+      inputTokenCount: estimateTokens(from: fallbackText),
+      measurement: .estimated
+    )
+  }
+
+  /// Counts instructions with Apple's tokenizer when available, otherwise
+  /// uses the package's calibrated text estimator.
+  func tokenUsage(
+    for instructions: Instructions,
+    estimatedFrom fallbackText: String
+  ) async -> ModelTokenUsage {
+    #if compiler(>=6.3)
+    if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *),
+       let count = try? await tokenCount(for: instructions) {
+      return ModelTokenUsage(inputTokenCount: count, measurement: .tokenized)
+    }
+    #endif
+
+    return ModelTokenUsage(
+      inputTokenCount: estimateTokens(from: fallbackText),
+      measurement: .estimated
+    )
+  }
+
+  /// Counts tool definitions with Apple's tokenizer when available, otherwise
+  /// estimates from their serialized manifests.
+  func tokenUsage(
+    for tools: [any Tool],
+    estimatedFrom fallbackText: String
+  ) async -> ModelTokenUsage {
+    #if compiler(>=6.3)
+    if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *),
+       let count = try? await tokenCount(for: tools) {
+      return ModelTokenUsage(inputTokenCount: count, measurement: .tokenized)
+    }
+    #endif
+
+    return ModelTokenUsage(
+      inputTokenCount: estimateTokens(from: fallbackText),
+      measurement: .estimated
+    )
+  }
+
+  /// Counts a generation schema with Apple's tokenizer when available,
+  /// otherwise estimates from the serialized schema document.
+  func tokenUsage(
+    for schema: GenerationSchema,
+    estimatedFrom fallbackText: String
+  ) async -> ModelTokenUsage {
+    #if compiler(>=6.3)
+    if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *),
+       let count = try? await tokenCount(for: schema) {
+      return ModelTokenUsage(inputTokenCount: count, measurement: .tokenized)
+    }
+    #endif
+
+    return ModelTokenUsage(
+      inputTokenCount: estimateTokens(from: fallbackText),
+      measurement: .estimated
+    )
+  }
+}

--- a/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Extensions/Transcript+ModelTokenCounting.swift
+++ b/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Extensions/Transcript+ModelTokenCounting.swift
@@ -6,28 +6,38 @@ private let exactTokenSafetyBufferMultiplier = 0.05
 public extension Transcript.Entry {
   /// Returns the model's exact token count when the API is available, otherwise an estimate.
   func tokenCount(using model: SystemLanguageModel = .default) async -> Int {
+    await tokenUsage(using: model).totalTokenCount
+  }
+
+  /// Returns a token count together with whether it was tokenized or estimated.
+  func tokenUsage(using model: SystemLanguageModel = .default) async -> ModelTokenUsage {
     #if compiler(>=6.3)
     if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *),
        let exactTokenCount = try? await model.tokenCount(for: [self]) {
-      return exactTokenCount
+      return ModelTokenUsage(inputTokenCount: exactTokenCount, measurement: .tokenized)
     }
     #endif
 
-    return estimatedTokenCount
+    return ModelTokenUsage(inputTokenCount: estimatedTokenCount, measurement: .estimated)
   }
 }
 
 public extension Transcript {
   /// Returns the model's exact token count when the API is available, otherwise an estimate.
   func tokenCount(using model: SystemLanguageModel = .default) async -> Int {
+    await tokenUsage(using: model).totalTokenCount
+  }
+
+  /// Returns a token count together with whether it was tokenized or estimated.
+  func tokenUsage(using model: SystemLanguageModel = .default) async -> ModelTokenUsage {
     #if compiler(>=6.3)
     if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *),
        let exactTokenCount = try? await model.tokenCount(for: Array(self)) {
-      return exactTokenCount
+      return ModelTokenUsage(inputTokenCount: exactTokenCount, measurement: .tokenized)
     }
     #endif
 
-    return estimatedTokenCount
+    return ModelTokenUsage(inputTokenCount: estimatedTokenCount, measurement: .estimated)
   }
 
   /// Returns an exact token count with a small buffer, or the conservative estimated count.

--- a/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Extensions/Transcript+TokenCounting.swift
+++ b/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Extensions/Transcript+TokenCounting.swift
@@ -3,7 +3,7 @@
 //  FoundationModelsTools
 //
 //  Token counting and context window management utilities for Foundation Models transcripts.
-//  Uses Apple's guidance of 4.5 characters per token for estimation.
+//  Uses the package's calibrated character-ratio estimator.
 //
 
 import Foundation
@@ -28,6 +28,9 @@ private let systemOverheadTokens = 100
 
 /// Tool call overhead in tokens
 private let toolCallOverheadTokens = 5
+
+/// Tool definition framing overhead in tokens
+private let toolDefinitionOverheadTokens = 8
 
 /// Tool output overhead in tokens
 private let toolOutputOverheadTokens = 3
@@ -63,7 +66,12 @@ extension Transcript.Entry {
   public var estimatedTokenCount: Int {
     switch self {
     case .instructions(let instructions):
-      return instructions.segments.totalEstimatedTokenCount
+      let definitionTokens = instructions.toolDefinitions.reduce(0) { total, definition in
+        total + estimateTokensConservative(from: definition.name) +
+        estimateTokensConservative(from: definition.description) +
+        toolDefinitionOverheadTokens
+      }
+      return instructions.segments.totalEstimatedTokenCount + definitionTokens
 
     case .prompt(let prompt):
       return prompt.segments.totalEstimatedTokenCount
@@ -96,10 +104,10 @@ extension Transcript.Segment {
   /// Estimates the token count for this transcript segment.
   ///
   /// Calculates tokens based on segment type:
-  /// - Text segments: Character count divided by 4.5
-  /// - Structured segments: JSON representation length divided by 4.5
+  /// - Text segments: Character count divided by the calibrated ratio
+  /// - Structured segments: JSON representation length divided by the calibrated ratio
   ///
-  /// Uses Apple's guidance of 4.5 characters per token.
+  /// Uses the package's calibrated estimate.
   public var estimatedTokenCount: Int {
     switch self {
     case .text(let textSegment):
@@ -127,7 +135,7 @@ extension Transcript {
   /// Estimates the total token count for all entries in this transcript.
   ///
   /// Returns the sum of estimated tokens across all transcript entries.
-  /// Uses Apple's guidance of 4.5 characters per token.
+  /// Uses the package's calibrated estimate.
   ///
   /// Example:
   /// ```swift

--- a/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Models/ModelTokenUsage.swift
+++ b/Packages/FoundationModelsKit/Sources/FoundationModelsKit/Models/ModelTokenUsage.swift
@@ -1,0 +1,121 @@
+import Foundation
+import FoundationModels
+
+/// A stable, serializable projection of Foundation Models token accounting.
+///
+/// `observed` values come from a completed model response. `tokenized` values
+/// come from `SystemLanguageModel.tokenCount(for:)` without running generation,
+/// and `estimated` values come from FoundationModelsKit's calibrated fallback.
+public struct ModelTokenUsage: Codable, Hashable, Sendable {
+  public enum Measurement: String, Codable, Hashable, Sendable {
+    case observed
+    case tokenized
+    case estimated
+  }
+
+  public enum Scope: String, Codable, Hashable, Sendable {
+    /// Tokens attributable to one completed generation.
+    case response
+    /// Tokens accumulated across every generation in one session.
+    case session
+    /// Tokens currently present in supplied prompt or transcript context.
+    case context
+  }
+
+  public struct Input: Codable, Hashable, Sendable {
+    public let totalTokenCount: Int
+    public let cachedTokenCount: Int?
+
+    public init(totalTokenCount: Int, cachedTokenCount: Int? = nil) {
+      self.totalTokenCount = max(0, totalTokenCount)
+      self.cachedTokenCount = cachedTokenCount.map { max(0, $0) }
+    }
+  }
+
+  public struct Output: Codable, Hashable, Sendable {
+    public let totalTokenCount: Int
+    public let reasoningTokenCount: Int?
+
+    public init(totalTokenCount: Int, reasoningTokenCount: Int? = nil) {
+      self.totalTokenCount = max(0, totalTokenCount)
+      self.reasoningTokenCount = reasoningTokenCount.map { max(0, $0) }
+    }
+  }
+
+  public let input: Input
+  public let output: Output?
+  public let measurement: Measurement
+  public let scope: Scope
+
+  public var totalTokenCount: Int {
+    input.totalTokenCount + (output?.totalTokenCount ?? 0)
+  }
+
+  public init(
+    input: Input,
+    output: Output? = nil,
+    measurement: Measurement,
+    scope: Scope
+  ) {
+    self.input = input
+    self.output = output
+    self.measurement = measurement
+    self.scope = scope
+  }
+
+  public init(inputTokenCount: Int, measurement: Measurement, scope: Scope = .context) {
+    self.init(
+      input: Input(totalTokenCount: inputTokenCount),
+      measurement: measurement,
+      scope: scope
+    )
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case input
+    case output
+    case measurement
+    case scope
+    case totalTokenCount
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(input, forKey: .input)
+    try container.encodeIfPresent(output, forKey: .output)
+    try container.encode(measurement, forKey: .measurement)
+    try container.encode(scope, forKey: .scope)
+    try container.encode(totalTokenCount, forKey: .totalTokenCount)
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      input: try container.decode(Input.self, forKey: .input),
+      output: try container.decodeIfPresent(Output.self, forKey: .output),
+      measurement: try container.decode(Measurement.self, forKey: .measurement),
+      scope: try container.decode(Scope.self, forKey: .scope)
+    )
+  }
+}
+
+#if compiler(>=6.4)
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+public extension ModelTokenUsage {
+  /// Creates an observed usage value from Foundation Models runtime metrics.
+  init(observing usage: LanguageModelSession.Usage, scope: Scope = .response) {
+    self.init(
+      input: Input(
+        totalTokenCount: usage.input.totalTokenCount,
+        cachedTokenCount: usage.input.cachedTokenCount
+      ),
+      output: Output(
+        totalTokenCount: usage.output.totalTokenCount,
+        reasoningTokenCount: usage.output.reasoningTokenCount
+      ),
+      measurement: .observed,
+      scope: scope
+    )
+  }
+}
+#endif

--- a/Packages/FoundationModelsKit/Tests/FoundationModelsKitTests/ModelTokenUsageTests.swift
+++ b/Packages/FoundationModelsKit/Tests/FoundationModelsKitTests/ModelTokenUsageTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import FoundationModels
+import Testing
+@testable import FoundationModelsKit
+
+@Suite("Model Token Usage Tests")
+struct ModelTokenUsageTests {
+  @Test("Unavailable cached and reasoning counts stay absent through Codable")
+  func unavailableDetailsStayAbsent() throws {
+    let usage = ModelTokenUsage(
+      inputTokenCount: 42,
+      measurement: .tokenized
+    )
+
+    let data = try JSONEncoder().encode(usage)
+    let object = try #require(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+    let input = try #require(object["input"] as? [String: Any])
+
+    #expect(input["totalTokenCount"] as? Int == 42)
+    #expect(input["cachedTokenCount"] == nil)
+    #expect(object["output"] == nil)
+    #expect(object["totalTokenCount"] as? Int == 42)
+    #expect(try JSONDecoder().decode(ModelTokenUsage.self, from: data) == usage)
+  }
+
+  @Test("Input and output totals are encoded with explicit provenance")
+  func totalsAndProvenanceAreEncoded() throws {
+    let usage = ModelTokenUsage(
+      input: .init(totalTokenCount: 30, cachedTokenCount: 20),
+      output: .init(totalTokenCount: 15, reasoningTokenCount: 4),
+      measurement: .observed,
+      scope: .response
+    )
+
+    let data = try JSONEncoder().encode(usage)
+    let object = try #require(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+
+    #expect(object["measurement"] as? String == "observed")
+    #expect(object["scope"] as? String == "response")
+    #expect(object["totalTokenCount"] as? Int == 45)
+    #expect(try JSONDecoder().decode(ModelTokenUsage.self, from: data) == usage)
+  }
+
+  #if compiler(>=6.4)
+  @Test("Observed zero cached and reasoning counts remain explicit")
+  @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+  func observedZerosRemainExplicit() throws {
+    let runtimeUsage = LanguageModelSession.Usage(
+      input: .init(totalTokenCount: 8, cachedTokenCount: 0),
+      output: .init(totalTokenCount: 3, reasoningTokenCount: 0)
+    )
+    let usage = ModelTokenUsage(observing: runtimeUsage)
+
+    let data = try JSONEncoder().encode(usage)
+    let object = try #require(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+    let input = try #require(object["input"] as? [String: Any])
+    let output = try #require(object["output"] as? [String: Any])
+
+    #expect(input["cachedTokenCount"] as? Int == 0)
+    #expect(output["reasoningTokenCount"] as? Int == 0)
+    #expect(usage.measurement == .observed)
+    #expect(usage.scope == .response)
+  }
+  #endif
+}

--- a/Packages/FoundationModelsKit/Tests/FoundationModelsKitTests/TokenCountingTests.swift
+++ b/Packages/FoundationModelsKit/Tests/FoundationModelsKitTests/TokenCountingTests.swift
@@ -91,6 +91,43 @@ struct TokenCountingTests {
 
     #expect(trimmed == [instruction])
   }
+
+  @Test("Instruction estimates include tool definitions")
+  func instructionEstimatesIncludeToolDefinitions() throws {
+    let schema = try GenerationSchema(
+      root: DynamicGenerationSchema(
+        name: "WeatherArguments",
+        properties: [
+          .init(name: "city", schema: .init(type: String.self))
+        ]
+      ),
+      dependencies: []
+    )
+    let segments: [Transcript.Segment] = [
+      .text(Transcript.TextSegment(content: "Use tools when helpful."))
+    ]
+    let textOnly: Transcript.Entry = .instructions(
+      Transcript.Instructions(segments: segments, toolDefinitions: [])
+    )
+    let withTool: Transcript.Entry = .instructions(
+      Transcript.Instructions(
+        segments: segments,
+        toolDefinitions: [
+          Transcript.ToolDefinition(
+            name: "weather",
+            description: "Looks up current weather for a city.",
+            parameters: schema
+          )
+        ]
+      )
+    )
+
+    #expect(withTool.estimatedTokenCount > textOnly.estimatedTokenCount)
+    #expect(
+      withTool.estimatedTokenCount - textOnly.estimatedTokenCount >=
+      estimateTokensConservative(from: "weatherLooks up current weather for a city.")
+    )
+  }
 }
 
 @Suite("Token Estimation Accuracy Tests")

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ brew install afm
 
 swift run afm --help
 swift run afm model status
+swift run afm token-count -i @instructions.md --prompt @prompt.md --breakdown
 swift run afm session respond --prompt "Summarize Foundation Models."
 ```
 
@@ -218,8 +219,9 @@ archived in favor of this shared implementation.
 
 ## Swift Package Products
 
-- `FoundationModelsKit` provides transcript history transforms, token estimation,
-  and context-budget utilities.
+- `FoundationModelsKit` provides transcript history transforms, provenance-aware
+  token accounting shared by the app and CLI, calibrated estimation, and
+  context-budget utilities.
 - `FoundationModelsTools` provides calendar, contacts, health, location, music,
   reminders, weather, web search, and web metadata tools.
 - `FoundationLabCore` provides the shared capability and experiment runtime.

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -36,6 +36,7 @@ To run live model commands, you still need a supported Apple Intelligence Mac. F
 - It is built for real terminal use: explicit flags, readable help, file-based inputs, and clean JSON output.
 - It works well in automation and agent flows with dry-runs, stdin support, schema and tool directories, and NDJSON-style streaming events.
 - It keeps important runtime controls close at hand, including adapters, use cases, guardrails, schema prompting, and feedback issues.
+- It reports token provenance instead of presenting tokenized, estimated, and observed usage as if they were interchangeable.
 
 ## First Commands
 
@@ -43,6 +44,8 @@ These are good starting points after install:
 
 ```bash
 afm model status
+afm token-count "What is Swift?"
+afm token-count -i @instructions.md --prompt @prompt.md --breakdown
 afm session respond --prompt "Summarize Foundation Models in one paragraph."
 afm session respond --adapter ~/MyAdapter.fmadapter --prompt "Rewrite this in my house style."
 afm session stream --prompt "Write a short poem about rain."
@@ -64,6 +67,42 @@ afm model languages
 afm model use-cases
 afm model guardrails
 ```
+
+### Count and budget tokens
+
+`afm token-count` accepts the same core text inputs as Apple's `fm token-count`
+and adds files, JSON provenance, context-window budgeting, estimator comparison,
+schemas, and file-backed tool definitions:
+
+```bash
+afm token-count "What is Swift?"
+afm token-count -i "You are a helpful assistant" "What is Swift?"
+afm token-count --text "First segment" --text "Second segment"
+cat prompt.md | afm token-count --output json --pretty
+afm token-count --schema person-card --tool demo-weather --breakdown
+afm token-count --quiet "Print only the integer"
+```
+
+Measurement is explicit:
+
+- `tokenized` means `SystemLanguageModel.tokenCount(for:)` succeeded on macOS 26.4 or later.
+- `estimated` means the calibrated FoundationModelsKit fallback was used, including when the tokenizer was unavailable.
+- `observed` is reserved for usage reported by an actual model response on macOS 27 or later.
+
+JSON output includes input/output structure, scope, per-component counts, cached
+and reasoning counts when the runtime supplies them, the model context limit,
+remaining capacity, and calibrated and conservative estimates. Missing cached or
+reasoning counts are omitted rather than reported as zero.
+
+The standalone total is the sum of the individually tokenized supplied
+components: instructions, prompt segments, schema, and tool definitions. It does
+not invent an unattributed runtime overhead value. Runtime framing is available
+only from `observed` generation usage.
+
+Standalone counting measures only the context supplied to the command. A real
+generation can consume more input tokens because Foundation Models adds runtime
+and session framing. The legacy `tokenCount` field in generation commands remains
+available; richer `tokenUsage` is additive.
 
 ### Try prompts and chat
 
@@ -138,6 +177,7 @@ afm feedback export --prompt "What is the capital of France?" --sentiment positi
 ```bash
 afm session respond --prompt @prompt.md
 cat prompt.md | afm session respond --output json
+cat prompt.md | afm token-count --output json
 afm schema run custom --schema person-card --schema-dir .afm/schemas --input @person.txt
 afm tool call --tool echo-json --tool-dir .afm/tools --args @args.json
 ```

--- a/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
@@ -18,7 +18,9 @@ struct AFMEntryPoint {
         let firstArgument = arguments[1]
         guard !firstArgument.hasPrefix("-") else { return nil }
 
-        let rootCommands = ["model", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"]
+        let rootCommands = [
+            "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"
+        ]
         if !rootCommands.contains(firstArgument) {
             if let suggestion = suggestRootCommand(for: firstArgument) {
                 return "Unknown command '\(firstArgument)'. Did you mean '\(suggestion)'?"

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
@@ -15,6 +15,7 @@ struct AFMRootCommand: AsyncParsableCommand {
         version: "0.1.0",
         subcommands: [
             ModelCommand.self,
+            TokenCountCommand.self,
             TagCommand.self,
             SessionCommand.self,
             SchemaCommand.self,
@@ -40,7 +41,7 @@ struct AFMRootCommand: AsyncParsableCommand {
         let payload = RootStatusPayload(
             name: Self.configuration.commandName ?? "afm",
             summary: "Workflow-first CLI for Foundation Models sessions, schemas, tools, transcripts, and feedback.",
-            commands: ["model", "tag", "session", "schema", "tool", "transcript", "feedback"]
+            commands: ["model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback"]
         )
         let human: String
         if options.verbose {

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
@@ -378,6 +378,9 @@ enum HelpText {
     MODEL COMMANDS
       model        Inspect model readiness and supported languages.
 
+    TOKEN COMMANDS
+      token-count  Count prompt context with exact provenance and breakdowns.
+
     TAG COMMANDS
       tag          Try the content tagging system model.
 
@@ -398,6 +401,8 @@ enum HelpText {
       afm model status
       afm model use-cases
       afm model guardrails
+      afm token-count "What is Swift?"
+      afm token-count -i @instructions.md --prompt @prompt.md --breakdown
       afm session respond --prompt "Summarize Foundation Models in one paragraph."
       afm session respond --adapter ~/MyAdapter.fmadapter --prompt "Rewrite this in my style."
       afm session stream --prompt "Write a short poem about rain"
@@ -429,7 +434,7 @@ enum HelpText {
 }
 
 func suggestRootCommand(for input: String) -> String? {
-    let commands = ["model", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"]
+    let commands = ["model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"]
     return suggestCommand(input, in: commands)
 }
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommandSupport.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import FoundationLabCore
 import FoundationModels
+import FoundationModelsKit
 
 struct SessionStreamingEventPayload: Encodable {
     let event: String
@@ -16,6 +17,7 @@ struct SessionStreamingEventPayload: Encodable {
     let exchanges: [AFMConversationExchange]?
     let sessionCount: Int?
     let tokenCount: Int?
+    let tokenUsage: ModelTokenUsage?
     let transcript: [CLITranscriptEntry]?
 }
 
@@ -27,6 +29,7 @@ struct SessionStreamingEventContent {
     var exchanges: [AFMConversationExchange]?
     var sessionCount: Int?
     var tokenCount: Int?
+    var tokenUsage: ModelTokenUsage?
     var transcript: [CLITranscriptEntry]?
 }
 
@@ -70,6 +73,7 @@ struct SessionCommandContext {
             exchanges: content.exchanges,
             sessionCount: content.sessionCount,
             tokenCount: content.tokenCount,
+            tokenUsage: content.tokenUsage,
             transcript: content.transcript
         )
     }
@@ -101,6 +105,7 @@ struct SessionSnapshot {
     let transcript: [CLITranscriptEntry]?
     let sessionCount: Int
     let tokenCount: Int
+    let tokenUsage: ModelTokenUsage?
 }
 
 struct ConversationRenderContext {
@@ -108,6 +113,7 @@ struct ConversationRenderContext {
     let transcript: [CLITranscriptEntry]?
     let sessionCount: Int
     let tokenCount: Int
+    let tokenUsage: ModelTokenUsage?
     let verbose: Bool
     let streamed: Bool
 }
@@ -191,22 +197,21 @@ func captureSessionSnapshot(
     SessionSnapshot(
         transcript: includeTranscript ? transcriptPayload(engine.session.transcript) : nil,
         sessionCount: engine.sessionCount,
-        tokenCount: engine.currentTokenCount
+        tokenCount: engine.currentTokenCount,
+        tokenUsage: engine.currentTokenUsage
     )
 }
 
 func humanReadableSessionResponse(
     response: String,
-    transcript: [CLITranscriptEntry]?,
-    sessionCount: Int,
-    tokenCount: Int,
+    snapshot: SessionSnapshot,
     verbose: Bool
 ) -> String {
     var lines: [String] = []
     if !response.isEmpty {
         lines.append(response)
     }
-    if let transcript, !transcript.isEmpty {
+    if let transcript = snapshot.transcript, !transcript.isEmpty {
         if !lines.isEmpty { lines.append("") }
         lines.append("Transcript")
         lines.append(
@@ -215,8 +220,12 @@ func humanReadableSessionResponse(
     }
     if verbose {
         if !lines.isEmpty { lines.append("") }
-        lines.append("Sessions: \(sessionCount)")
-        lines.append("Token count: \(tokenCount)")
+        lines.append("Sessions: \(snapshot.sessionCount)")
+        appendTokenAccounting(
+            tokenCount: snapshot.tokenCount,
+            tokenUsage: snapshot.tokenUsage,
+            to: &lines
+        )
     }
     return lines.joined(separator: "\n")
 }
@@ -341,9 +350,35 @@ func humanReadableConversation(_ context: ConversationRenderContext) -> String {
     if context.verbose {
         if !lines.isEmpty { lines.append("") }
         lines.append("Sessions: \(context.sessionCount)")
-        lines.append("Token count: \(context.tokenCount)")
+        appendTokenAccounting(
+            tokenCount: context.tokenCount,
+            tokenUsage: context.tokenUsage,
+            to: &lines
+        )
     }
     return lines.joined(separator: "\n")
+}
+
+private func appendTokenAccounting(
+    tokenCount: Int,
+    tokenUsage: ModelTokenUsage?,
+    to lines: inout [String]
+) {
+    lines.append("Context token count: \(tokenCount)")
+    guard let tokenUsage else { return }
+
+    lines.append("Input tokens: \(tokenUsage.input.totalTokenCount)")
+    if let cachedTokenCount = tokenUsage.input.cachedTokenCount {
+        lines.append("Cached input tokens: \(cachedTokenCount)")
+    }
+    if let output = tokenUsage.output {
+        lines.append("Output tokens: \(output.totalTokenCount)")
+        if let reasoningTokenCount = output.reasoningTokenCount {
+            lines.append("Reasoning output tokens: \(reasoningTokenCount)")
+        }
+    }
+    lines.append("Accounted tokens: \(tokenUsage.totalTokenCount)")
+    lines.append("Measurement: \(tokenUsage.measurement.rawValue) (\(tokenUsage.scope.rawValue))")
 }
 
 struct ResolvedToolSet {

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SessionCommands.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import FoundationLabCore
 import FoundationModels
+import FoundationModelsKit
 
 struct SessionCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -27,6 +28,7 @@ struct SessionResponsePayload: Encodable {
     let exchanges: [AFMConversationExchange]?
     let sessionCount: Int
     let tokenCount: Int
+    let tokenUsage: ModelTokenUsage?
     let transcript: [CLITranscriptEntry]?
 }
 
@@ -329,13 +331,12 @@ private func emitRespondResult(
         exchanges: nil,
         sessionCount: snapshot.sessionCount,
         tokenCount: snapshot.tokenCount,
+        tokenUsage: snapshot.tokenUsage,
         transcript: snapshot.transcript
     )
     let human = humanReadableSessionResponse(
         response: response,
-        transcript: snapshot.transcript,
-        sessionCount: snapshot.sessionCount,
-        tokenCount: snapshot.tokenCount,
+        snapshot: snapshot,
         verbose: context.verbose
     )
     try CLIOutput.emit(payload: payload, human: human, options: context.output)
@@ -358,6 +359,7 @@ private func emitStreamResult(
         exchanges: nil,
         sessionCount: snapshot.sessionCount,
         tokenCount: snapshot.tokenCount,
+        tokenUsage: snapshot.tokenUsage,
         transcript: snapshot.transcript
     )
     if context.streamsToJSON {
@@ -369,6 +371,7 @@ private func emitStreamResult(
                     response: response,
                     sessionCount: snapshot.sessionCount,
                     tokenCount: snapshot.tokenCount,
+                    tokenUsage: snapshot.tokenUsage,
                     transcript: snapshot.transcript
                 )
             )
@@ -379,9 +382,7 @@ private func emitStreamResult(
     let humanResponse = context.streamsToConsole ? "" : response
     let human = humanReadableSessionResponse(
         response: humanResponse,
-        transcript: snapshot.transcript,
-        sessionCount: snapshot.sessionCount,
-        tokenCount: snapshot.tokenCount,
+        snapshot: snapshot,
         verbose: context.verbose
     )
     try CLIOutput.emit(payload: payload, human: human, options: context.output)
@@ -404,6 +405,7 @@ private func emitChatResult(
         exchanges: exchanges,
         sessionCount: snapshot.sessionCount,
         tokenCount: snapshot.tokenCount,
+        tokenUsage: snapshot.tokenUsage,
         transcript: snapshot.transcript
     )
     if context.streamsToJSON {
@@ -414,6 +416,7 @@ private func emitChatResult(
                     exchanges: exchanges,
                     sessionCount: snapshot.sessionCount,
                     tokenCount: snapshot.tokenCount,
+                    tokenUsage: snapshot.tokenUsage,
                     transcript: snapshot.transcript
                 )
             )
@@ -427,6 +430,7 @@ private func emitChatResult(
             transcript: snapshot.transcript,
             sessionCount: snapshot.sessionCount,
             tokenCount: snapshot.tokenCount,
+            tokenUsage: snapshot.tokenUsage,
             verbose: context.verbose,
             streamed: context.streamsToConsole
         )

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/TokenCountCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/TokenCountCommand.swift
@@ -1,0 +1,471 @@
+import ArgumentParser
+import Foundation
+import FoundationModels
+import FoundationModelsKit
+
+struct TokenCountCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "token-count",
+        abstract: "Count tokens in prompts, instructions, schemas, and tool definitions.",
+        discussion: """
+        Uses Apple's tokenizer on macOS 26.4 and later. On earlier systems, or
+        when tokenization is unavailable, the result is explicitly marked as
+        estimated. This command counts supplied context; generation usage can
+        be larger because the runtime adds model and session framing.
+        """
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var toolSource: ToolSourceOptions
+    @OptionGroup var schemaSource: SchemaSourceOptions
+
+    @Argument(help: "Prompt to count. Prefix with @ to read from a file.")
+    var positionalPrompt: String?
+
+    @Option(name: .long, help: "Prompt to count. Prefix with @ to read from a file.")
+    var prompt: String?
+
+    @Option(name: .customLong("prompt-file"), help: "Read the prompt from a file path.")
+    var promptFile: String?
+
+    @Option(name: .shortAndLong, help: "Instructions to include. Prefix with @ to read from a file.")
+    var instructions: String?
+
+    @Option(name: .customLong("instructions-file"), help: "Read instructions from a file path.")
+    var instructionsFile: String?
+
+    @Option(name: .long, help: "Additional prompt text. Repeat to add multiple segments.")
+    var text: [String] = []
+
+    @Flag(name: .long, help: "Read the primary prompt from standard input.")
+    var stdin = false
+
+    @Flag(name: .shortAndLong, help: "Print only the integer token count.")
+    var quiet = false
+
+    @Flag(name: .long, help: "Show per-component counts and estimator comparison.")
+    var breakdown = false
+
+    mutating func run() async throws {
+        try validateOutputOptions()
+        let output = try options.resolvedOutput()
+        let input = try resolveInput()
+        let artifacts = try resolveArtifacts()
+
+        if options.dryRun {
+            try emitDryRun(input: input, artifacts: artifacts, output: output)
+            return
+        }
+
+        let report = await measure(input: input, artifacts: artifacts)
+        if quiet {
+            print(report.usage.totalTokenCount)
+            return
+        }
+
+        try CLIOutput.emit(
+            payload: report,
+            human: report.humanDescription(detailed: breakdown || options.verbose),
+            options: output
+        )
+    }
+}
+
+struct TokenCountReport: Encodable {
+    let command: String
+    let usage: ModelTokenUsage
+    let components: [TokenCountComponent]
+    let componentTokenCount: Int
+    let calibratedEstimate: Int
+    let conservativeEstimate: Int
+    let context: TokenCountContext
+
+    func humanDescription(detailed: Bool) -> String {
+        var lines = [
+            "Token count: \(usage.totalTokenCount)",
+            "Measurement: \(usage.measurement.rawValue)"
+        ]
+        guard detailed else {
+            return lines.joined(separator: "\n")
+        }
+
+        lines.append("Context: \(context.usedTokenCount) / \(context.limitTokenCount) (\(context.formattedPercentage))")
+        lines.append("Remaining: \(context.remainingTokenCount)")
+        lines.append("")
+        lines.append("Breakdown")
+        lines.append(contentsOf: components.map { component in
+            "  \(component.label): \(component.tokenCount) [\(component.measurement.rawValue)]"
+        })
+        lines.append("")
+        lines.append("Calibrated estimate: \(calibratedEstimate)")
+        lines.append("Conservative estimate: \(conservativeEstimate)")
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct TokenCountComponent: Encodable {
+    enum Kind: String, Encodable {
+        case instructions
+        case prompt
+        case schema
+        case tools
+    }
+
+    let kind: Kind
+    let label: String
+    let tokenCount: Int
+    let measurement: ModelTokenUsage.Measurement
+    let characterCount: Int
+    let itemCount: Int
+    let files: [String]?
+}
+
+struct TokenCountContext: Encodable {
+    let usedTokenCount: Int
+    let limitTokenCount: Int
+    let remainingTokenCount: Int
+    let percentageUsed: Double
+    let exceedsLimit: Bool
+
+    var formattedPercentage: String {
+        String(format: "%.1f%%", percentageUsed)
+    }
+}
+
+private struct ResolvedTokenCountInput {
+    let instructions: ResolvedTextInput?
+    let promptSegments: [ResolvedTextInput]
+}
+
+private struct ResolvedTokenCountArtifacts {
+    let schema: ResolvedTokenCountSchema?
+    let tools: ResolvedToolSet
+    let toolSourceText: String
+}
+
+private struct ResolvedTokenCountSchema {
+    let reference: ResolvedArtifactReference
+    let schema: GenerationSchema
+    let sourceText: String
+}
+
+private struct MeasuredTokenCountComponent {
+    let component: TokenCountComponent
+    let fallbackText: String
+}
+
+private extension TokenCountCommand {
+    func validateOutputOptions() throws {
+        if quiet && (breakdown || options.verbose || options.pretty || options.dryRun) {
+            throw ValidationError("--quiet cannot be combined with --breakdown, --verbose, --pretty, or --dry-run.")
+        }
+    }
+
+    func resolveInput() throws -> ResolvedTokenCountInput {
+        let resolvedInstructions = try resolveOptionalText(
+            inline: instructions,
+            file: instructionsFile,
+            inlineName: "--instructions",
+            fileName: "--instructions-file"
+        )
+        let primaryPrompt = try resolvePrimaryPrompt()
+        var promptSegments = primaryPrompt.map { [$0] } ?? []
+        promptSegments.append(contentsOf: try text.map {
+            try resolveInlineValue($0, optionName: "--text")
+        })
+
+        let hasArtifacts = schemaSource.schema != nil || !toolSource.tool.isEmpty
+        guard resolvedInstructions != nil || !promptSegments.isEmpty || hasArtifacts else {
+            throw ValidationError(
+                "Provide a prompt, --instructions, --text, --schema, --tool, or stdin."
+            )
+        }
+        return ResolvedTokenCountInput(
+            instructions: resolvedInstructions,
+            promptSegments: promptSegments
+        )
+    }
+
+    func resolvePrimaryPrompt() throws -> ResolvedTextInput? {
+        let explicitValues = [positionalPrompt, prompt, promptFile].compactMap { $0 }
+        let explicitCount = explicitValues.count + (stdin ? 1 : 0)
+        guard explicitCount <= 1 else {
+            throw ValidationError("Use only one positional prompt, --prompt, --prompt-file, or --stdin.")
+        }
+
+        if let positionalPrompt {
+            return try resolveInlineValue(positionalPrompt, optionName: "prompt")
+        }
+        if let prompt {
+            return try resolveInlineValue(prompt, optionName: "--prompt")
+        }
+        if let promptFile {
+            return try readFileInput(path: promptFile, optionName: "--prompt-file")
+        }
+        if stdin {
+            return try readStandardInput(
+                optionName: "--stdin",
+                requiredMessage: "Please provide a non-empty prompt on stdin."
+            )
+        }
+        if shouldAutomaticallyReadFromStdin() {
+            return try readOptionalStandardInput(optionName: "stdin")
+        }
+        return nil
+    }
+
+    func resolveOptionalText(
+        inline: String?,
+        file: String?,
+        inlineName: String,
+        fileName: String
+    ) throws -> ResolvedTextInput? {
+        guard inline == nil || file == nil else {
+            throw ValidationError("Use only one of \(inlineName) or \(fileName).")
+        }
+        if let inline {
+            return try resolveInlineValue(inline, optionName: inlineName)
+        }
+        if let file {
+            return try readFileInput(path: file, optionName: fileName)
+        }
+        return nil
+    }
+
+    func resolveArtifacts() throws -> ResolvedTokenCountArtifacts {
+        let tools = try resolveToolManifests(toolSource)
+        let toolSourceText = try tools.references.map {
+            try String(contentsOfFile: $0.filePath, encoding: .utf8)
+        }
+        .joined(separator: "\n")
+        let schema: ResolvedTokenCountSchema?
+        if schemaSource.schema != nil {
+            let reference = try schemaSource.resolve()
+            let document = try AFMArtifactRegistry.loadSchemaDocument(from: reference)
+            let sourceText = try String(contentsOfFile: reference.filePath, encoding: .utf8)
+            schema = ResolvedTokenCountSchema(
+                reference: reference,
+                schema: try document.generationSchema(
+                    fallbackName: reference.identifier.camelizedSchemaName()
+                ),
+                sourceText: sourceText
+            )
+        } else {
+            schema = nil
+        }
+        return ResolvedTokenCountArtifacts(
+            schema: schema,
+            tools: tools,
+            toolSourceText: toolSourceText
+        )
+    }
+
+    func measure(
+        input: ResolvedTokenCountInput,
+        artifacts: ResolvedTokenCountArtifacts
+    ) async -> TokenCountReport {
+        let model = SystemLanguageModel.default
+        let measurements = await [
+            measureInstructions(input.instructions, model: model),
+            measurePrompt(input.promptSegments, model: model),
+            measureSchema(artifacts.schema, model: model),
+            measureTools(artifacts, model: model)
+        ].compactMap { $0 }
+
+        return makeReport(
+            model: model,
+            components: measurements.map(\.component),
+            fallbackTexts: measurements.map(\.fallbackText)
+        )
+    }
+
+    func component(
+        kind: TokenCountComponent.Kind,
+        usage: ModelTokenUsage,
+        text: String,
+        itemCount: Int,
+        files: [String]?
+    ) -> TokenCountComponent {
+        TokenCountComponent(
+            kind: kind,
+            label: componentLabel(kind: kind, itemCount: itemCount),
+            tokenCount: usage.totalTokenCount,
+            measurement: usage.measurement,
+            characterCount: text.count,
+            itemCount: itemCount,
+            files: files
+        )
+    }
+
+    func componentLabel(kind: TokenCountComponent.Kind, itemCount: Int) -> String {
+        switch kind {
+        case .instructions:
+            "Instructions"
+        case .prompt:
+            itemCount == 1 ? "Prompt" : "Prompt (\(itemCount) segments)"
+        case .schema:
+            "Schema"
+        case .tools:
+            itemCount == 1 ? "Tool definitions" : "Tool definitions (\(itemCount))"
+        }
+    }
+
+    func measureInstructions(
+        _ instructions: ResolvedTextInput?,
+        model: SystemLanguageModel
+    ) async -> MeasuredTokenCountComponent? {
+        guard let instructions else { return nil }
+        let usage = await model.tokenUsage(
+            for: Instructions(instructions.value),
+            estimatedFrom: instructions.value
+        )
+        return MeasuredTokenCountComponent(
+            component: component(
+                kind: .instructions,
+                usage: usage,
+                text: instructions.value,
+                itemCount: 1,
+                files: instructions.file.map { [$0] }
+            ),
+            fallbackText: instructions.value
+        )
+    }
+
+    func measurePrompt(
+        _ segments: [ResolvedTextInput],
+        model: SystemLanguageModel
+    ) async -> MeasuredTokenCountComponent? {
+        guard !segments.isEmpty else { return nil }
+        let values = segments.map(\.value)
+        let fallbackText = values.joined(separator: "\n")
+        let prompt = Prompt {
+            for value in values {
+                value
+            }
+        }
+        let usage = await model.tokenUsage(for: prompt, estimatedFrom: fallbackText)
+        return MeasuredTokenCountComponent(
+            component: component(
+                kind: .prompt,
+                usage: usage,
+                text: fallbackText,
+                itemCount: values.count,
+                files: segments.compactMap(\.file).nonEmpty
+            ),
+            fallbackText: fallbackText
+        )
+    }
+
+    func measureSchema(
+        _ schema: ResolvedTokenCountSchema?,
+        model: SystemLanguageModel
+    ) async -> MeasuredTokenCountComponent? {
+        guard let schema else { return nil }
+        let usage = await model.tokenUsage(
+            for: schema.schema,
+            estimatedFrom: schema.sourceText
+        )
+        return MeasuredTokenCountComponent(
+            component: component(
+                kind: .schema,
+                usage: usage,
+                text: schema.sourceText,
+                itemCount: 1,
+                files: [schema.reference.filePath]
+            ),
+            fallbackText: schema.sourceText
+        )
+    }
+
+    func measureTools(
+        _ artifacts: ResolvedTokenCountArtifacts,
+        model: SystemLanguageModel
+    ) async -> MeasuredTokenCountComponent? {
+        guard !artifacts.tools.tools.isEmpty else { return nil }
+        let usage = await model.tokenUsage(
+            for: artifacts.tools.tools,
+            estimatedFrom: artifacts.toolSourceText
+        )
+        return MeasuredTokenCountComponent(
+            component: component(
+                kind: .tools,
+                usage: usage,
+                text: artifacts.toolSourceText,
+                itemCount: artifacts.tools.tools.count,
+                files: artifacts.tools.references.map(\.filePath)
+            ),
+            fallbackText: artifacts.toolSourceText
+        )
+    }
+
+    func makeReport(
+        model: SystemLanguageModel,
+        components: [TokenCountComponent],
+        fallbackTexts: [String]
+    ) -> TokenCountReport {
+        let componentTotal = components.reduce(0) { $0 + $1.tokenCount }
+        let measurement: ModelTokenUsage.Measurement = components.allSatisfy {
+            $0.measurement == .tokenized
+        } ? .tokenized : .estimated
+        let limit = model.contextSize
+        let percentage = limit > 0 ? Double(componentTotal) / Double(limit) * 100 : 0
+        let calibratedEstimate = fallbackTexts.reduce(0) { $0 + estimateTokens(from: $1) }
+        let conservativeEstimate = fallbackTexts.reduce(0) {
+            $0 + estimateTokensConservative(from: $1)
+        }
+
+        return TokenCountReport(
+            command: "token-count",
+            usage: ModelTokenUsage(
+                inputTokenCount: componentTotal,
+                measurement: measurement
+            ),
+            components: components,
+            componentTokenCount: componentTotal,
+            calibratedEstimate: calibratedEstimate,
+            conservativeEstimate: conservativeEstimate,
+            context: TokenCountContext(
+                usedTokenCount: componentTotal,
+                limitTokenCount: limit,
+                remainingTokenCount: max(0, limit - componentTotal),
+                percentageUsed: percentage,
+                exceedsLimit: componentTotal > limit
+            )
+        )
+    }
+
+    func emitDryRun(
+        input: ResolvedTokenCountInput,
+        artifacts: ResolvedTokenCountArtifacts,
+        output: CLIOutputOptions
+    ) throws {
+        let payload = TokenCountDryRunPayload(
+            status: "dry_run",
+            command: "token-count",
+            instructions: input.instructions?.value,
+            promptSegments: input.promptSegments.map(\.value),
+            schemaFile: artifacts.schema?.reference.filePath,
+            toolFiles: artifacts.tools.references.map(\.filePath)
+        )
+        try CLIOutput.emit(
+            payload: payload,
+            human: "[dry-run] afm token-count",
+            options: output
+        )
+    }
+}
+
+private struct TokenCountDryRunPayload: Encodable {
+    let status: String
+    let command: String
+    let instructions: String?
+    let promptSegments: [String]
+    let schemaFile: String?
+    let toolFiles: [String]
+}
+
+private extension Array {
+    var nonEmpty: Self? {
+        isEmpty ? nil : self
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -7,6 +7,7 @@ func rootHelpShowsGroupedCommands() throws {
 
     #expect(result.status == 0)
     #expect(result.stdout.contains("MODEL COMMANDS"))
+    #expect(result.stdout.contains("TOKEN COMMANDS"))
     #expect(result.stdout.contains("SESSION COMMANDS"))
     #expect(result.stdout.contains("SCHEMA COMMANDS"))
     #expect(result.stdout.contains("TOOL COMMANDS"))
@@ -31,6 +32,7 @@ func leafCommandHelpCoverage() throws {
         ["model", "languages", "--help"],
         ["model", "use-cases", "--help"],
         ["model", "guardrails", "--help"],
+        ["token-count", "--help"],
         ["tag", "run", "--help"],
         ["session", "respond", "--help"],
         ["session", "stream", "--help"],
@@ -428,11 +430,26 @@ func streamingJSONEmitsEvents() throws {
     #expect((streamEvents.first?["event"] as? String) == "started")
     #expect(streamEvents.contains { ($0["event"] as? String) == "delta" })
     #expect((streamEvents.last?["event"] as? String) == "completed")
+    let streamUsage = try #require(streamEvents.last?["tokenUsage"] as? [String: Any])
+    expectValidRuntimeTokenUsage(streamUsage)
+    #expect((streamUsage["totalTokenCount"] as? Int) ?? 0 > 0)
 
     #expect(chatEvents.contains { ($0["event"] as? String) == "message_started" })
     #expect(chatEvents.contains { ($0["event"] as? String) == "message_delta" })
     #expect(chatEvents.contains { ($0["event"] as? String) == "message_completed" })
     #expect((chatEvents.last?["event"] as? String) == "session_completed")
+    let chatUsage = try #require(chatEvents.last?["tokenUsage"] as? [String: Any])
+    expectValidRuntimeTokenUsage(chatUsage)
+}
+
+private func expectValidRuntimeTokenUsage(_ usage: [String: Any]) {
+    let measurement = usage["measurement"] as? String
+    #expect(["observed", "tokenized", "estimated"].contains { $0 == measurement })
+    if measurement == "observed" {
+        #expect(usage["scope"] as? String == "session")
+    } else {
+        #expect(usage["scope"] as? String == "context")
+    }
 }
 
 @Test("Unknown commands suggest the closest valid command")

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITokenCountTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITokenCountTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+
+@Suite("AFM token-count")
+struct AFMCLITokenCountTests {
+    @Test("JSON output carries provenance, context, and an additive breakdown")
+    func jsonOutputCarriesProvenance() throws {
+        let result = try runAFM(
+            "token-count", "--output", "json",
+            "Hello world",
+            "--instructions", "Be concise.",
+            "--text", "A second segment."
+        )
+
+        #expect(result.status == 0)
+        let json = try parseJSONObject(result.stdout)
+        let usage = try #require(json["usage"] as? [String: Any])
+        let input = try #require(usage["input"] as? [String: Any])
+        let components = try #require(json["components"] as? [[String: Any]])
+        let total = try #require(usage["totalTokenCount"] as? Int)
+        let componentTotal = components.reduce(0) {
+            $0 + (($1["tokenCount"] as? Int) ?? 0)
+        }
+
+        #expect(json["command"] as? String == "token-count")
+        #expect(["tokenized", "estimated"].contains(usage["measurement"] as? String))
+        #expect(usage["scope"] as? String == "context")
+        #expect(input["cachedTokenCount"] == nil)
+        #expect(usage["output"] == nil)
+        #expect(total > 0)
+        #expect(componentTotal == total)
+        #expect(json["componentTokenCount"] as? Int == total)
+    }
+
+    @Test("Quiet mode matches Apple's fm tokenizer when it is installed")
+    func quietModeMatchesFM() throws {
+        let prompt = try runAFM("token-count", "--quiet", "Hello world")
+        let instructed = try runAFM(
+            "token-count", "--quiet", "--instructions", "Be concise.", "Hello world"
+        )
+
+        #expect(prompt.status == 0)
+        #expect(instructed.status == 0)
+        #expect(Int(prompt.stdout) != nil)
+        #expect(Int(instructed.stdout) != nil)
+
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/fm") else {
+            return
+        }
+        let fmPrompt = try runExternal(
+            executable: "/usr/bin/fm",
+            arguments: ["token-count", "--quiet", "Hello world"]
+        )
+        let fmInstructed = try runExternal(
+            executable: "/usr/bin/fm",
+            arguments: [
+                "token-count", "--quiet", "--instructions", "Be concise.", "Hello world"
+            ]
+        )
+
+        // The binary can exist on hosted macOS runners where Apple Intelligence
+        // and its tokenizer assets are unavailable. Keep this a live parity
+        // assertion when both native invocations can actually produce counts.
+        guard fmPrompt.status == 0, fmInstructed.status == 0 else {
+            return
+        }
+        #expect(prompt.stdout == fmPrompt.stdout)
+        #expect(instructed.stdout == fmInstructed.stdout)
+    }
+
+    @Test("Prompt, instructions, files, and stdin compose predictably")
+    func fileAndStdinInputsCompose() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "afm-token-inputs-\(UUID().uuidString)")
+        let instructions = directory.appending(path: "instructions.txt")
+        let extra = directory.appending(path: "extra.txt")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try "Answer as a Swift expert.".write(to: instructions, atomically: true, encoding: .utf8)
+        try "Include one code example.".write(to: extra, atomically: true, encoding: .utf8)
+
+        let result = try runAFM(
+            [
+                "token-count", "--output", "json", "--stdin",
+                "--instructions-file", instructions.path(),
+                "--text", "@\(extra.path())"
+            ],
+            stdin: "Explain actors."
+        )
+
+        #expect(result.status == 0)
+        let json = try parseJSONObject(result.stdout)
+        let components = try #require(json["components"] as? [[String: Any]])
+        #expect(components.compactMap { $0["kind"] as? String } == ["instructions", "prompt"])
+        #expect(components.compactMap { $0["itemCount"] as? Int } == [1, 2])
+    }
+
+    @Test("Schema and tool manifests participate in token counting")
+    func schemaAndToolsParticipate() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "afm-token-artifacts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let schema = """
+        {
+          "title": "Person",
+          "type": "object",
+          "properties": { "name": { "type": "string" } },
+          "required": ["name"]
+        }
+        """
+        let tool = """
+        name: echo
+        description: Echoes a value.
+        parameters:
+          title: EchoArguments
+          type: object
+          properties:
+            value:
+              type: string
+          required: [value]
+        runner:
+          kind: static
+          outputFormat: text
+          text: ok
+        """
+        try schema.write(
+            to: directory.appending(path: "person.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try tool.write(
+            to: directory.appending(path: "echo.yaml"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try runAFM(
+            "token-count", "--output", "json",
+            "--schema", "person", "--schema-dir", directory.path(),
+            "--tool", "echo", "--tool-dir", directory.path()
+        )
+
+        #expect(result.status == 0)
+        let json = try parseJSONObject(result.stdout)
+        let components = try #require(json["components"] as? [[String: Any]])
+        #expect(components.compactMap { $0["kind"] as? String } == ["schema", "tools"])
+        #expect(components.allSatisfy { (($0["tokenCount"] as? Int) ?? 0) > 0 })
+    }
+
+    @Test("Human breakdown distinguishes tokenizer output from estimates")
+    func humanBreakdown() throws {
+        let result = try runAFM(
+            "token-count", "--breakdown", "Hello world",
+            environment: ["AFM_FORCE_TTY": "1"]
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stdout.contains("Token count:"))
+        #expect(result.stdout.contains("Measurement:"))
+        #expect(result.stdout.contains("Breakdown"))
+        #expect(result.stdout.contains("Calibrated estimate:"))
+    }
+}
+
+private func runExternal(executable: String, arguments: [String]) throws -> CommandResult {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let standardOutput = Pipe()
+    let standardError = Pipe()
+    process.standardOutput = standardOutput
+    process.standardError = standardError
+    process.standardInput = FileHandle.nullDevice
+    try process.run()
+    let stdout = standardOutput.fileHandleForReading.readDataToEndOfFile()
+    let stderr = standardError.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return CommandResult(
+        status: process.terminationStatus,
+        stdout: (String(bytes: stdout, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+        stderr: (String(bytes: stderr, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+}


### PR DESCRIPTION
## What

- add a stable `ModelTokenUsage` value with input/output totals, optional cached/reasoning details, measurement provenance, and response/session/context scope
- add `afm token-count` for prompts, instructions, repeated text, stdin/files, schemas, and tool manifests
- use Apple's exact tokenizer on OS 26.4+, keep the existing estimator as an explicitly labeled fallback, and expose both context budgeting and component breakdowns
- add OS 27 observed session usage to `afm session` JSON/NDJSON and verbose text output without removing the existing `tokenCount` field
- persist that same shared usage value with Foundation Lab Playground run records
- include tool definitions in transcript fallback accounting

## Why

Apple's macOS 27 `fm` CLI establishes a useful token-counting baseline, but a bare integer cannot say whether a value was tokenized, estimated, or observed. This makes that distinction machine-readable while keeping `afm` buildable with Xcode 26.6 and runnable from macOS 26.

The result also goes beyond total-only reporting on OS 27: generation output can carry input, output, cached-input, and reasoning-output counts when the runtime supplies them. Missing details stay absent instead of becoming invented zeroes.

## Compatibility and boundaries

- exact preflight counts require the public OS 26.4 tokenizer API
- observed input/output usage requires the OS 27 SDK and runtime
- OS 27 symbols remain behind compiler and availability gates
- standalone counting covers supplied context only; hidden runtime/session framing appears only in observed generation usage
- the legacy generation `tokenCount` field remains unchanged; `tokenUsage` is additive
- images, lossless transcript input, and server endpoints remain separate PRs

## Verification

- strict Core/CLI and FoundationModelsKit SwiftLint
- root Swift package tests under Xcode 26.6 and Xcode 27
- standalone FoundationModelsKit tests
- generic macOS and iOS Simulator app builds under both toolchains
- x86_64 `afm` build smoke test on the macOS 26 deployment floor
- live `/usr/bin/fm` parity: prompt `11 == 11`; instructions + prompt `57 == 57`
- live OS 27 session stream: observed input/output usage emitted in the final event

References: [LanguageModelSession.Response](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/response), [WWDC26: Use the Foundation Models framework from the command line](https://developer.apple.com/videos/play/wwdc2026/334/), and Apple's [foundation-models-utilities](https://github.com/apple/foundation-models-utilities).
