### PR TITLE
Reject unsupported schemas before conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,7 +97,10 @@ let package = Package(
         .testTarget(
             name: "AFMCLITests",
             dependencies: ["AFMCLI"],
-            path: "Tools/AFMCLI/Tests/AFMCLITests"
+            path: "Tools/AFMCLI/Tests/AFMCLITests",
+            resources: [
+                .copy("Fixtures")
+            ]
         ),
         .testTarget(
             name: "FMFBenchCoreTests",

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMArtifactRegistry.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMArtifactRegistry.swift
@@ -27,6 +27,9 @@ enum AFMArtifactRegistry {
             do {
                 return try YAMLDecoder().decode(type, from: text)
             } catch {
+                if let schemaError = AFMSchemaValidationError.find(in: error) {
+                    throw ValidationError("Schema validation failed in \(path): \(schemaError.localizedDescription)")
+                }
                 throw ValidationError("Could not decode \(path) as YAML: \(error.localizedDescription)")
             }
         default:
@@ -34,6 +37,9 @@ enum AFMArtifactRegistry {
                 let data = Data(text.utf8)
                 return try JSONDecoder().decode(type, from: data)
             } catch {
+                if let schemaError = AFMSchemaValidationError.find(in: error) {
+                    throw ValidationError("Schema validation failed in \(path): \(schemaError.localizedDescription)")
+                }
                 throw ValidationError("Could not decode \(path) as JSON: \(error.localizedDescription)")
             }
         }
@@ -50,8 +56,9 @@ struct AFMSchemaDocument: Sendable, Codable {
     let minimumItems: Int?
     let maximumItems: Int?
     let enumValues: [String]?
+    let additionalProperties: Bool?
 
-    enum CodingKeys: String, CodingKey {
+    private enum SchemaCodingKeys: String, CodingKey {
         case title
         case description
         case type
@@ -61,6 +68,67 @@ struct AFMSchemaDocument: Sendable, Codable {
         case minimumItems = "minItems"
         case maximumItems = "maxItems"
         case enumValues = "enum"
+        case definitions = "$defs"
+        case reference = "$ref"
+        case anyOf
+        case propertyOrder = "x-order"
+        case additionalProperties
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SchemaCodingKeys.self)
+
+        try Self.rejectUnsupportedKeyword(.definitions, in: container, decoder: decoder)
+        try Self.rejectUnsupportedKeyword(.reference, in: container, decoder: decoder)
+        try Self.rejectUnsupportedKeyword(.anyOf, in: container, decoder: decoder)
+        try Self.rejectUnsupportedKeyword(.propertyOrder, in: container, decoder: decoder)
+
+        if container.contains(.additionalProperties) {
+            let value: Bool
+            do {
+                value = try container.decode(Bool.self, forKey: .additionalProperties)
+            } catch {
+                throw AFMSchemaValidationError.unsupportedKeyword(
+                    SchemaCodingKeys.additionalProperties.rawValue,
+                    codingPath: decoder.codingPath,
+                    detail: "Only the boolean value false is supported."
+                )
+            }
+            guard !value else {
+                throw AFMSchemaValidationError.unsupportedKeyword(
+                    SchemaCodingKeys.additionalProperties.rawValue,
+                    codingPath: decoder.codingPath,
+                    detail: "Only the boolean value false is supported."
+                )
+            }
+            additionalProperties = value
+        } else {
+            additionalProperties = nil
+        }
+
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        type = try container.decodeIfPresent(String.self, forKey: .type)
+        properties = try container.decodeIfPresent([String: AFMSchemaDocumentBox].self, forKey: .properties)
+        required = try container.decodeIfPresent([String].self, forKey: .required)
+        items = try container.decodeIfPresent(AFMSchemaDocumentBox.self, forKey: .items)
+        minimumItems = try container.decodeIfPresent(Int.self, forKey: .minimumItems)
+        maximumItems = try container.decodeIfPresent(Int.self, forKey: .maximumItems)
+        enumValues = try container.decodeIfPresent([String].self, forKey: .enumValues)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: SchemaCodingKeys.self)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(properties, forKey: .properties)
+        try container.encodeIfPresent(required, forKey: .required)
+        try container.encodeIfPresent(items, forKey: .items)
+        try container.encodeIfPresent(minimumItems, forKey: .minimumItems)
+        try container.encodeIfPresent(maximumItems, forKey: .maximumItems)
+        try container.encodeIfPresent(enumValues, forKey: .enumValues)
+        try container.encodeIfPresent(additionalProperties, forKey: .additionalProperties)
     }
 
     func generationSchema(fallbackName: String = "RootSchema") throws -> GenerationSchema {
@@ -133,6 +201,68 @@ struct AFMSchemaDocument: Sendable, Codable {
             return "string"
         }
         return "object"
+    }
+
+    private static func rejectUnsupportedKeyword(
+        _ key: SchemaCodingKeys,
+        in container: KeyedDecodingContainer<SchemaCodingKeys>,
+        decoder: Decoder
+    ) throws {
+        guard container.contains(key) else {
+            return
+        }
+        throw AFMSchemaValidationError.unsupportedKeyword(
+            key.rawValue,
+            codingPath: decoder.codingPath
+        )
+    }
+}
+
+private struct AFMSchemaValidationError: LocalizedError {
+    let keyword: String
+    let jsonPointer: String
+    let detail: String
+
+    static func unsupportedKeyword(
+        _ keyword: String,
+        codingPath: [any CodingKey],
+        detail: String = "This keyword is not supported."
+    ) -> Self {
+        let components = codingPath.map(\.stringValue) + [keyword]
+        let pointer = "/" + components.map(jsonPointerEscaped).joined(separator: "/")
+        return Self(keyword: keyword, jsonPointer: pointer, detail: detail)
+    }
+
+    var errorDescription: String? {
+        "Unsupported schema keyword '\(keyword)' at JSON pointer '\(jsonPointer)'. \(detail)"
+    }
+
+    static func find(in error: any Error) -> Self? {
+        if let schemaError = error as? Self {
+            return schemaError
+        }
+
+        let underlyingError: (any Error)?
+        switch error {
+        case DecodingError.dataCorrupted(let context),
+             DecodingError.keyNotFound(_, let context),
+             DecodingError.typeMismatch(_, let context),
+             DecodingError.valueNotFound(_, let context):
+            underlyingError = context.underlyingError
+        default:
+            underlyingError = nil
+        }
+
+        guard let underlyingError else {
+            return nil
+        }
+        return find(in: underlyingError)
+    }
+
+    private static func jsonPointerEscaped(_ component: String) -> String {
+        component
+            .replacingOccurrences(of: "~", with: "~0")
+            .replacingOccurrences(of: "/", with: "~1")
     }
 }
 

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLISchemaTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLISchemaTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+@testable import AFMCLI
 
 @Test("Schema commands expose list and run flows")
 func schemaCommands() throws {
@@ -175,4 +176,187 @@ func pipedSchemaInputOverridesPresetDefaults() throws {
     #expect(result.status == 0)
     let json = try parseJSONObject(result.stdout)
     #expect(json["input"] as? String == pipedInput)
+}
+
+@Test("Schemas emitted by fm fail closed instead of changing shape silently")
+func foundationModelsCLISchemaFixturesFailClosed() throws {
+    let fixtures = ["fm-schema-nested", "fm-schema-union"]
+
+    for fixture in fixtures {
+        let schemaURL = try #require(
+            Bundle.module.url(
+                forResource: fixture,
+                withExtension: "json",
+                subdirectory: "Fixtures"
+            )
+        )
+        let result = try runCustomSchemaDryRun(schemaURL)
+
+        #expect(result.status == 64)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.contains("Unsupported schema keyword '$defs'"))
+        #expect(result.stderr.contains("JSON pointer '/$defs'"))
+    }
+}
+
+@Test("Unsupported schema keywords report their exact JSON pointers")
+func unsupportedSchemaKeywordsReportExactPointers() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-unsupported-schemas-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let cases = [
+        UnsupportedSchemaCase(
+            name: "definitions",
+            document: #"{"type":"object","$defs":{}}"#,
+            keyword: "$defs",
+            pointer: "/$defs"
+        ),
+        UnsupportedSchemaCase(
+            name: "reference",
+            document: ##"{"type":"object","properties":{"address":{"$ref":"#/$defs/Address"}}}"##,
+            keyword: "$ref",
+            pointer: "/properties/address/$ref"
+        ),
+        UnsupportedSchemaCase(
+            name: "escaped-reference-path",
+            document: ##"{"type":"object","properties":{"home/office~primary":{"$ref":"#/$defs/Room"}}}"##,
+            keyword: "$ref",
+            pointer: "/properties/home~1office~0primary/$ref"
+        ),
+        UnsupportedSchemaCase(
+            name: "union",
+            document: #"{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"}]}}"#,
+            keyword: "anyOf",
+            pointer: "/items/anyOf"
+        ),
+        UnsupportedSchemaCase(
+            name: "property-order",
+            document: #"{"type":"object","properties":{"profile":{"type":"object","x-order":[]}}}"#,
+            keyword: "x-order",
+            pointer: "/properties/profile/x-order"
+        ),
+        UnsupportedSchemaCase(
+            name: "open-additional-properties",
+            document: #"{"type":"object","properties":{"profile":{"type":"object","additionalProperties":true}}}"#,
+            keyword: "additionalProperties",
+            pointer: "/properties/profile/additionalProperties"
+        ),
+        UnsupportedSchemaCase(
+            name: "schema-additional-properties",
+            document: #"{"type":"object","additionalProperties":{"type":"string"}}"#,
+            keyword: "additionalProperties",
+            pointer: "/additionalProperties"
+        )
+    ]
+
+    for testCase in cases {
+        let schemaURL = directory.appending(path: "\(testCase.name).json")
+        try testCase.document.write(to: schemaURL, atomically: true, encoding: .utf8)
+        let result = try runCustomSchemaDryRun(schemaURL)
+
+        #expect(result.status == 64)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.contains("Unsupported schema keyword '\(testCase.keyword)'"))
+        #expect(result.stderr.contains("JSON pointer '\(testCase.pointer)'"))
+    }
+
+}
+
+@Test("Unsupported YAML schema keywords report exact JSON pointers")
+func unsupportedYAMLSchemaKeywordReportsExactPointer() throws {
+    let schemaURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-unsupported-schema-\(UUID().uuidString).yaml")
+    defer { try? FileManager.default.removeItem(at: schemaURL) }
+    let schema = """
+    type: object
+    properties:
+      address:
+        $ref: '#/$defs/Address'
+    """
+    try schema.write(to: schemaURL, atomically: true, encoding: .utf8)
+
+    let result = try runCustomSchemaDryRun(schemaURL)
+
+    #expect(result.status == 64)
+    #expect(result.stderr.contains("Unsupported schema keyword '$ref'"))
+    #expect(result.stderr.contains("JSON pointer '/properties/address/$ref'"))
+}
+
+@Test("Closed additional properties preserve supported schema conversion")
+func closedAdditionalPropertiesRemainSupported() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-supported-schema-\(UUID().uuidString)")
+    let schemaURL = directory.appending(path: "supported.json")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let schema = """
+    {
+      "title": "ReleaseSummary",
+      "description": "A supported schema using every currently converted shape.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "string",
+          "enum": ["low", "medium", "high"]
+        },
+        "scores": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 3,
+          "items": {
+            "type": "number"
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "revision": {
+              "type": "integer"
+            }
+          },
+          "required": ["revision"]
+        },
+        "approved": {
+          "type": "boolean"
+        }
+      },
+      "required": ["name", "priority", "scores", "metadata"]
+    }
+    """
+    let document = try JSONDecoder().decode(AFMSchemaDocument.self, from: Data(schema.utf8))
+    _ = try document.generationSchema(fallbackName: "ReleaseSummary")
+    try schema.write(to: schemaURL, atomically: true, encoding: .utf8)
+
+    let result = try runCustomSchemaDryRun(schemaURL)
+
+    #expect(result.status == 0)
+    #expect(result.stderr.isEmpty)
+    let json = try parseJSONObject(result.stdout)
+    #expect(json["command"] as? String == "schema run custom")
+    #expect(json["schemaFile"] as? String == schemaURL.path())
+}
+
+private func runCustomSchemaDryRun(_ schemaURL: URL) throws -> CommandResult {
+    try runAFM(
+        "schema", "run", "custom",
+        "--output", "json",
+        "--dry-run",
+        "--schema", schemaURL.path(),
+        "--input", "Test input"
+    )
+}
+
+private struct UnsupportedSchemaCase {
+    let name: String
+    let document: String
+    let keyword: String
+    let pointer: String
 }

