### PR TITLE
Verify universal AFM release artifacts

### DIFF
--- a/.github/scripts/verify-afm-artifact.sh
+++ b/.github/scripts/verify-afm-artifact.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-afm-binary>" >&2
+  exit 64
+fi
+
+binary="$1"
+expected_minos="${AFM_EXPECTED_MACOS_MINIMUM:-26.0}"
+
+if [[ "$binary" != /* ]]; then
+  binary="$PWD/$binary"
+fi
+
+if [[ ! -f "$binary" || ! -x "$binary" ]]; then
+  echo "::error::AFM artifact is not an executable file: $binary"
+  exit 1
+fi
+
+architectures="$(/usr/bin/lipo -archs "$binary")"
+architecture_count="$(wc -w <<< "$architectures" | tr -d ' ')"
+
+if [[ "$architecture_count" != "2" ]]; then
+  echo "::error::Expected exactly two architecture slices, found: $architectures"
+  exit 1
+fi
+
+for architecture in arm64 x86_64; do
+  if ! /usr/bin/lipo "$binary" -verify_arch "$architecture"; then
+    echo "::error::AFM artifact is missing its $architecture slice"
+    exit 1
+  fi
+
+  actual_minos="$(
+    /usr/bin/xcrun vtool -arch "$architecture" -show-build "$binary" |
+      /usr/bin/awk '$1 == "minos" { print $2 }'
+  )"
+
+  if [[ "$actual_minos" != "$expected_minos" ]]; then
+    echo "::error::$architecture minimum macOS is $actual_minos; expected $expected_minos"
+    exit 1
+  fi
+done
+
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+run_offline_smokes() {
+  local architecture="$1"
+  local output_prefix="$temporary_directory/$architecture"
+
+  /usr/bin/arch "-$architecture" "$binary" --help > "$output_prefix-help.txt"
+  /usr/bin/grep -Fq "MODEL COMMANDS" "$output_prefix-help.txt"
+
+  /usr/bin/arch "-$architecture" "$binary" --output json --dry-run \
+    > "$output_prefix-dry-run.json"
+  /usr/bin/grep -Fq '"status":"dry_run"' "$output_prefix-dry-run.json"
+
+  /usr/bin/arch "-$architecture" "$binary" schema list --output json --dry-run \
+    > "$output_prefix-schema.json"
+  /usr/bin/grep -Fq '"command":"schema list"' "$output_prefix-schema.json"
+
+  set +e
+  /usr/bin/arch "-$architecture" "$binary" \
+    session respond --prompt hi --temperature 2 \
+    > "$output_prefix-validation.txt" 2>&1
+  local validation_status=$?
+  set -e
+
+  if [[ "$validation_status" -ne 64 ]]; then
+    echo "::error::$architecture validation smoke exited $validation_status; expected 64"
+    exit 1
+  fi
+
+  /usr/bin/grep -Fq -- "--temperature must be between 0 and 1" \
+    "$output_prefix-validation.txt"
+  echo "Verified offline $architecture artifact smokes"
+}
+
+if ! /usr/bin/arch -arm64 /usr/bin/true >/dev/null 2>&1; then
+  echo "::error::The runner cannot execute the required arm64 artifact smoke tests"
+  exit 1
+fi
+
+run_offline_smokes arm64
+
+if /usr/bin/arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+  run_offline_smokes x86_64
+else
+  echo "::notice::Rosetta is unavailable; x86_64 execution smokes were skipped. The slice and minimum OS were still verified."
+fi
+
+echo "Verified AFM artifact architectures ($architectures) and macOS $expected_minos minimum"

--- a/.github/workflows/afm-cli.yml
+++ b/.github/workflows/afm-cli.yml
@@ -10,7 +10,9 @@ on:
       - 'Package.swift'
       - 'Package.resolved'
       - '.swiftlint-core-cli.yml'
+      - '.github/scripts/verify-afm-artifact.sh'
       - '.github/workflows/afm-cli.yml'
+      - '.github/workflows/afm-release.yml'
   push:
     branches: [main]
     paths:
@@ -20,7 +22,9 @@ on:
       - 'Package.swift'
       - 'Package.resolved'
       - '.swiftlint-core-cli.yml'
+      - '.github/scripts/verify-afm-artifact.sh'
       - '.github/workflows/afm-cli.yml'
+      - '.github/workflows/afm-release.yml'
   workflow_dispatch:
 
 permissions:
@@ -66,6 +70,18 @@ jobs:
       - name: Test standalone FoundationModelsKit package
         run: swift test --package-path Packages/FoundationModelsKit
 
+  universal-artifact:
+    needs: build-and-test
+    runs-on: macos-26
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Show artifact toolchain versions
+        run: |
+          xcodebuild -version
+          swift --version
+
       - name: Build universal release binary
         run: |
           rm -rf .build-release build
@@ -75,8 +91,31 @@ jobs:
             --arch x86_64 \
             --product afm \
             --scratch-path .build-release
+          AFM_BIN_PATH="$(swift build \
+            -c release \
+            --arch arm64 \
+            --arch x86_64 \
+            --product afm \
+            --scratch-path .build-release \
+            --show-bin-path)"
           mkdir -p build
-          cp .build-release/apple/Products/Release/afm build/afm_dev_macOS_universal
+          cp "$AFM_BIN_PATH/afm" build/afm_dev_macOS_universal
+          chmod +x build/afm_dev_macOS_universal
+
+      - name: Verify universal artifact
+        env:
+          AFM_EXPECTED_MACOS_MINIMUM: '26.0'
+        run: bash .github/scripts/verify-afm-artifact.sh build/afm_dev_macOS_universal
+
+      - name: Test the packaged binary
+        env:
+          AFM_TEST_BINARY: ${{ github.workspace }}/build/afm_dev_macOS_universal
+        run: |
+          swift test \
+            --filter 'AFMCLITests\.(rootHelpShowsGroupedCommands|rootDryRun|discoveryCommandsHonorDryRun|validationErrorsAreDeterministic)'
+
+      - name: Write artifact checksum
+        run: |
           shasum -a 256 build/afm_dev_macOS_universal > build/afm_dev_checksums.txt
 
       - name: Upload CLI artifact

--- a/.github/workflows/afm-release.yml
+++ b/.github/workflows/afm-release.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Show release toolchain versions
+        run: |
+          xcodebuild -version
+          swift --version
+
       - name: Validate release tag
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -40,8 +45,26 @@ jobs:
             --arch x86_64 \
             --product afm \
             --scratch-path .build-release
-          cp .build-release/apple/Products/Release/afm "release/afm_${VERSION}_macOS_universal"
+          AFM_BIN_PATH="$(swift build \
+            -c release \
+            --arch arm64 \
+            --arch x86_64 \
+            --product afm \
+            --scratch-path .build-release \
+            --show-bin-path)"
+          cp "$AFM_BIN_PATH/afm" "release/afm_${VERSION}_macOS_universal"
           chmod +x "release/afm_${VERSION}_macOS_universal"
+
+      - name: Verify universal release artifact
+        env:
+          AFM_EXPECTED_MACOS_MINIMUM: '26.0'
+        run: bash .github/scripts/verify-afm-artifact.sh "release/afm_${VERSION}_macOS_universal"
+
+      - name: Test the packaged release binary
+        run: |
+          AFM_TEST_BINARY="$PWD/release/afm_${VERSION}_macOS_universal" \
+            swift test \
+            --filter 'AFMCLITests\.(rootHelpShowsGroupedCommands|rootDryRun|discoveryCommandsHonorDryRun|validationErrorsAreDeterministic)'
 
       - name: Detect signing configuration
         id: signing

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITestSupport.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITestSupport.swift
@@ -21,9 +21,10 @@ func runAFM(
     stdin: String? = nil
 ) throws -> CommandResult {
     let process = Process()
-    process.executableURL = try findAFMBinary()
+    let processEnvironment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+    process.executableURL = try findAFMBinary(environment: processEnvironment)
     process.currentDirectoryURL = packageRoot()
-    process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+    process.environment = processEnvironment
 
     let stdoutPipe = Pipe()
     let stderrPipe = Pipe()
@@ -90,8 +91,26 @@ private func decodedOutput(_ data: Data) -> String {
         .trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
-private func findAFMBinary() throws -> URL {
+private func findAFMBinary(environment: [String: String]) throws -> URL {
     let root = packageRoot()
+
+    if let providedPath = environment["AFM_TEST_BINARY"]?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+       !providedPath.isEmpty {
+        let providedBinary = URL(
+            fileURLWithPath: providedPath,
+            relativeTo: root
+        ).standardizedFileURL
+
+        guard FileManager.default.isExecutableFile(atPath: providedBinary.path()) else {
+            throw TestFailure(
+                "AFM_TEST_BINARY is not an executable file: \(providedBinary.path())"
+            )
+        }
+
+        return providedBinary
+    }
+
     let directCandidates = [
         root.appending(path: ".build/debug/afm"),
         root.appending(path: ".build/arm64-apple-macosx/debug/afm"),

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -1,6 +1,17 @@
 import Foundation
 import Testing
 
+@Test("Test helper can target a provided executable")
+func providedAFMBinaryOverridesBuildSearch() throws {
+    let result = try runAFM(
+        "provided-binary",
+        environment: ["AFM_TEST_BINARY": "/usr/bin/printf"]
+    )
+
+    #expect(result.status == 0)
+    #expect(result.stdout == "provided-binary")
+}
+
 @Test("Root help shows grouped command discovery")
 func rootHelpShowsGroupedCommands() throws {
     let result = try runAFM("--help")


### PR DESCRIPTION
## What

- split universal packaging into its own CI job after deterministic tests pass
- discover SwiftPM's release output instead of relying on one build-directory layout
- verify the shipped binary contains exactly `arm64` and `x86_64` slices
- verify both slices retain a macOS 26.0 minimum with `vtool`
- run packaged-binary help, dry-run, schema, and validation smokes on arm64 and under Rosetta when available
- let CLI tests target an explicit packaged executable through `AFM_TEST_BINARY`
- apply the same verification before publishing an AFM release

## Why

A successful source build does not prove that the uploaded artifact is universal, keeps the intended deployment floor, or is the binary the smoke tests exercised. These checks make the release artifact itself the test subject.

## Toolchain boundary

GitHub's current official macOS 26 hosted images provide Xcode 26.5, but neither Xcode 26.6 nor Xcode 27. This repository also has no self-hosted runner. The workflow therefore reports and uses the actual hosted default instead of creating a fake or permanently red matrix.

Both supported compilers were verified locally. The CI structure is ready to use newer hosted defaults when GitHub adds them; a genuine dual-toolchain matrix remains a follow-up once both toolchains are available on a runner.

## Verification

- `actionlint`
- `bash -n .github/scripts/verify-afm-artifact.sh`
- strict SwiftLint and `git diff --check`
- Xcode 26.6 universal build, slice/minOS verification, helper test, and packaged-binary smokes
- Xcode 27 deterministic tests, standalone package tests, universal build, slice/minOS verification, and packaged-binary smokes
- Rosetta detection is conditional; local x86_64 execution was skipped because Rosetta is unavailable, while the slice and minOS were still statically verified

Hosted image references: [macOS 26 arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md) and [macOS 26 Intel](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md).