--- a/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-nested.json
+++ b/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-nested.json
@@ -1,0 +1,38 @@
+{
+  "additionalProperties" : false,
+  "$defs" : {
+    "Address" : {
+      "required" : [
+        "street"
+      ],
+      "additionalProperties" : false,
+      "properties" : {
+        "zip" : {
+          "type" : "string"
+        },
+        "street" : {
+          "type" : "string"
+        }
+      },
+      "type" : "object",
+      "title" : "Address",
+      "x-order" : [
+        "street",
+        "zip"
+      ]
+    }
+  },
+  "type" : "object",
+  "x-order" : [
+    "address"
+  ],
+  "properties" : {
+    "address" : {
+      "$ref" : "#\/$defs\/Address"
+    }
+  },
+  "title" : "ContactCard",
+  "required" : [
+    "address"
+  ]
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-union.json
+++ b/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-union.json
@@ -1,0 +1,45 @@
+{
+  "anyOf" : [
+    {
+      "$ref" : "#\/$defs\/EmailContact"
+    },
+    {
+      "$ref" : "#\/$defs\/PhoneContact"
+    }
+  ],
+  "title" : "ContactMethod",
+  "$defs" : {
+    "EmailContact" : {
+      "properties" : {
+        "email" : {
+          "type" : "string"
+        }
+      },
+      "x-order" : [
+        "email"
+      ],
+      "additionalProperties" : false,
+      "type" : "object",
+      "required" : [
+        "email"
+      ],
+      "title" : "EmailContact"
+    },
+    "PhoneContact" : {
+      "properties" : {
+        "phone" : {
+          "type" : "string"
+        }
+      },
+      "x-order" : [
+        "phone"
+      ],
+      "additionalProperties" : false,
+      "type" : "object",
+      "required" : [
+        "phone"
+      ],
+      "title" : "PhoneContact"
+    }
+  }
+}


### PR DESCRIPTION
## What

- make custom JSON/YAML schema decoding reject `$defs`, `$ref`, `anyOf`, and `x-order` before conversion
- accept `additionalProperties: false`, but reject open or schema-valued `additionalProperties`
- report the unsupported keyword and its exact RFC 6901 JSON pointer, including nested and escaped property names
- add sanitized fixtures captured from live `fm schema object` nested and union output
- retain successful conversion for every schema shape `afm` currently supports

## Why

`AFMSchemaDocument` previously ignored these keys. That meant a schema generated by Apple's `fm` could be accepted by `afm` and silently converted into a different shape—for example, a `$ref` property could become an empty object. A clear validation failure is safer than a successful command with false semantics.

This is deliberately the fail-closed prerequisite. A later, separate parity PR can add real `$defs`/`$ref`, union, and ordering support without obscuring the correctness fix.

## Verification

- strict app and Core/CLI SwiftLint
- Xcode 26.6 schema and tool-manifest tests
- Xcode 27 schema and tool-manifest tests
- JSON and YAML nested-pointer cases
- RFC 6901 escaping case
- exact live-`fm` nested and union fixtures
- supported closed-object conversion regression
- `git diff --check`
