### PR TITLE
Add secure AFM server transport and discovery endpoints

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf404e35b53aa57c0e9907b65a2edc3144942c58e3e12a7c0d67061679ce8e2e",
+  "originHash" : "370a5ea74b24f152ffe369db9569d8f9c946a44d4b50a3d359833e196eb9d154",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,42 @@
       "state" : {
         "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
         "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.101.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.1")
     ],
     targets: [
@@ -63,12 +64,22 @@ let package = Package(
         .executableTarget(
             name: "AFMCLI",
             dependencies: [
+                "AFMServer",
                 "FoundationLabCore",
                 "FoundationModelsKit",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Yams", package: "Yams")
             ],
             path: "Tools/AFMCLI/Sources/AFMCLI"
+        ),
+        .target(
+            name: "AFMServer",
+            dependencies: [
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio")
+            ],
+            path: "Tools/AFMCLI/Sources/AFMServer"
         ),
         .target(
             name: "FMFBenchCore",
@@ -98,6 +109,14 @@ let package = Package(
             name: "AFMCLITests",
             dependencies: ["AFMCLI"],
             path: "Tools/AFMCLI/Tests/AFMCLITests"
+        ),
+        .testTarget(
+            name: "AFMServerTests",
+            dependencies: [
+                "AFMServer",
+                .product(name: "NIOEmbedded", package: "swift-nio")
+            ],
+            path: "Tools/AFMCLI/Tests/AFMServerTests"
         ),
         .testTarget(
             name: "FMFBenchCoreTests",

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -32,7 +32,7 @@ To run live model commands, you still need a supported Apple Intelligence Mac. F
 
 ## Why `afm`
 
-- It gives Foundation Models a direct command-line workflow for prompting, tagging, schemas, tools, transcripts, and feedback.
+- It gives Foundation Models a direct workflow for prompting, tagging, schemas, tools, transcripts, feedback, and local services.
 - It is built for real terminal use: explicit flags, readable help, file-based inputs, and clean JSON output.
 - It works well in automation and agent flows with dry-runs, stdin support, schema and tool directories, and NDJSON-style streaming events.
 - It keeps important runtime controls close at hand, including adapters, use cases, guardrails, schema prompting, and feedback issues.
@@ -52,6 +52,7 @@ afm session stream --prompt "Write a short poem about rain."
 afm tag run --prompt "A joyful dog playing in a sunny park."
 afm schema run typed-person --input "Alex Rivera is a designer in Berlin."
 afm schema run custom --schema person-card --schema-dir .afm/schemas --input @person.txt
+afm serve
 ```
 
 ## Sample Workflows
@@ -169,6 +170,31 @@ Use export commands when you want artifacts you can keep, diff, or send elsewher
 afm transcript export --message "Hello" --message "Summarize our conversation." --file transcript.json
 afm feedback export --prompt "What is the capital of France?" --sentiment positive --issue incorrect --file feedback.json
 ```
+
+### Start the local server
+
+`afm serve` starts a transport for local integrations. This first server surface
+provides `GET /health` and `GET /v1/models`; model inference endpoints are added
+separately.
+
+```bash
+afm serve
+curl http://127.0.0.1:1976/health
+curl http://127.0.0.1:1976/v1/models
+```
+
+The default listener is loopback-only. Cross-site requests are rejected unless
+their exact origin is passed with `--allow-origin`. Add bearer authentication
+with `--token` or the `AFM_SERVER_TOKEN` environment variable:
+
+```bash
+AFM_SERVER_TOKEN="$(openssl rand -hex 32)" afm serve
+afm serve --socket /tmp/afm.sock
+```
+
+A non-loopback binding requires both `--allow-network` and a bearer token. Unix
+sockets are created with mode `0600`, and `afm` refuses to replace regular files,
+symlinks, or active sockets at the requested path.
 
 ## Files, Pipes, And Automation
 

--- a/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
@@ -19,7 +19,8 @@ struct AFMEntryPoint {
         guard !firstArgument.hasPrefix("-") else { return nil }
 
         let rootCommands = [
-            "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"
+            "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve",
+            "help", "version"
         ]
         if !rootCommands.contains(firstArgument) {
             if let suggestion = suggestRootCommand(for: firstArgument) {

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
@@ -21,7 +21,8 @@ struct AFMRootCommand: AsyncParsableCommand {
             SchemaCommand.self,
             ToolCommand.self,
             TranscriptCommand.self,
-            FeedbackCommand.self
+            FeedbackCommand.self,
+            ServeCommand.self
         ]
     )
 
@@ -40,8 +41,10 @@ struct AFMRootCommand: AsyncParsableCommand {
 
         let payload = RootStatusPayload(
             name: Self.configuration.commandName ?? "afm",
-            summary: "Workflow-first CLI for Foundation Models sessions, schemas, tools, transcripts, and feedback.",
-            commands: ["model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback"]
+            summary: "Workflow-first CLI for Foundation Models sessions, schemas, tools, exports, and local services.",
+            commands: [
+                "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve"
+            ]
         )
         let human: String
         if options.verbose {

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
@@ -397,6 +397,9 @@ enum HelpText {
       transcript   Export transcript data from a session flow.
       feedback     Export Foundation Models feedback attachments.
 
+    SERVER COMMANDS
+      serve        Serve local HTTP endpoints over TCP or a Unix-domain socket.
+
     QUICK START
       afm model status
       afm model use-cases
@@ -415,6 +418,7 @@ enum HelpText {
       afm tool inspect --tool demo-weather
       afm transcript export --message "Hello" --message "Summarize this conversation." --file transcript.json
       afm feedback export --prompt "What is the capital of France?" --sentiment positive --file feedback.json
+      afm serve
     """
 
     static let session = """
@@ -434,7 +438,10 @@ enum HelpText {
 }
 
 func suggestRootCommand(for input: String) -> String? {
-    let commands = ["model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"]
+    let commands = [
+        "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve", "help",
+        "version"
+    ]
     return suggestCommand(input, in: commands)
 }
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ServeCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ServeCommand.swift
@@ -1,0 +1,195 @@
+import AFMServer
+import ArgumentParser
+import Foundation
+import FoundationLabCore
+
+struct ServeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Serve local Foundation Models-compatible HTTP endpoints."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+
+    @Option(name: .long, help: "TCP host. Defaults to 127.0.0.1.")
+    var host: String?
+
+    @Option(name: .long, help: "TCP port. Defaults to 1976.")
+    var port: Int?
+
+    @Option(name: .long, help: "Listen on an absolute Unix-domain socket path instead of TCP.")
+    var socket: String?
+
+    @Flag(name: .customLong("allow-network"), help: "Allow a non-loopback TCP binding.")
+    var allowNetwork = false
+
+    @Option(
+        name: .customLong("token"),
+        help: "Require this bearer token. Prefer the AFM_SERVER_TOKEN environment variable."
+    )
+    var bearerToken: String?
+
+    @Option(
+        name: .customLong("allow-origin"),
+        parsing: .upToNextOption,
+        help: "Allow an exact Origin value. Repeat for multiple origins."
+    )
+    var allowedOrigins: [String] = []
+
+    mutating func run() async throws {
+        let output = try options.resolvedOutput()
+        let serverConfiguration = try resolvedServerConfiguration()
+
+        if options.dryRun {
+            let payload = ServeDryRunPayload(configuration: serverConfiguration)
+            try CLIOutput.emit(
+                payload: payload,
+                human: "[dry-run] afm serve \(payload.endpoint)",
+                options: output
+            )
+            return
+        }
+
+        let availability = CheckModelAvailabilityUseCase().execute()
+        let catalog = AFMStaticModelCatalog(
+            models: [.init(id: "system", isAvailable: availability.isAvailable)]
+        )
+        let server = try AFMHTTPServer(configuration: serverConfiguration, catalog: catalog)
+        let terminationSignal = AFMTerminationSignal()
+
+        do {
+            let address = try await server.start()
+            try emitStartupMessage(
+                address: address,
+                configuration: serverConfiguration,
+                output: output
+            )
+            try await waitForShutdown(server: server, terminationSignal: terminationSignal)
+        } catch {
+            try? await server.stop()
+            throw error
+        }
+    }
+
+    private func waitForShutdown(
+        server: AFMHTTPServer,
+        terminationSignal: AFMTerminationSignal
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await terminationSignal.wait()
+            }
+            group.addTask {
+                try await server.waitUntilClosed()
+            }
+
+            _ = try await group.next()
+            try await server.stop()
+            group.cancelAll()
+        }
+    }
+
+    private func resolvedServerConfiguration() throws -> AFMServerConfiguration {
+        let endpoint: AFMServerEndpoint
+        if let socket {
+            guard host == nil, port == nil else {
+                throw ValidationError("--socket cannot be combined with --host or --port")
+            }
+            guard !allowNetwork else {
+                throw ValidationError("--allow-network is only valid with a TCP endpoint")
+            }
+            endpoint = .unixSocket(path: socket)
+        } else {
+            let resolvedPort = port ?? 1976
+            guard (1...65_535).contains(resolvedPort) else {
+                throw ValidationError("--port must be between 1 and 65535")
+            }
+            endpoint = .tcp(host: host ?? "127.0.0.1", port: resolvedPort)
+        }
+
+        let environmentToken = ProcessInfo.processInfo.environment["AFM_SERVER_TOKEN"]
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let configuration = AFMServerConfiguration(
+            endpoint: endpoint,
+            security: .init(
+                allowNetwork: allowNetwork,
+                bearerToken: bearerToken ?? environmentToken,
+                allowedOrigins: Set(allowedOrigins)
+            )
+        )
+        do {
+            return try configuration.validated()
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+    }
+
+    private func emitStartupMessage(
+        address: AFMServerBoundAddress,
+        configuration: AFMServerConfiguration,
+        output: CLIOutputOptions
+    ) throws {
+        let payload = ServeStartedPayload(address: address, configuration: configuration)
+        var humanLines = ["afm serve listening on \(payload.endpoint)"]
+        if configuration.security.bearerToken != nil {
+            humanLines.append("Bearer authentication is enabled.")
+        }
+        try CLIOutput.emit(payload: payload, human: humanLines.joined(separator: "\n"), options: output)
+        fflush(stdout)
+        if payload.networkExposed, output.format == .text {
+            fputs("Warning: requests travel over plaintext HTTP on the local network.\n", stderr)
+        }
+    }
+}
+
+private struct ServeDryRunPayload: Encodable {
+    let status = "dry_run"
+    let command = "serve"
+    let endpoint: String
+    let authenticationEnabled: Bool
+    let allowedOrigins: [String]
+
+    init(configuration: AFMServerConfiguration) {
+        switch configuration.endpoint {
+        case .tcp(let host, let port):
+            endpoint = AFMServerBoundAddress.tcp(host: host, port: port).description
+        case .unixSocket(let path):
+            endpoint = "unix://\(path)"
+        }
+        authenticationEnabled = configuration.security.bearerToken != nil
+        allowedOrigins = configuration.security.allowedOrigins.sorted()
+    }
+}
+
+private struct ServeStartedPayload: Encodable {
+    let status = "started"
+    let command = "serve"
+    let endpoint: String
+    let transport: String
+    let authenticationEnabled: Bool
+    let allowedOrigins: [String]
+    let networkExposed: Bool
+
+    init(address: AFMServerBoundAddress, configuration: AFMServerConfiguration) {
+        switch address {
+        case .tcp(let host, let port):
+            let renderedHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+            endpoint = "http://\(renderedHost):\(port)"
+            transport = "tcp"
+        case .unixSocket(let path):
+            endpoint = "unix://\(path)"
+            transport = "unix"
+        }
+        authenticationEnabled = configuration.security.bearerToken != nil
+        allowedOrigins = configuration.security.allowedOrigins.sorted()
+        if case .tcp(let host, _) = configuration.endpoint {
+            let normalizedHost = host.lowercased()
+            networkExposed = !normalizedHost.hasPrefix("127.")
+                && normalizedHost != "localhost"
+                && normalizedHost != "::1"
+                && normalizedHost != "[::1]"
+        } else {
+            networkExposed = false
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMTerminationSignal.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMTerminationSignal.swift
@@ -1,0 +1,40 @@
+import Darwin
+import Dispatch
+
+final class AFMTerminationSignal: @unchecked Sendable {
+    private let stream: AsyncStream<Int32>
+    private let continuation: AsyncStream<Int32>.Continuation
+    private let sources: [DispatchSourceSignal]
+
+    init() {
+        let pair = AsyncStream.makeStream(of: Int32.self)
+        stream = pair.stream
+        continuation = pair.continuation
+
+        let handledSignals = [SIGINT, SIGTERM]
+        for signalNumber in handledSignals {
+            Darwin.signal(signalNumber, SIG_IGN)
+        }
+        sources = handledSignals.map { signalNumber in
+            let source = DispatchSource.makeSignalSource(signal: signalNumber)
+            source.setEventHandler {
+                pair.continuation.yield(signalNumber)
+            }
+            source.resume()
+            return source
+        }
+    }
+
+    deinit {
+        for source in sources {
+            source.cancel()
+        }
+        continuation.finish()
+    }
+
+    func wait() async {
+        for await _ in stream {
+            return
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChildChannelRegistry.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChildChannelRegistry.swift
@@ -1,0 +1,55 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
+final class AFMChildChannelRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var channels: [ObjectIdentifier: any Channel] = [:]
+    private var isShuttingDown = false
+
+    func insert(_ channel: any Channel) {
+        lock.lock()
+        if isShuttingDown {
+            lock.unlock()
+            channel.close(promise: nil)
+            return
+        }
+        channels[ObjectIdentifier(channel)] = channel
+        lock.unlock()
+    }
+
+    func remove(_ channel: any Channel) {
+        lock.lock()
+        channels.removeValue(forKey: ObjectIdentifier(channel))
+        lock.unlock()
+    }
+
+    func beginShutdown() -> [any Channel] {
+        lock.lock()
+        isShuttingDown = true
+        let openChannels = Array(channels.values)
+        channels.removeAll()
+        lock.unlock()
+        return openChannels
+    }
+}
+
+final class AFMChildChannelLifecycleHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart
+
+    private let registry: AFMChildChannelRegistry
+
+    init(registry: AFMChildChannelRegistry) {
+        self.registry = registry
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        registry.insert(context.channel)
+        context.fireChannelActive()
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        registry.remove(context.channel)
+        context.fireChannelInactive()
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChildChannelRegistry.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChildChannelRegistry.swift
@@ -28,9 +28,15 @@ final class AFMChildChannelRegistry: @unchecked Sendable {
         lock.lock()
         isShuttingDown = true
         let openChannels = Array(channels.values)
-        channels.removeAll()
         lock.unlock()
         return openChannels
+    }
+
+    func finishShutdown() {
+        lock.lock()
+        precondition(channels.isEmpty, "Cannot finish shutdown with open child channels")
+        isShuttingDown = false
+        lock.unlock()
     }
 }
 

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPHandler.swift
@@ -1,0 +1,215 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
+final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private let router: AFMRequestRouter
+    private let limits: AFMServerLimits
+    private var requestHead: HTTPRequestHead?
+    private var receivedBodyBytes = 0
+    private var responseWasSent = false
+
+    init(router: AFMRequestRouter, limits: AFMServerLimits) {
+        self.router = router
+        self.limits = limits
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case .head(let head):
+            receiveHead(head, context: context)
+        case .body(let buffer):
+            receiveBody(buffer, context: context)
+        case .end:
+            receiveEnd(context: context)
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        guard !responseWasSent else {
+            context.close(promise: nil)
+            return
+        }
+
+        let response: AFMHTTPResponse
+        if case HTTPParserError.headerOverflow = error {
+            response = .apiError(
+                status: .custom(code: 431, reasonPhrase: "Request Header Fields Too Large"),
+                message: "Request headers exceed the server limit.",
+                code: "headers_too_large"
+            )
+        } else if error is HTTPParserError {
+            response = .apiError(
+                status: .badRequest,
+                message: "The HTTP request could not be parsed.",
+                code: "invalid_http_request"
+            )
+        } else {
+            context.close(promise: nil)
+            return
+        }
+
+        responseWasSent = true
+        send(response, version: requestHead?.version ?? .http1_1, close: true, context: context)
+    }
+
+    private func receiveHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
+        guard requestHead == nil, !responseWasSent else {
+            responseWasSent = true
+            send(
+                .apiError(
+                    status: .badRequest,
+                    message: "Only one request may be active on a connection.",
+                    code: "invalid_http_request"
+                ),
+                version: head.version,
+                close: true,
+                context: context
+            )
+            return
+        }
+
+        requestHead = head
+        receivedBodyBytes = 0
+
+        if let contentLength = declaredContentLength(head), contentLength > UInt64(limits.maximumBodyBytes) {
+            responseWasSent = true
+            sendPayloadTooLarge(version: head.version, context: context)
+            return
+        }
+
+        if declaresBody(head), !hasJSONContentType(head) {
+            responseWasSent = true
+            sendUnsupportedMediaType(version: head.version, context: context)
+        }
+    }
+
+    private func receiveBody(_ buffer: ByteBuffer, context: ChannelHandlerContext) {
+        guard let head = requestHead, !responseWasSent else { return }
+
+        if receivedBodyBytes == 0, !declaresBody(head), !hasJSONContentType(head) {
+            responseWasSent = true
+            sendUnsupportedMediaType(version: head.version, context: context)
+            return
+        }
+
+        let (newCount, overflowed) = receivedBodyBytes.addingReportingOverflow(buffer.readableBytes)
+        guard !overflowed, newCount <= limits.maximumBodyBytes else {
+            responseWasSent = true
+            sendPayloadTooLarge(version: head.version, context: context)
+            return
+        }
+        receivedBodyBytes = newCount
+    }
+
+    private func receiveEnd(context: ChannelHandlerContext) {
+        guard let head = requestHead else {
+            if !responseWasSent {
+                responseWasSent = true
+                send(
+                    .apiError(
+                        status: .badRequest,
+                        message: "The HTTP request is missing its request line and headers.",
+                        code: "invalid_http_request"
+                    ),
+                    version: .http1_1,
+                    close: true,
+                    context: context
+                )
+            }
+            return
+        }
+        guard !responseWasSent else { return }
+
+        let response = router.response(for: head)
+        let shouldClose = !head.isKeepAlive
+        send(response, version: head.version, close: shouldClose, context: context)
+        resetRequestState()
+    }
+
+    private func sendPayloadTooLarge(version: HTTPVersion, context: ChannelHandlerContext) {
+        send(
+            .apiError(
+                status: .payloadTooLarge,
+                message: "Request bodies may not exceed \(limits.maximumBodyBytes) bytes.",
+                code: "request_too_large"
+            ),
+            version: version,
+            close: true,
+            context: context
+        )
+    }
+
+    private func sendUnsupportedMediaType(version: HTTPVersion, context: ChannelHandlerContext) {
+        send(
+            .apiError(
+                status: .unsupportedMediaType,
+                message: "Request bodies must use Content-Type: application/json.",
+                code: "unsupported_media_type"
+            ),
+            version: version,
+            close: true,
+            context: context
+        )
+    }
+
+    private func send(
+        _ response: AFMHTTPResponse,
+        version: HTTPVersion,
+        close: Bool,
+        context: ChannelHandlerContext
+    ) {
+        var headers = response.headers
+        headers.replaceOrAdd(name: "content-type", value: "application/json")
+        headers.replaceOrAdd(name: "content-length", value: String(response.body.count))
+        headers.replaceOrAdd(name: "cache-control", value: "no-store")
+        headers.replaceOrAdd(name: "x-content-type-options", value: "nosniff")
+        if close {
+            headers.replaceOrAdd(name: "connection", value: "close")
+        }
+
+        let head = HTTPResponseHead(version: version, status: response.status, headers: headers)
+        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        if !response.body.isEmpty {
+            var buffer = context.channel.allocator.buffer(capacity: response.body.count)
+            buffer.writeBytes(response.body)
+            context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+        }
+
+        let completion = context.writeAndFlush(wrapOutboundOut(.end(nil)))
+        if close {
+            let channel = context.channel
+            completion.whenComplete { _ in
+                channel.close(promise: nil)
+            }
+        }
+    }
+
+    private func resetRequestState() {
+        requestHead = nil
+        receivedBodyBytes = 0
+        responseWasSent = false
+    }
+
+    private func declaredContentLength(_ head: HTTPRequestHead) -> UInt64? {
+        head.headers.first(name: "content-length").flatMap(UInt64.init)
+    }
+
+    private func declaresBody(_ head: HTTPRequestHead) -> Bool {
+        if let contentLength = declaredContentLength(head), contentLength > 0 {
+            return true
+        }
+        return head.headers.contains(name: "transfer-encoding")
+    }
+
+    private func hasJSONContentType(_ head: HTTPRequestHead) -> Bool {
+        guard let contentType = head.headers.first(name: "content-type") else { return false }
+        let mediaType = contentType.split(separator: ";", maxSplits: 1).first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return mediaType == "application/json"
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPResponse.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPResponse.swift
@@ -1,0 +1,76 @@
+import Foundation
+import NIOHTTP1
+
+struct AFMHTTPResponse {
+    let status: HTTPResponseStatus
+    let headers: HTTPHeaders
+    let body: Data
+
+    init(status: HTTPResponseStatus, headers: HTTPHeaders = .init(), body: Data) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+
+    static func json<T: Encodable>(
+        status: HTTPResponseStatus = .ok,
+        headers: HTTPHeaders = .init(),
+        body: T
+    ) -> Self {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(body) else {
+            return internalEncodingFailure()
+        }
+        return .init(status: status, headers: headers, body: data)
+    }
+
+    static func apiError(
+        status: HTTPResponseStatus,
+        message: String,
+        code: String,
+        type: String = "invalid_request_error",
+        headers: HTTPHeaders = .init()
+    ) -> Self {
+        json(
+            status: status,
+            headers: headers,
+            body: AFMErrorEnvelope(
+                error: .init(message: message, type: type, parameter: nil, code: code)
+            )
+        )
+    }
+
+    private static func internalEncodingFailure() -> Self {
+        let body = Data(
+            #"{"error":{"code":"internal_error","message":"The response could not be encoded.","param":null,"type":"server_error"}}"#.utf8
+        )
+        return .init(status: .internalServerError, body: body)
+    }
+}
+
+private struct AFMErrorEnvelope: Encodable {
+    struct Detail: Encodable {
+        let message: String
+        let type: String
+        let parameter: String?
+        let code: String
+
+        enum CodingKeys: String, CodingKey {
+            case message
+            case type
+            case parameter = "param"
+            case code
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(message, forKey: .message)
+            try container.encode(type, forKey: .type)
+            try container.encodeNil(forKey: .parameter)
+            try container.encode(code, forKey: .code)
+        }
+    }
+
+    let error: Detail
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPServer.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPServer.swift
@@ -81,18 +81,19 @@ public actor AFMHTTPServer {
                     self.channel = channel
                     return .unixSocket(path: path)
                 } catch {
-                    try? boundSocket.lease.cleanup()
+                    do {
+                        try AFMUnixSocketManager.cleanupAfterFailedAdoption(boundSocket)
+                    } catch {
+                        socketLease = boundSocket.lease
+                    }
                     throw error
                 }
             }
         } catch {
             self.channel = nil
-            if let socketLease {
-                try? socketLease.cleanup()
-                self.socketLease = nil
-            }
-            try? await group.shutdownGracefully()
-            self.group = nil
+            let socketCleanupError = cleanupSocket()
+            let groupShutdownError = await shutdownEventLoopGroup()
+            hasStarted = socketCleanupError != nil || groupShutdownError != nil
             throw error
         }
     }
@@ -112,13 +113,19 @@ public actor AFMHTTPServer {
         if let firstError = errors.compactMap({ $0 }).first {
             throw firstError
         }
+        childChannels.finishShutdown()
+        hasStarted = false
     }
 
     private func closeListeningChannel() async -> Error? {
-        defer { channel = nil }
-        guard let channel, channel.isActive else { return nil }
+        guard let channel else { return nil }
+        guard channel.isActive else {
+            self.channel = nil
+            return nil
+        }
         do {
             try await channel.close().get()
+            self.channel = nil
             return nil
         } catch {
             return error
@@ -127,9 +134,14 @@ public actor AFMHTTPServer {
 
     private func closeChildChannels() async -> Error? {
         var firstError: Error?
-        for childChannel in childChannels.beginShutdown() where childChannel.isActive {
+        for childChannel in childChannels.beginShutdown() {
+            guard childChannel.isActive else {
+                childChannels.remove(childChannel)
+                continue
+            }
             do {
                 try await childChannel.close().get()
+                childChannels.remove(childChannel)
             } catch {
                 if firstError == nil { firstError = error }
             }
@@ -138,10 +150,10 @@ public actor AFMHTTPServer {
     }
 
     private func cleanupSocket() -> Error? {
-        defer { socketLease = nil }
         guard let socketLease else { return nil }
         do {
             try socketLease.cleanup()
+            self.socketLease = nil
             return nil
         } catch {
             return error
@@ -149,10 +161,10 @@ public actor AFMHTTPServer {
     }
 
     private func shutdownEventLoopGroup() async -> Error? {
-        defer { group = nil }
         guard let group else { return nil }
         do {
             try await group.shutdownGracefully()
+            self.group = nil
             return nil
         } catch {
             return error

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPServer.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPServer.swift
@@ -1,0 +1,187 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+import NIOPosix
+
+public enum AFMServerBoundAddress: Sendable, Equatable, CustomStringConvertible {
+    case tcp(host: String, port: Int)
+    case unixSocket(path: String)
+
+    public var description: String {
+        switch self {
+        case .tcp(let host, let port):
+            let renderedHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+            return "http://\(renderedHost):\(port)"
+        case .unixSocket(let path):
+            return path
+        }
+    }
+}
+
+public enum AFMHTTPServerStateError: Error, LocalizedError {
+    case alreadyStarted
+    case notStarted
+    case missingLocalAddress
+
+    public var errorDescription: String? {
+        switch self {
+        case .alreadyStarted:
+            "The server has already started."
+        case .notStarted:
+            "The server has not started."
+        case .missingLocalAddress:
+            "The server started without a local address."
+        }
+    }
+}
+
+public actor AFMHTTPServer {
+    private let configuration: AFMServerConfiguration
+    private let router: AFMRequestRouter
+    private let childChannels = AFMChildChannelRegistry()
+    private var group: MultiThreadedEventLoopGroup?
+    private var channel: (any Channel)?
+    private var socketLease: AFMUnixSocketLease?
+    private var hasStarted = false
+
+    public init(
+        configuration: AFMServerConfiguration = .init(),
+        catalog: any AFMModelCatalog,
+        clock: any AFMServerClock = AFMSystemServerClock()
+    ) throws {
+        let configuration = try configuration.validated()
+        self.configuration = configuration
+        router = AFMRequestRouter(configuration: configuration, catalog: catalog, clock: clock)
+    }
+
+    public func start() async throws -> AFMServerBoundAddress {
+        guard !hasStarted else { throw AFMHTTPServerStateError.alreadyStarted }
+        hasStarted = true
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.group = group
+        let bootstrap = makeBootstrap(group: group)
+
+        do {
+            switch configuration.endpoint {
+            case .tcp(let host, let port):
+                let channel = try await bootstrap.bind(host: host, port: port).get()
+                guard let boundPort = channel.localAddress?.port else {
+                    try await channel.close().get()
+                    throw AFMHTTPServerStateError.missingLocalAddress
+                }
+                self.channel = channel
+                return .tcp(host: host, port: boundPort)
+            case .unixSocket(let path):
+                try AFMUnixSocketManager.prepare(path: path)
+                let boundSocket = try AFMUnixSocketManager.makeBoundSocket(path: path)
+                do {
+                    let channel = try await bootstrap.withBoundSocket(boundSocket.descriptor).get()
+                    socketLease = boundSocket.lease
+                    self.channel = channel
+                    return .unixSocket(path: path)
+                } catch {
+                    try? boundSocket.lease.cleanup()
+                    throw error
+                }
+            }
+        } catch {
+            self.channel = nil
+            if let socketLease {
+                try? socketLease.cleanup()
+                self.socketLease = nil
+            }
+            try? await group.shutdownGracefully()
+            self.group = nil
+            throw error
+        }
+    }
+
+    public func waitUntilClosed() async throws {
+        guard let channel else { throw AFMHTTPServerStateError.notStarted }
+        try await channel.closeFuture.get()
+    }
+
+    public func stop() async throws {
+        let listeningChannelError = await closeListeningChannel()
+        let childChannelError = await closeChildChannels()
+        let socketCleanupError = cleanupSocket()
+        let groupShutdownError = await shutdownEventLoopGroup()
+
+        let errors = [listeningChannelError, childChannelError, socketCleanupError, groupShutdownError]
+        if let firstError = errors.compactMap({ $0 }).first {
+            throw firstError
+        }
+    }
+
+    private func closeListeningChannel() async -> Error? {
+        defer { channel = nil }
+        guard let channel, channel.isActive else { return nil }
+        do {
+            try await channel.close().get()
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private func closeChildChannels() async -> Error? {
+        var firstError: Error?
+        for childChannel in childChannels.beginShutdown() where childChannel.isActive {
+            do {
+                try await childChannel.close().get()
+            } catch {
+                if firstError == nil { firstError = error }
+            }
+        }
+        return firstError
+    }
+
+    private func cleanupSocket() -> Error? {
+        defer { socketLease = nil }
+        guard let socketLease else { return nil }
+        do {
+            try socketLease.cleanup()
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private func shutdownEventLoopGroup() async -> Error? {
+        defer { group = nil }
+        guard let group else { return nil }
+        do {
+            try await group.shutdownGracefully()
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private func makeBootstrap(group: MultiThreadedEventLoopGroup) -> ServerBootstrap {
+        var decoderLimits = NIOHTTPDecoderLimitConfiguration()
+        decoderLimits.maxHeaderFieldSize = configuration.limits.maximumHeaderFieldBytes
+        decoderLimits.maxHeaderListSize = configuration.limits.maximumHeaderBytes
+        decoderLimits.maxHeaderFieldCount = configuration.limits.maximumHeaderCount
+        let configuredDecoderLimits = decoderLimits
+
+        let router = router
+        let limits = configuration.limits
+        let childChannels = childChannels
+        return ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline(
+                    withPipeliningAssistance: true,
+                    withErrorHandling: false,
+                    withDecoderLimitConfiguration: configuredDecoderLimits
+                ).flatMap {
+                    channel.pipeline.addHandlers(
+                        AFMChildChannelLifecycleHandler(registry: childChannels),
+                        AFMHTTPHandler(router: router, limits: limits)
+                    )
+                }
+            }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHostPolicy.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHostPolicy.swift
@@ -1,0 +1,59 @@
+import Foundation
+import NIOHTTP1
+
+enum AFMHostPolicy {
+    static func isLoopbackBinding(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        if normalized == "localhost" || normalized == "::1" || normalized == "[::1]" {
+            return true
+        }
+
+        let components = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 4,
+              components[0] == "127",
+              components.dropFirst().allSatisfy({ UInt8($0) != nil }) else {
+            return false
+        }
+        return true
+    }
+
+    static func validatesLoopbackHostHeader(_ headers: HTTPHeaders, bindingHost: String) -> Bool {
+        let values = headers["host"]
+        guard values.count == 1, let host = normalizedHost(from: values[0]) else {
+            return false
+        }
+
+        let allowed = [bindingHost, "localhost", "127.0.0.1", "::1"]
+            .map { normalizedHost(from: $0) }
+        return allowed.contains(host)
+    }
+
+    private static func normalizedHost(from value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.hasPrefix("[") {
+            guard let closingBracket = trimmed.firstIndex(of: "]") else { return nil }
+            let addressStart = trimmed.index(after: trimmed.startIndex)
+            let address = String(trimmed[addressStart..<closingBracket])
+            let suffix = trimmed[trimmed.index(after: closingBracket)...]
+            guard suffix.isEmpty || (suffix.first == ":" && UInt16(suffix.dropFirst()) != nil) else {
+                return nil
+            }
+            return address
+        }
+
+        let colonCount = trimmed.reduce(into: 0) { count, character in
+            if character == ":" { count += 1 }
+        }
+        if colonCount == 1, let separator = trimmed.lastIndex(of: ":") {
+            let hostname = String(trimmed[..<separator])
+            guard !hostname.isEmpty, UInt16(trimmed[trimmed.index(after: separator)...]) != nil else {
+                return nil
+            }
+            return hostname
+        }
+
+        return trimmed
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMModelCatalog.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMModelCatalog.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct AFMServerModel: Sendable, Equatable {
+    public let id: String
+    public let isAvailable: Bool
+    public let owner: String
+
+    public init(id: String, isAvailable: Bool, owner: String = "Apple") {
+        self.id = id
+        self.isAvailable = isAvailable
+        self.owner = owner
+    }
+}
+
+public protocol AFMModelCatalog: Sendable {
+    func models() -> [AFMServerModel]
+}
+
+public struct AFMStaticModelCatalog: AFMModelCatalog {
+    private let entries: [AFMServerModel]
+
+    public init(models: [AFMServerModel]) {
+        entries = models
+    }
+
+    public func models() -> [AFMServerModel] {
+        entries
+    }
+}
+
+public protocol AFMServerClock: Sendable {
+    func unixTime() -> Int64
+}
+
+public struct AFMSystemServerClock: AFMServerClock {
+    public init() {}
+
+    public func unixTime() -> Int64 {
+        Int64(Date().timeIntervalSince1970)
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMRequestRouter.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMRequestRouter.swift
@@ -1,0 +1,173 @@
+import Foundation
+import NIOHTTP1
+
+struct AFMRequestRouter: Sendable {
+    private let configuration: AFMServerConfiguration
+    private let catalog: any AFMModelCatalog
+    private let clock: any AFMServerClock
+
+    init(
+        configuration: AFMServerConfiguration,
+        catalog: any AFMModelCatalog,
+        clock: any AFMServerClock
+    ) {
+        self.configuration = configuration
+        self.catalog = catalog
+        self.clock = clock
+    }
+
+    func response(for request: HTTPRequestHead) -> AFMHTTPResponse {
+        if case .tcp(let host, _) = configuration.endpoint,
+           AFMHostPolicy.isLoopbackBinding(host),
+           !AFMHostPolicy.validatesLoopbackHostHeader(request.headers, bindingHost: host) {
+            return .apiError(
+                status: .forbidden,
+                message: "The Host header is not allowed for this loopback server.",
+                code: "forbidden_host"
+            )
+        }
+
+        let originResult = validateOrigin(request.headers)
+        guard originResult.isAllowed else {
+            return .apiError(
+                status: .forbidden,
+                message: "Cross-site requests are not allowed.",
+                code: "origin_not_allowed"
+            )
+        }
+
+        guard validatesAuthorization(request.headers) else {
+            var headers = HTTPHeaders()
+            headers.add(name: "www-authenticate", value: "Bearer")
+            return AFMHTTPResponse.apiError(
+                status: .unauthorized,
+                message: "A valid bearer token is required.",
+                code: "invalid_api_key",
+                type: "authentication_error",
+                headers: headers
+            ).addingOrigin(originResult.origin)
+        }
+
+        let path = request.uri.split(separator: "?", maxSplits: 1).first.map(String.init) ?? request.uri
+        let response: AFMHTTPResponse
+        switch path {
+        case "/health":
+            response = responseForKnownRoute(request, body: healthResponse)
+        case "/v1/models":
+            response = responseForKnownRoute(request, body: modelsResponse)
+        default:
+            response = .apiError(
+                status: .notFound,
+                message: "The requested endpoint was not found.",
+                code: "not_found"
+            )
+        }
+        return response.addingOrigin(originResult.origin)
+    }
+
+    private func responseForKnownRoute<T: Encodable>(
+        _ request: HTTPRequestHead,
+        body: () -> T
+    ) -> AFMHTTPResponse {
+        guard request.method == .GET else {
+            var headers = HTTPHeaders()
+            headers.add(name: "allow", value: "GET")
+            return .apiError(
+                status: .methodNotAllowed,
+                message: "This endpoint only accepts GET requests.",
+                code: "method_not_allowed",
+                headers: headers
+            )
+        }
+        return .json(body: body())
+    }
+
+    private func healthResponse() -> AFMHealthPayload {
+        let models = catalog.models().sorted { $0.id < $1.id }
+        return AFMHealthPayload(
+            status: "afm serve is running",
+            models: models.map { .init(name: $0.id, available: $0.isAvailable) }
+        )
+    }
+
+    private func modelsResponse() -> AFMModelsPayload {
+        let created = clock.unixTime()
+        let models = catalog.models().sorted { $0.id < $1.id }
+        return AFMModelsPayload(
+            object: "list",
+            data: models.map {
+                .init(id: $0.id, object: "model", created: created, owner: $0.owner)
+            }
+        )
+    }
+
+    private func validateOrigin(_ headers: HTTPHeaders) -> (isAllowed: Bool, origin: String?) {
+        let origins = headers["origin"]
+        guard !origins.isEmpty else { return (true, nil) }
+        guard origins.count == 1, configuration.security.allowedOrigins.contains(origins[0]) else {
+            return (false, nil)
+        }
+        return (true, origins[0])
+    }
+
+    private func validatesAuthorization(_ headers: HTTPHeaders) -> Bool {
+        guard let expectedToken = configuration.security.bearerToken else { return true }
+        let values = headers["authorization"]
+        guard values.count == 1 else { return false }
+
+        let parts = values[0].split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2, parts[0].lowercased() == "bearer" else { return false }
+        return constantTimeEquals(String(parts[1]), expectedToken)
+    }
+
+    private func constantTimeEquals(_ provided: String, _ expected: String) -> Bool {
+        let lhs = Array(provided.utf8)
+        let rhs = Array(expected.utf8)
+        var difference = UInt(lhs.count ^ rhs.count)
+        for index in 0..<max(lhs.count, rhs.count) {
+            let lhsByte = index < lhs.count ? lhs[index] : 0
+            let rhsByte = index < rhs.count ? rhs[index] : 0
+            difference |= UInt(lhsByte ^ rhsByte)
+        }
+        return difference == 0
+    }
+}
+
+private extension AFMHTTPResponse {
+    func addingOrigin(_ origin: String?) -> Self {
+        guard let origin else { return self }
+        var updatedHeaders = headers
+        updatedHeaders.add(name: "access-control-allow-origin", value: origin)
+        updatedHeaders.add(name: "vary", value: "Origin")
+        return .init(status: status, headers: updatedHeaders, body: body)
+    }
+}
+
+private struct AFMHealthPayload: Encodable {
+    struct Model: Encodable {
+        let name: String
+        let available: Bool
+    }
+
+    let status: String
+    let models: [Model]
+}
+
+private struct AFMModelsPayload: Encodable {
+    struct Model: Encodable {
+        let id: String
+        let object: String
+        let created: Int64
+        let owner: String
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case object
+            case created
+            case owner = "owned_by"
+        }
+    }
+
+    let object: String
+    let data: [Model]
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMServerConfiguration.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMServerConfiguration.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+public enum AFMServerEndpoint: Sendable, Equatable {
+    case tcp(host: String, port: Int)
+    case unixSocket(path: String)
+}
+
+public struct AFMServerLimits: Sendable, Equatable {
+    public var maximumBodyBytes: Int
+    public var maximumHeaderBytes: Int
+    public var maximumHeaderFieldBytes: Int
+    public var maximumHeaderCount: Int
+
+    public init(
+        maximumBodyBytes: Int = 1_048_576,
+        maximumHeaderBytes: Int = 65_536,
+        maximumHeaderFieldBytes: Int = 16_384,
+        maximumHeaderCount: Int = 100
+    ) {
+        self.maximumBodyBytes = maximumBodyBytes
+        self.maximumHeaderBytes = maximumHeaderBytes
+        self.maximumHeaderFieldBytes = maximumHeaderFieldBytes
+        self.maximumHeaderCount = maximumHeaderCount
+    }
+}
+
+public struct AFMServerSecurity: Sendable, Equatable {
+    public var allowNetwork: Bool
+    public var bearerToken: String?
+    public var allowedOrigins: Set<String>
+
+    public init(
+        allowNetwork: Bool = false,
+        bearerToken: String? = nil,
+        allowedOrigins: Set<String> = []
+    ) {
+        self.allowNetwork = allowNetwork
+        self.bearerToken = bearerToken
+        self.allowedOrigins = allowedOrigins
+    }
+}
+
+public struct AFMServerConfiguration: Sendable, Equatable {
+    public var endpoint: AFMServerEndpoint
+    public var limits: AFMServerLimits
+    public var security: AFMServerSecurity
+
+    public init(
+        endpoint: AFMServerEndpoint = .tcp(host: "127.0.0.1", port: 1976),
+        limits: AFMServerLimits = .init(),
+        security: AFMServerSecurity = .init()
+    ) {
+        self.endpoint = endpoint
+        self.limits = limits
+        self.security = security
+    }
+
+    public func validated() throws -> Self {
+        try validateLimits()
+        try validateSecurity()
+
+        var validatedConfiguration = self
+        validatedConfiguration.endpoint = try validatedEndpoint()
+        return validatedConfiguration
+    }
+
+    private func validateLimits() throws {
+        guard limits.maximumBodyBytes > 0,
+              limits.maximumHeaderBytes > 0,
+              limits.maximumHeaderFieldBytes > 0,
+              limits.maximumHeaderFieldBytes <= limits.maximumHeaderBytes,
+              limits.maximumHeaderCount > 0 else {
+            throw AFMServerConfigurationError.invalidLimits
+        }
+    }
+
+    private func validateSecurity() throws {
+        if let bearerToken = security.bearerToken, bearerToken.isEmpty {
+            throw AFMServerConfigurationError.emptyBearerToken
+        }
+        if security.allowedOrigins.contains(where: { !Self.isValidOrigin($0) }) {
+            throw AFMServerConfigurationError.invalidAllowedOrigin
+        }
+    }
+
+    private func validatedEndpoint() throws -> AFMServerEndpoint {
+        switch endpoint {
+        case .tcp(let host, let port):
+            return try validatedTCPEndpoint(host: host, port: port)
+        case .unixSocket(let path):
+            guard path.hasPrefix("/"), path.count > 1, !path.utf8.contains(0) else {
+                throw AFMServerConfigurationError.invalidSocketPath
+            }
+            return .unixSocket(path: path)
+        }
+    }
+
+    private func validatedTCPEndpoint(host: String, port: Int) throws -> AFMServerEndpoint {
+        let normalizedHost = Self.normalizedBindingHost(host)
+        guard !normalizedHost.isEmpty else {
+            throw AFMServerConfigurationError.emptyHost
+        }
+        guard (0...65_535).contains(port) else {
+            throw AFMServerConfigurationError.invalidPort(port)
+        }
+        if !AFMHostPolicy.isLoopbackBinding(normalizedHost) {
+            try validateNetworkSecurity(host: normalizedHost)
+        }
+        return .tcp(host: normalizedHost, port: port)
+    }
+
+    private func validateNetworkSecurity(host: String) throws {
+        guard security.allowNetwork else {
+            throw AFMServerConfigurationError.networkOptInRequired(host)
+        }
+        guard security.bearerToken != nil else {
+            throw AFMServerConfigurationError.networkAuthenticationRequired(host)
+        }
+    }
+
+    private static func isValidOrigin(_ origin: String) -> Bool {
+        guard origin == origin.trimmingCharacters(in: .whitespacesAndNewlines),
+              let components = URLComponents(string: origin),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host != nil,
+              components.user == nil,
+              components.password == nil,
+              components.path.isEmpty,
+              components.query == nil,
+              components.fragment == nil else {
+            return false
+        }
+        return true
+    }
+
+    private static func normalizedBindingHost(_ host: String) -> String {
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedHost.hasPrefix("["), trimmedHost.hasSuffix("]") else { return trimmedHost }
+        return String(trimmedHost.dropFirst().dropLast())
+    }
+}
+
+public enum AFMServerConfigurationError: Error, Equatable, LocalizedError {
+    case emptyHost
+    case invalidPort(Int)
+    case invalidLimits
+    case emptyBearerToken
+    case invalidAllowedOrigin
+    case invalidSocketPath
+    case networkOptInRequired(String)
+    case networkAuthenticationRequired(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyHost:
+            "The server host cannot be empty."
+        case .invalidPort(let port):
+            "Port \(port) is outside the valid range 0...65535."
+        case .invalidLimits:
+            "Server limits must be positive and internally consistent."
+        case .emptyBearerToken:
+            "The bearer token cannot be empty."
+        case .invalidAllowedOrigin:
+            "Allowed origins must be exact, non-empty origins; wildcards are not accepted."
+        case .invalidSocketPath:
+            "The Unix-domain socket path must be an absolute path."
+        case .networkOptInRequired(let host):
+            "Binding to non-loopback host '\(host)' requires explicit network opt-in."
+        case .networkAuthenticationRequired(let host):
+            "Binding to non-loopback host '\(host)' requires a bearer token."
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMUnixSocket.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMUnixSocket.swift
@@ -1,0 +1,259 @@
+import Darwin
+import Foundation
+
+enum AFMUnixSocketManager {
+    static func prepare(path: String) throws {
+        try validateParentDirectory(of: path)
+        guard path.utf8CString.count <= MemoryLayout<sockaddr_un>.size - MemoryLayout<sa_family_t>.size else {
+            throw AFMUnixSocketError.pathTooLong
+        }
+        guard let status = try fileStatus(at: path) else { return }
+        guard isSocket(status) else {
+            throw AFMUnixSocketError.pathExists(kind: fileKind(status))
+        }
+        guard status.st_uid == geteuid() else {
+            throw AFMUnixSocketError.socketOwnedByAnotherUser
+        }
+
+        switch try socketActivity(at: path) {
+        case .active:
+            throw AFMUnixSocketError.socketInUse
+        case .missing:
+            return
+        case .stale:
+            guard let currentStatus = try fileStatus(at: path),
+                  sameFile(status, currentStatus),
+                  isSocket(currentStatus),
+                  currentStatus.st_uid == geteuid() else {
+                throw AFMUnixSocketError.pathChanged
+            }
+            guard Darwin.unlink(path) == 0 else {
+                throw posixError(operation: "remove stale socket")
+            }
+        }
+    }
+
+    static func secureBoundSocket(path: String) throws -> AFMUnixSocketLease {
+        guard let status = try fileStatus(at: path), isSocket(status) else {
+            throw AFMUnixSocketError.boundPathIsNotSocket
+        }
+        guard status.st_uid == geteuid() else {
+            throw AFMUnixSocketError.socketOwnedByAnotherUser
+        }
+
+        let lease = AFMUnixSocketLease(path: path, device: status.st_dev, inode: status.st_ino)
+        guard Darwin.chmod(path, S_IRUSR | S_IWUSR) == 0 else {
+            try? lease.cleanup()
+            throw posixError(operation: "set socket permissions")
+        }
+        guard let securedStatus = try fileStatus(at: path),
+              sameFile(status, securedStatus),
+              isSocket(securedStatus) else {
+            throw AFMUnixSocketError.pathChanged
+        }
+        return lease
+    }
+
+    static func makeBoundSocket(path: String, backlog: Int32 = 256) throws -> AFMBoundUnixSocket {
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw posixError(operation: "create Unix socket") }
+        var transfersOwnership = false
+        defer {
+            if !transfersOwnership {
+                Darwin.close(descriptor)
+            }
+        }
+
+        guard Darwin.fcntl(descriptor, F_SETFD, FD_CLOEXEC) == 0 else {
+            throw posixError(operation: "configure Unix socket")
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = path.utf8CString
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            bytes.withUnsafeBytes { source in
+                destination.copyBytes(from: source)
+            }
+        }
+        let addressLength = socklen_t(MemoryLayout<sa_family_t>.size + bytes.count)
+        address.sun_len = UInt8(addressLength)
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(descriptor, $0, addressLength)
+            }
+        }
+        guard bindResult == 0 else { throw posixError(operation: "bind Unix socket") }
+
+        let lease = try secureBoundSocket(path: path)
+        do {
+            guard Darwin.listen(descriptor, backlog) == 0 else {
+                throw posixError(operation: "listen on Unix socket")
+            }
+        } catch {
+            try? lease.cleanup()
+            throw error
+        }
+
+        transfersOwnership = true
+        return AFMBoundUnixSocket(descriptor: descriptor, lease: lease)
+    }
+
+    private static func validateParentDirectory(of path: String) throws {
+        let parentPath = (path as NSString).deletingLastPathComponent
+        var status = stat()
+        let result = parentPath.withCString { pointer in
+            stat(pointer, &status)
+        }
+        guard result == 0, (status.st_mode & S_IFMT) == S_IFDIR else {
+            throw AFMUnixSocketError.invalidParentDirectory
+        }
+
+        let isSticky = (status.st_mode & S_ISVTX) != 0
+        let isWritableByOthers = (status.st_mode & (S_IWGRP | S_IWOTH)) != 0
+        guard !isWritableByOthers || isSticky else {
+            throw AFMUnixSocketError.insecureParentDirectory
+        }
+        guard Darwin.access(parentPath, W_OK | X_OK) == 0 else {
+            throw AFMUnixSocketError.parentDirectoryNotWritable
+        }
+    }
+
+    private static func fileStatus(at path: String) throws -> stat? {
+        var status = stat()
+        if Darwin.lstat(path, &status) == 0 {
+            return status
+        }
+        if errno == ENOENT {
+            return nil
+        }
+        throw posixError(operation: "inspect socket path")
+    }
+
+    private static func socketActivity(at path: String) throws -> AFMSocketActivity {
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw posixError(operation: "create socket probe") }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = path.utf8CString
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            bytes.withUnsafeBytes { source in
+                destination.copyBytes(from: source)
+            }
+        }
+        let addressLength = socklen_t(MemoryLayout<sa_family_t>.size + bytes.count)
+        address.sun_len = UInt8(addressLength)
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, addressLength)
+            }
+        }
+        if result == 0 {
+            return .active
+        }
+
+        switch errno {
+        case ENOENT:
+            return .missing
+        case ECONNREFUSED:
+            return .stale
+        default:
+            throw posixError(operation: "probe existing socket")
+        }
+    }
+
+    private static func isSocket(_ status: stat) -> Bool {
+        (status.st_mode & S_IFMT) == S_IFSOCK
+    }
+
+    private static func sameFile(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev && lhs.st_ino == rhs.st_ino
+    }
+
+    private static func fileKind(_ status: stat) -> String {
+        switch status.st_mode & S_IFMT {
+        case S_IFLNK: "symbolic link"
+        case S_IFDIR: "directory"
+        case S_IFREG: "regular file"
+        default: "non-socket file"
+        }
+    }
+
+    private static func posixError(operation: String) -> AFMUnixSocketError {
+        .posix(operation: operation, code: errno)
+    }
+}
+
+struct AFMUnixSocketLease: Sendable {
+    let path: String
+    let device: dev_t
+    let inode: ino_t
+
+    func cleanup() throws {
+        var status = stat()
+        if Darwin.lstat(path, &status) != 0 {
+            if errno == ENOENT { return }
+            throw AFMUnixSocketError.posix(operation: "inspect socket during cleanup", code: errno)
+        }
+        guard status.st_dev == device,
+              status.st_ino == inode,
+              (status.st_mode & S_IFMT) == S_IFSOCK,
+              status.st_uid == geteuid() else {
+            return
+        }
+        guard Darwin.unlink(path) == 0 else {
+            throw AFMUnixSocketError.posix(operation: "remove socket", code: errno)
+        }
+    }
+}
+
+struct AFMBoundUnixSocket: Sendable {
+    let descriptor: CInt
+    let lease: AFMUnixSocketLease
+}
+
+private enum AFMSocketActivity {
+    case active
+    case stale
+    case missing
+}
+
+enum AFMUnixSocketError: Error, Equatable, LocalizedError {
+    case invalidParentDirectory
+    case insecureParentDirectory
+    case parentDirectoryNotWritable
+    case pathTooLong
+    case pathExists(kind: String)
+    case socketOwnedByAnotherUser
+    case socketInUse
+    case pathChanged
+    case boundPathIsNotSocket
+    case posix(operation: String, code: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidParentDirectory:
+            "The Unix-domain socket parent must be an existing directory."
+        case .insecureParentDirectory:
+            "The Unix-domain socket parent is writable by other users and does not use the sticky bit."
+        case .parentDirectoryNotWritable:
+            "The Unix-domain socket parent is not writable."
+        case .pathTooLong:
+            "The Unix-domain socket path is too long."
+        case .pathExists(let kind):
+            "Refusing to replace the \(kind) at the Unix-domain socket path."
+        case .socketOwnedByAnotherUser:
+            "Refusing to replace a Unix-domain socket owned by another user."
+        case .socketInUse:
+            "Another server is already listening on the Unix-domain socket."
+        case .pathChanged:
+            "The Unix-domain socket path changed during a safety check."
+        case .boundPathIsNotSocket:
+            "The bound Unix-domain socket path is not a socket."
+        case .posix(let operation, let code):
+            "Could not \(operation): \(String(cString: strerror(code)))."
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMUnixSocket.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMUnixSocket.swift
@@ -99,6 +99,20 @@ enum AFMUnixSocketManager {
         return AFMBoundUnixSocket(descriptor: descriptor, lease: lease)
     }
 
+    static func cleanupAfterFailedAdoption(_ socket: AFMBoundUnixSocket) throws {
+        let closeResult = Darwin.close(socket.descriptor)
+        let closeError = errno
+
+        try socket.lease.cleanup()
+
+        guard closeResult == 0 || closeError == EBADF else {
+            throw AFMUnixSocketError.posix(
+                operation: "close unadopted Unix socket",
+                code: closeError
+            )
+        }
+    }
+
     private static func validateParentDirectory(of path: String) throws {
         let parentPath = (path as NSString).deletingLastPathComponent
         var status = stat()

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIServeTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIServeTests.swift
@@ -1,0 +1,139 @@
+import Darwin
+import Foundation
+import Testing
+
+@Test("Serve command is discoverable and documents its security controls")
+func serveHelp() throws {
+    let root = try runAFM("--help")
+    let serve = try runAFM("serve", "--help")
+
+    #expect(root.status == 0)
+    #expect(root.stdout.contains("SERVER COMMANDS"))
+    #expect(root.stdout.contains("afm serve"))
+    #expect(serve.status == 0)
+    for flag in ["--host", "--port", "--socket", "--allow-network", "--token", "--allow-origin"] {
+        #expect(serve.stdout.contains(flag))
+    }
+}
+
+@Test("Serve dry-run resolves defaults without exposing bearer tokens")
+func serveDryRun() throws {
+    let result = try runAFM("serve", "--output", "json", "--dry-run", "--token", "do-not-print-me")
+
+    #expect(result.status == 0)
+    #expect(!result.stdout.contains("do-not-print-me"))
+    let json = try parseJSONObject(result.stdout)
+    #expect(json["status"] as? String == "dry_run")
+    #expect(json["command"] as? String == "serve")
+    #expect(json["endpoint"] as? String == "http://127.0.0.1:1976")
+    #expect(json["authenticationEnabled"] as? Bool == true)
+}
+
+@Test("Serve rejects unsafe binding combinations before listening")
+func serveConfigurationValidation() throws {
+    let implicitNetwork = try runAFM(
+        ["serve", "--dry-run", "--host", "0.0.0.0"],
+        environment: ["AFM_SERVER_TOKEN": ""]
+    )
+    #expect(implicitNetwork.status == 64)
+    #expect(implicitNetwork.stderr.contains("requires explicit network opt-in"))
+
+    let unauthenticatedNetwork = try runAFM(
+        ["serve", "--dry-run", "--host", "0.0.0.0", "--allow-network"],
+        environment: ["AFM_SERVER_TOKEN": ""]
+    )
+    #expect(unauthenticatedNetwork.status == 64)
+    #expect(unauthenticatedNetwork.stderr.contains("requires a bearer token"))
+
+    let mixedTransports = try runAFM(
+        "serve", "--dry-run", "--socket", "/tmp/afm.sock", "--host", "127.0.0.1"
+    )
+    #expect(mixedTransports.status == 64)
+    #expect(mixedTransports.stderr.contains("--socket cannot be combined"))
+
+    let wildcardOrigin = try runAFM("serve", "--dry-run", "--allow-origin", "*")
+    #expect(wildcardOrigin.status == 64)
+    #expect(wildcardOrigin.stderr.contains("exact, non-empty origins"))
+}
+
+@Test("SIGTERM gracefully removes a CLI Unix-domain socket")
+func serveGracefulShutdown() throws {
+    let path = "/tmp/afm-cli-\(UUID().uuidString.prefix(8)).sock"
+    let process = Process()
+    process.executableURL = try findAFMBinary()
+    process.currentDirectoryURL = packageRoot()
+    let secret = "never-print-this-token"
+    process.arguments = ["serve", "--socket", path, "--output", "json", "--token", secret]
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    process.standardInput = FileHandle.nullDevice
+    defer {
+        if process.isRunning {
+            Darwin.kill(process.processIdentifier, SIGKILL)
+        }
+        Darwin.unlink(path)
+    }
+
+    try process.run()
+    waitForSocket(path: path, process: process)
+    #expect(FileManager.default.fileExists(atPath: path))
+    guard process.isRunning else {
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        Issue.record("afm serve exited before startup: \(stderr)")
+        return
+    }
+
+    let startupOutput = readStartupOutput(from: stdoutPipe)
+
+    #expect(Darwin.kill(process.processIdentifier, SIGTERM) == 0)
+    waitForShutdown(process)
+
+    var completeOutput = startupOutput
+    completeOutput.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
+    let stdout = String(data: completeOutput, encoding: .utf8) ?? ""
+    let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    #expect(process.terminationStatus == 0)
+    let json = try parseJSONObject(stdout)
+    #expect(json["status"] as? String == "started")
+    #expect(json["command"] as? String == "serve")
+    #expect(json["endpoint"] as? String == "unix://\(path)")
+    #expect(json["transport"] as? String == "unix")
+    #expect(json["authenticationEnabled"] as? Bool == true)
+    #expect(!stdout.contains(secret))
+    #expect(!stderr.contains(secret))
+    #expect(!FileManager.default.fileExists(atPath: path))
+}
+
+private func waitForSocket(path: String, process: Process) {
+    let deadline = Date().addingTimeInterval(5)
+    while !FileManager.default.fileExists(atPath: path),
+          process.isRunning,
+          Date() < deadline {
+        usleep(20_000)
+    }
+}
+
+private func readStartupOutput(from pipe: Pipe) -> Data {
+    var descriptor = pollfd(
+        fd: pipe.fileHandleForReading.fileDescriptor,
+        events: Int16(POLLIN),
+        revents: 0
+    )
+    #expect(Darwin.poll(&descriptor, 1, 2_000) == 1)
+    return pipe.fileHandleForReading.availableData
+}
+
+private func waitForShutdown(_ process: Process) {
+    let deadline = Date().addingTimeInterval(5)
+    while process.isRunning, Date() < deadline {
+        usleep(20_000)
+    }
+    if process.isRunning {
+        Issue.record("afm serve did not stop after SIGTERM")
+        Darwin.kill(process.processIdentifier, SIGKILL)
+    }
+    process.waitUntilExit()
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITestSupport.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITestSupport.swift
@@ -90,7 +90,7 @@ private func decodedOutput(_ data: Data) -> String {
         .trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
-private func findAFMBinary() throws -> URL {
+func findAFMBinary() throws -> URL {
     let root = packageRoot()
     let directCandidates = [
         root.appending(path: ".build/debug/afm"),
@@ -114,7 +114,7 @@ private func findAFMBinary() throws -> URL {
     throw TestFailure("Could not find built afm executable under \(buildRoot.path())")
 }
 
-private func packageRoot() -> URL {
+func packageRoot() -> URL {
     var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
     while directory.path != "/" {

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -47,7 +47,8 @@ func leafCommandHelpCoverage() throws {
         ["tool", "validate", "--help"],
         ["tool", "call", "--help"],
         ["transcript", "export", "--help"],
-        ["feedback", "export", "--help"]
+        ["feedback", "export", "--help"],
+        ["serve", "--help"]
     ]
 
     for command in commands {

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPHandlerTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPHandlerTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import Testing
+@testable import AFMServer
+
+@Test("Health and model discovery use the injected catalog and clock")
+func healthAndModels() throws {
+    let catalog = AFMStaticModelCatalog(
+        models: [
+            .init(id: "system", isAvailable: true),
+            .init(id: "adapter-demo", isAvailable: false, owner: "local")
+        ]
+    )
+    let router = AFMRequestRouter(
+        configuration: .init(),
+        catalog: catalog,
+        clock: TestClock(value: 1_234)
+    )
+
+    let health = try performRequest(path: "/health", router: router)
+    #expect(health.head.status == .ok)
+    let healthJSON = try jsonObject(health.body)
+    #expect(healthJSON["status"] as? String == "afm serve is running")
+    let healthModels = try #require(healthJSON["models"] as? [[String: Any]])
+    #expect(healthModels.map { $0["name"] as? String } == ["adapter-demo", "system"])
+    #expect(healthModels[0]["available"] as? Bool == false)
+
+    let models = try performRequest(path: "/v1/models?ignored=true", router: router)
+    #expect(models.head.status == .ok)
+    let modelsJSON = try jsonObject(models.body)
+    let modelData = try #require(modelsJSON["data"] as? [[String: Any]])
+    #expect(modelData.map { $0["id"] as? String } == ["adapter-demo", "system"])
+    #expect(modelData.allSatisfy { $0["created"] as? Int == 1_234 })
+    #expect(modelData[0]["owned_by"] as? String == "local")
+}
+
+@Test("Unknown routes and wrong methods return JSON API errors")
+func routingErrors() throws {
+    let router = testRouter()
+
+    let missing = try performRequest(path: "/missing", router: router)
+    #expect(missing.head.status == .notFound)
+    #expect(try errorCode(missing.body) == "not_found")
+
+    let wrongMethod = try performRequest(method: .POST, path: "/health", router: router)
+    #expect(wrongMethod.head.status == .methodNotAllowed)
+    #expect(wrongMethod.head.headers.first(name: "allow") == "GET")
+    #expect(try errorCode(wrongMethod.body) == "method_not_allowed")
+}
+
+@Test("Loopback Host and Origin policies reject cross-site requests by default")
+func hostAndOriginPolicy() throws {
+    let router = testRouter()
+
+    let hostileHost = try performRequest(path: "/health", host: "example.com", router: router)
+    #expect(hostileHost.head.status == .forbidden)
+    #expect(try errorCode(hostileHost.body) == "forbidden_host")
+
+    let hostileOrigin = try performRequest(
+        path: "/health",
+        additionalHeaders: [("origin", "https://example.com")],
+        router: router
+    )
+    #expect(hostileOrigin.head.status == .forbidden)
+    #expect(try errorCode(hostileOrigin.body) == "origin_not_allowed")
+
+    let allowedRouter = testRouter(allowedOrigins: ["https://trusted.example"])
+    let allowed = try performRequest(
+        path: "/health",
+        additionalHeaders: [("origin", "https://trusted.example")],
+        router: allowedRouter
+    )
+    #expect(allowed.head.status == .ok)
+    #expect(allowed.head.headers.first(name: "access-control-allow-origin") == "https://trusted.example")
+    #expect(allowed.head.headers.first(name: "vary") == "Origin")
+}
+
+@Test("Bearer authentication protects every route when configured")
+func bearerAuthentication() throws {
+    let router = testRouter(token: "correct-token", allowedOrigins: ["https://trusted.example"])
+
+    let missing = try performRequest(
+        path: "/health",
+        additionalHeaders: [("origin", "https://trusted.example")],
+        router: router
+    )
+    #expect(missing.head.status == .unauthorized)
+    #expect(missing.head.headers.first(name: "www-authenticate") == "Bearer")
+    #expect(missing.head.headers.first(name: "access-control-allow-origin") == "https://trusted.example")
+    #expect(missing.head.headers.first(name: "vary") == "Origin")
+
+    let incorrect = try performRequest(
+        path: "/health",
+        additionalHeaders: [("authorization", "Bearer incorrect-token")],
+        router: router
+    )
+    #expect(incorrect.head.status == .unauthorized)
+
+    let valid = try performRequest(
+        path: "/health",
+        additionalHeaders: [("authorization", "bearer correct-token")],
+        router: router
+    )
+    #expect(valid.head.status == .ok)
+}
+
+@Test("Body and media-type limits produce deterministic JSON errors")
+func bodyAndMediaTypeLimits() throws {
+    let limits = AFMServerLimits(maximumBodyBytes: 4)
+    let router = testRouter(limits: limits)
+
+    let exactLimit = try performRequest(
+        path: "/health",
+        body: Data("1234".utf8),
+        contentType: "application/json; charset=utf-8",
+        router: router,
+        limits: limits
+    )
+    #expect(exactLimit.head.status == .ok)
+
+    let tooLarge = try performRequest(
+        path: "/health",
+        body: Data("12345".utf8),
+        contentType: "application/json",
+        router: router,
+        limits: limits
+    )
+    #expect(tooLarge.head.status == .payloadTooLarge)
+    #expect(try errorCode(tooLarge.body) == "request_too_large")
+
+    let enormousDeclaration = try performRequest(
+        path: "/health",
+        additionalHeaders: [
+            ("content-length", String(UInt64.max)),
+            ("content-type", "application/json")
+        ],
+        router: router,
+        limits: limits
+    )
+    #expect(enormousDeclaration.head.status == .payloadTooLarge)
+
+    let unsupported = try performRequest(
+        path: "/health",
+        body: Data("1".utf8),
+        contentType: "text/plain",
+        router: router,
+        limits: limits
+    )
+    #expect(unsupported.head.status == .unsupportedMediaType)
+    #expect(try errorCode(unsupported.body) == "unsupported_media_type")
+}
+
+@Test("Header overflow becomes a JSON 431 response")
+func headerOverflow() throws {
+    let channel = EmbeddedChannel(handler: AFMHTTPHandler(router: testRouter(), limits: .init()))
+    channel.pipeline.fireErrorCaught(HTTPParserError.headerOverflow)
+
+    let response = try readResponse(from: channel)
+    #expect(response.head.status.code == 431)
+    #expect(response.head.status.reasonPhrase == "Request Header Fields Too Large")
+    #expect(try errorCode(response.body) == "headers_too_large")
+    _ = try? channel.finish()
+}
+
+@Test("Keep-alive connections reset request state between requests")
+func keepAliveRequests() throws {
+    let channel = EmbeddedChannel(handler: AFMHTTPHandler(router: testRouter(), limits: .init()))
+    try writeRequest(path: "/health", to: channel)
+    let first = try readResponse(from: channel)
+    try writeRequest(path: "/v1/models", to: channel)
+    let second = try readResponse(from: channel)
+
+    #expect(first.head.status == .ok)
+    #expect(second.head.status == .ok)
+    _ = try? channel.finish()
+}
+
+private struct TestClock: AFMServerClock {
+    let value: Int64
+
+    func unixTime() -> Int64 { value }
+}
+
+private struct TestHTTPResponse {
+    let head: HTTPResponseHead
+    let body: Data
+}
+
+private func testRouter(
+    token: String? = nil,
+    allowedOrigins: Set<String> = [],
+    limits: AFMServerLimits = .init()
+) -> AFMRequestRouter {
+    AFMRequestRouter(
+        configuration: .init(
+            limits: limits,
+            security: .init(bearerToken: token, allowedOrigins: allowedOrigins)
+        ),
+        catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+        clock: TestClock(value: 123)
+    )
+}
+
+private func performRequest(
+    method: HTTPMethod = .GET,
+    path: String,
+    host: String = "127.0.0.1:1976",
+    additionalHeaders: [(String, String)] = [],
+    body: Data? = nil,
+    contentType: String? = nil,
+    router: AFMRequestRouter,
+    limits: AFMServerLimits = .init()
+) throws -> TestHTTPResponse {
+    let channel = EmbeddedChannel(handler: AFMHTTPHandler(router: router, limits: limits))
+    try writeRequest(
+        method: method,
+        path: path,
+        host: host,
+        additionalHeaders: additionalHeaders,
+        body: body,
+        contentType: contentType,
+        to: channel
+    )
+    let response = try readResponse(from: channel)
+    _ = try? channel.finish()
+    return response
+}
+
+private func writeRequest(
+    method: HTTPMethod = .GET,
+    path: String,
+    host: String = "127.0.0.1:1976",
+    additionalHeaders: [(String, String)] = [],
+    body: Data? = nil,
+    contentType: String? = nil,
+    to channel: EmbeddedChannel
+) throws {
+    var headers = HTTPHeaders()
+    headers.add(name: "host", value: host)
+    for (name, value) in additionalHeaders {
+        headers.add(name: name, value: value)
+    }
+    if let body {
+        headers.add(name: "content-length", value: String(body.count))
+    }
+    if let contentType {
+        headers.add(name: "content-type", value: contentType)
+    }
+
+    let head = HTTPRequestHead(version: .http1_1, method: method, uri: path, headers: headers)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    if let body {
+        var buffer = channel.allocator.buffer(capacity: body.count)
+        buffer.writeBytes(body)
+        try channel.writeInbound(HTTPServerRequestPart.body(buffer))
+    }
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+}
+
+private func readResponse(from channel: EmbeddedChannel) throws -> TestHTTPResponse {
+    var responseHead: HTTPResponseHead?
+    var responseBody = Data()
+
+    while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
+        switch part {
+        case .head(let head):
+            responseHead = head
+        case .body(.byteBuffer(var buffer)):
+            if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+                responseBody.append(contentsOf: bytes)
+            }
+        case .body(.fileRegion):
+            Issue.record("Unexpected file-region response body")
+        case .end:
+            return TestHTTPResponse(head: try #require(responseHead), body: responseBody)
+        }
+    }
+    throw TestResponseError.missingEnd
+}
+
+private func jsonObject(_ data: Data) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func errorCode(_ data: Data) throws -> String? {
+    let object = try jsonObject(data)
+    let error = try #require(object["error"] as? [String: Any])
+    return error["code"] as? String
+}
+
+private enum TestResponseError: Error {
+    case missingEnd
+}

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -1,0 +1,328 @@
+import Darwin
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("TCP transport serves health and enforces parser and body limits")
+func tcpTransportAndLimits() async throws {
+    let limits = AFMServerLimits(
+        maximumBodyBytes: 4,
+        maximumHeaderBytes: 128,
+        maximumHeaderFieldBytes: 128,
+        maximumHeaderCount: 12
+    )
+    let server = try testServer(configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0), limits: limits))
+
+    do {
+        let address = try await server.start()
+        guard case .tcp(_, let port) = address else {
+            Issue.record("Expected a TCP address")
+            try await server.stop()
+            return
+        }
+
+        let health = try sendRawHTTPRequest(
+            "GET /health HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nConnection: close\r\n\r\n",
+            port: port
+        )
+        #expect(health.hasPrefix("HTTP/1.1 200 OK"))
+        #expect(health.contains("\"status\":\"afm serve is running\""))
+
+        let oversizedHeader = try sendRawHTTPRequest(
+            "GET /health HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nX-Large: \(String(repeating: "a", count: 200))\r\n\r\n",
+            port: port
+        )
+        #expect(oversizedHeader.hasPrefix("HTTP/1.1 431 Request Header Fields Too Large"))
+        #expect(oversizedHeader.contains("\"code\":\"headers_too_large\""))
+
+        let oversizedBody = try sendRawHTTPRequest(
+            "GET /health HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nContent-Type: application/json\r\nContent-Length: 5\r\n\r\n12345",
+            port: port
+        )
+        #expect(oversizedBody.hasPrefix("HTTP/1.1 413 Payload Too Large"))
+        #expect(oversizedBody.contains("\"code\":\"request_too_large\""))
+
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Unix socket is private and removed during graceful shutdown")
+func unixSocketPermissionsAndCleanup() async throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let path = directory.appending(path: "afm.sock").path()
+    let server = try testServer(configuration: .init(endpoint: .unixSocket(path: path)))
+
+    do {
+        _ = try await server.start()
+        var status = stat()
+        #expect(Darwin.lstat(path, &status) == 0)
+        #expect((status.st_mode & S_IFMT) == S_IFSOCK)
+        #expect((status.st_mode & 0o777) == 0o600)
+
+        try await server.stop()
+        #expect(Darwin.lstat(path, &status) == -1)
+        #expect(errno == ENOENT)
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Graceful shutdown closes accepted keep-alive connections")
+func gracefulShutdownClosesChildChannels() async throws {
+    let server = try testServer(configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)))
+
+    do {
+        let address = try await server.start()
+        guard case .tcp(_, let port) = address else {
+            Issue.record("Expected a TCP address")
+            try await server.stop()
+            return
+        }
+        let descriptor = try connectTCPSocket(port: port)
+        defer { Darwin.close(descriptor) }
+        usleep(20_000)
+
+        try await server.stop()
+
+        var byte: UInt8 = 0
+        #expect(Darwin.read(descriptor, &byte, 1) == 0)
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Unix socket cleanup never removes a replacement path")
+func unixSocketInodeSafeCleanup() async throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let socketURL = directory.appending(path: "afm.sock")
+    let movedSocketURL = directory.appending(path: "original.sock")
+    let server = try testServer(configuration: .init(endpoint: .unixSocket(path: socketURL.path())))
+
+    do {
+        _ = try await server.start()
+        try FileManager.default.moveItem(at: socketURL, to: movedSocketURL)
+        try createStaleUnixSocket(path: socketURL.path())
+        var replacementStatus = stat()
+        #expect(Darwin.lstat(socketURL.path(), &replacementStatus) == 0)
+
+        try await server.stop()
+
+        var statusAfterShutdown = stat()
+        #expect(Darwin.lstat(socketURL.path(), &statusAfterShutdown) == 0)
+        #expect(statusAfterShutdown.st_dev == replacementStatus.st_dev)
+        #expect(statusAfterShutdown.st_ino == replacementStatus.st_ino)
+        var movedStatus = stat()
+        #expect(Darwin.lstat(movedSocketURL.path(), &movedStatus) == 0)
+        #expect((movedStatus.st_mode & S_IFMT) == S_IFSOCK)
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Unix socket refuses regular files, symlinks, and active listeners")
+func unixSocketRefusesUnsafePaths() async throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let regularFile = directory.appending(path: "regular.sock")
+    try Data("keep".utf8).write(to: regularFile)
+    let regularServer = try testServer(configuration: .init(endpoint: .unixSocket(path: regularFile.path())))
+    await expectStartFailure(regularServer, matching: .pathExists(kind: "regular file"))
+    #expect(try Data(contentsOf: regularFile) == Data("keep".utf8))
+
+    let symlink = directory.appending(path: "link.sock")
+    try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: regularFile)
+    let symlinkServer = try testServer(configuration: .init(endpoint: .unixSocket(path: symlink.path())))
+    await expectStartFailure(symlinkServer, matching: .pathExists(kind: "symbolic link"))
+
+    let activePath = directory.appending(path: "active.sock").path()
+    let firstServer = try testServer(configuration: .init(endpoint: .unixSocket(path: activePath)))
+    let secondServer = try testServer(configuration: .init(endpoint: .unixSocket(path: activePath)))
+    do {
+        _ = try await firstServer.start()
+        await expectStartFailure(secondServer, matching: .socketInUse)
+        try await firstServer.stop()
+    } catch {
+        try? await firstServer.stop()
+        try? await secondServer.stop()
+        throw error
+    }
+}
+
+@Test("Owned stale Unix sockets are replaced safely")
+func staleUnixSocketRecovery() async throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let path = directory.appending(path: "stale.sock").path()
+    try createStaleUnixSocket(path: path)
+
+    let server = try testServer(configuration: .init(endpoint: .unixSocket(path: path)))
+    do {
+        _ = try await server.start()
+        var status = stat()
+        #expect(Darwin.lstat(path, &status) == 0)
+        #expect((status.st_mode & 0o777) == 0o600)
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Unix sockets reject non-sticky shared parent directories")
+func unixSocketRejectsInsecureParent() async throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    #expect(Darwin.chmod(directory.path(), 0o777) == 0)
+
+    let path = directory.appending(path: "afm.sock").path()
+    let server = try testServer(configuration: .init(endpoint: .unixSocket(path: path)))
+    await expectStartFailure(server, matching: .insecureParentDirectory)
+}
+
+private func testServer(configuration: AFMServerConfiguration) throws -> AFMHTTPServer {
+    try AFMHTTPServer(
+        configuration: configuration,
+        catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+        clock: IntegrationTestClock()
+    )
+}
+
+private struct IntegrationTestClock: AFMServerClock {
+    func unixTime() -> Int64 { 123 }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let identifier = UUID().uuidString.prefix(8)
+    let directory = URL(fileURLWithPath: "/tmp/afm-tests-\(identifier)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    return directory
+}
+
+private func expectStartFailure(
+    _ server: AFMHTTPServer,
+    matching expectedError: AFMUnixSocketError
+) async {
+    do {
+        _ = try await server.start()
+        Issue.record("Expected server startup to fail with \(expectedError)")
+        try? await server.stop()
+    } catch let error as AFMUnixSocketError {
+        #expect(error == expectedError)
+    } catch {
+        Issue.record("Unexpected startup error: \(error)")
+    }
+}
+
+private func sendRawHTTPRequest(_ request: String, port: Int) throws -> String {
+    let descriptor = try connectTCPSocket(port: port)
+    defer { Darwin.close(descriptor) }
+
+    let requestBytes = Array(request.utf8)
+    try requestBytes.withUnsafeBytes { buffer in
+        var sent = 0
+        while sent < buffer.count {
+            let result = Darwin.write(
+                descriptor,
+                buffer.baseAddress?.advanced(by: sent),
+                buffer.count - sent
+            )
+            guard result > 0 else { throw POSIXTestError(operation: "write TCP request", code: errno) }
+            sent += result
+        }
+    }
+
+    var response = Data()
+    var buffer = [UInt8](repeating: 0, count: 4_096)
+    while true {
+        let count = Darwin.read(descriptor, &buffer, buffer.count)
+        if count > 0 {
+            response.append(contentsOf: buffer.prefix(count))
+        } else if count == 0 {
+            break
+        } else if errno == EAGAIN || errno == EWOULDBLOCK {
+            break
+        } else {
+            throw POSIXTestError(operation: "read TCP response", code: errno)
+        }
+    }
+    return try #require(String(data: response, encoding: .utf8))
+}
+
+private func connectTCPSocket(port: Int) throws -> CInt {
+    let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+    guard descriptor >= 0 else { throw POSIXTestError(operation: "create TCP socket", code: errno) }
+    var shouldClose = true
+    defer {
+        if shouldClose {
+            Darwin.close(descriptor)
+        }
+    }
+
+    var timeout = timeval(tv_sec: 2, tv_usec: 0)
+    guard setsockopt(
+        descriptor,
+        SOL_SOCKET,
+        SO_RCVTIMEO,
+        &timeout,
+        socklen_t(MemoryLayout<timeval>.size)
+    ) == 0 else {
+        throw POSIXTestError(operation: "set TCP timeout", code: errno)
+    }
+
+    var address = sockaddr_in()
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = in_port_t(port).bigEndian
+    let addressResult = "127.0.0.1".withCString {
+        inet_pton(AF_INET, $0, &address.sin_addr)
+    }
+    guard addressResult == 1 else { throw POSIXTestError(operation: "encode TCP address", code: errno) }
+    let connectResult = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    guard connectResult == 0 else { throw POSIXTestError(operation: "connect TCP socket", code: errno) }
+    shouldClose = false
+    return descriptor
+}
+
+private func createStaleUnixSocket(path: String) throws {
+    let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+    guard descriptor >= 0 else { throw POSIXTestError(operation: "create Unix socket", code: errno) }
+    defer { Darwin.close(descriptor) }
+
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let bytes = path.utf8CString
+    withUnsafeMutableBytes(of: &address.sun_path) { destination in
+        bytes.withUnsafeBytes { source in
+            destination.copyBytes(from: source)
+        }
+    }
+    let length = socklen_t(MemoryLayout<sa_family_t>.size + bytes.count)
+    address.sun_len = UInt8(length)
+    let result = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            Darwin.bind(descriptor, $0, length)
+        }
+    }
+    guard result == 0 else { throw POSIXTestError(operation: "bind stale Unix socket", code: errno) }
+}
+
+private struct POSIXTestError: Error, CustomStringConvertible {
+    let operation: String
+    let code: Int32
+
+    var description: String {
+        "Could not \(operation): \(String(cString: strerror(code)))"
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -72,6 +72,103 @@ func unixSocketPermissionsAndCleanup() async throws {
     }
 }
 
+@Test("Failed Unix channel adoption closes the descriptor and removes its socket")
+func failedUnixChannelAdoptionCleanup() throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let path = directory.appending(path: "afm.sock").path()
+    let boundSocket = try AFMUnixSocketManager.makeBoundSocket(path: path)
+    defer {
+        if Darwin.fcntl(boundSocket.descriptor, F_GETFD) >= 0 {
+            Darwin.close(boundSocket.descriptor)
+        }
+        Darwin.unlink(path)
+    }
+
+    try AFMUnixSocketManager.cleanupAfterFailedAdoption(boundSocket)
+
+    errno = 0
+    #expect(Darwin.fcntl(boundSocket.descriptor, F_GETFD) == -1)
+    #expect(errno == EBADF)
+    var status = stat()
+    #expect(Darwin.lstat(path, &status) == -1)
+    #expect(errno == ENOENT)
+}
+
+@Test("A server can retry after its first TCP bind fails")
+func failedTCPBindCanRetrySameServer() async throws {
+    let blocker = try testServer(configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)))
+    var retryingServer: AFMHTTPServer?
+
+    do {
+        let blockerAddress = try await blocker.start()
+        guard case .tcp(_, let port) = blockerAddress else {
+            Issue.record("Expected a TCP address")
+            try await blocker.stop()
+            return
+        }
+        let server = try testServer(configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: port)))
+        retryingServer = server
+
+        do {
+            _ = try await server.start()
+            Issue.record("Expected the occupied port bind to fail")
+        } catch {
+            #expect(!(error is AFMHTTPServerStateError))
+        }
+
+        try await blocker.stop()
+        let retryAddress = try await server.start()
+        #expect(retryAddress == .tcp(host: "127.0.0.1", port: port))
+        try await server.stop()
+    } catch {
+        try? await blocker.stop()
+        if let retryingServer {
+            try? await retryingServer.stop()
+        }
+        throw error
+    }
+}
+
+@Test("Failed shutdown retains its socket lease until a retry succeeds")
+func failedShutdownCanRetryAndRestart() async throws {
+    let directory = try makeTemporaryDirectory()
+    defer {
+        Darwin.chmod(directory.path(), 0o700)
+        try? FileManager.default.removeItem(at: directory)
+    }
+    let path = directory.appending(path: "afm.sock").path()
+    let server = try testServer(configuration: .init(endpoint: .unixSocket(path: path)))
+
+    do {
+        _ = try await server.start()
+        #expect(Darwin.chmod(directory.path(), 0o500) == 0)
+
+        do {
+            try await server.stop()
+            Issue.record("Expected socket cleanup to fail in a read-only directory")
+        } catch {
+            #expect(error is AFMUnixSocketError)
+        }
+
+        var status = stat()
+        #expect(Darwin.lstat(path, &status) == 0)
+        #expect((status.st_mode & S_IFMT) == S_IFSOCK)
+
+        #expect(Darwin.chmod(directory.path(), 0o700) == 0)
+        try await server.stop()
+        #expect(Darwin.lstat(path, &status) == -1)
+        #expect(errno == ENOENT)
+
+        _ = try await server.start()
+        try await server.stop()
+    } catch {
+        Darwin.chmod(directory.path(), 0o700)
+        try? await server.stop()
+        throw error
+    }
+}
+
 @Test("Graceful shutdown closes accepted keep-alive connections")
 func gracefulShutdownClosesChildChannels() async throws {
     let server = try testServer(configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)))

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -78,8 +78,9 @@ func failedUnixChannelAdoptionCleanup() throws {
     defer { try? FileManager.default.removeItem(at: directory) }
     let path = directory.appending(path: "afm.sock").path()
     let boundSocket = try AFMUnixSocketManager.makeBoundSocket(path: path)
+    let socketIdentity = try fileIdentity(of: boundSocket.descriptor)
     defer {
-        if Darwin.fcntl(boundSocket.descriptor, F_GETFD) >= 0 {
+        if descriptor(boundSocket.descriptor, stillRefersTo: socketIdentity) {
             Darwin.close(boundSocket.descriptor)
         }
         Darwin.unlink(path)
@@ -87,9 +88,7 @@ func failedUnixChannelAdoptionCleanup() throws {
 
     try AFMUnixSocketManager.cleanupAfterFailedAdoption(boundSocket)
 
-    errno = 0
-    #expect(Darwin.fcntl(boundSocket.descriptor, F_GETFD) == -1)
-    #expect(errno == EBADF)
+    #expect(!descriptor(boundSocket.descriptor, stillRefersTo: socketIdentity))
     var status = stat()
     #expect(Darwin.lstat(path, &status) == -1)
     #expect(errno == ENOENT)
@@ -295,6 +294,25 @@ private func testServer(configuration: AFMServerConfiguration) throws -> AFMHTTP
 
 private struct IntegrationTestClock: AFMServerClock {
     func unixTime() -> Int64 { 123 }
+}
+
+private struct FileIdentity: Equatable {
+    let device: dev_t
+    let inode: ino_t
+}
+
+private func fileIdentity(of descriptor: CInt) throws -> FileIdentity {
+    var status = stat()
+    guard Darwin.fstat(descriptor, &status) == 0 else {
+        throw POSIXTestError(operation: "inspect Unix socket", code: errno)
+    }
+    return FileIdentity(device: status.st_dev, inode: status.st_ino)
+}
+
+private func descriptor(_ descriptor: CInt, stillRefersTo identity: FileIdentity) -> Bool {
+    var status = stat()
+    guard Darwin.fstat(descriptor, &status) == 0 else { return false }
+    return status.st_dev == identity.device && status.st_ino == identity.inode
 }
 
 private func makeTemporaryDirectory() throws -> URL {

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMServerConfigurationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMServerConfigurationTests.swift
@@ -1,0 +1,80 @@
+import Testing
+@testable import AFMServer
+
+@Test("Loopback bindings do not require network opt-in")
+func loopbackBindings() throws {
+    for host in ["localhost", "127.0.0.1", "127.2.3.4", "::1", "[::1]"] {
+        let configuration = AFMServerConfiguration(endpoint: .tcp(host: host, port: 1976))
+        let validated = try configuration.validated()
+        let expectedHost = host == "[::1]" ? "::1" : host
+        #expect(validated.endpoint == .tcp(host: expectedHost, port: 1976))
+    }
+}
+
+@Test("Non-loopback bindings require explicit opt-in and authentication")
+func networkBindingSecurity() throws {
+    let implicit = AFMServerConfiguration(endpoint: .tcp(host: "0.0.0.0", port: 1976))
+    #expect(throws: AFMServerConfigurationError.networkOptInRequired("0.0.0.0")) {
+        _ = try implicit.validated()
+    }
+
+    let unauthenticated = AFMServerConfiguration(
+        endpoint: .tcp(host: "0.0.0.0", port: 1976),
+        security: .init(allowNetwork: true)
+    )
+    #expect(throws: AFMServerConfigurationError.networkAuthenticationRequired("0.0.0.0")) {
+        _ = try unauthenticated.validated()
+    }
+
+    let authenticated = AFMServerConfiguration(
+        endpoint: .tcp(host: "0.0.0.0", port: 1976),
+        security: .init(allowNetwork: true, bearerToken: "secret")
+    )
+    #expect(throws: Never.self) {
+        _ = try authenticated.validated()
+    }
+}
+
+@Test("Origin allowlists accept exact web origins only")
+func allowedOriginValidation() throws {
+    for origin in ["", "*", "null", "https://example.com/", "https://example.com/path", "file://local"] {
+        let configuration = AFMServerConfiguration(
+            security: .init(allowedOrigins: [origin])
+        )
+        #expect(throws: AFMServerConfigurationError.invalidAllowedOrigin) {
+            _ = try configuration.validated()
+        }
+    }
+
+    let configuration = AFMServerConfiguration(
+        security: .init(allowedOrigins: ["https://example.com", "http://localhost:8080"])
+    )
+    #expect(throws: Never.self) {
+        _ = try configuration.validated()
+    }
+}
+
+@Test("Transport and parser limits validate before the server starts")
+func transportLimitValidation() throws {
+    let invalidPort = AFMServerConfiguration(endpoint: .tcp(host: "127.0.0.1", port: 65_536))
+    #expect(throws: AFMServerConfigurationError.invalidPort(65_536)) {
+        _ = try invalidPort.validated()
+    }
+
+    let invalidLimits = AFMServerConfiguration(
+        limits: .init(maximumHeaderBytes: 10, maximumHeaderFieldBytes: 11)
+    )
+    #expect(throws: AFMServerConfigurationError.invalidLimits) {
+        _ = try invalidLimits.validated()
+    }
+
+    let relativeSocket = AFMServerConfiguration(endpoint: .unixSocket(path: "afm.sock"))
+    #expect(throws: AFMServerConfigurationError.invalidSocketPath) {
+        _ = try relativeSocket.validated()
+    }
+
+    let nullSocket = AFMServerConfiguration(endpoint: .unixSocket(path: "/tmp/afm\0shadow.sock"))
+    #expect(throws: AFMServerConfigurationError.invalidSocketPath) {
+        _ = try nullSocket.validated()
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #167. This PR contains only the server transport, discovery endpoints, and their security/test foundation; chat completions remain a separate follow-up.

## What

- add an internal `AFMServer` target built directly on Apple SwiftNIO
- add `afm serve`, defaulting to `127.0.0.1:1976`
- add `GET /health` and OpenAI-shaped `GET /v1/models`
- support TCP and Unix-domain sockets with graceful SIGINT/SIGTERM shutdown
- emit immediately flushed human or structured JSON startup output without ever serializing the bearer token
- enforce a 1 MiB body limit, aggregate/per-field header limits, header-count limits, JSON media types, and structured 400/401/403/404/405/413/415/431 errors
- reject cross-site requests by default, validate loopback Host headers, support exact Origin allowlisting, and use constant-time bearer comparison
- require both `--allow-network` and bearer authentication for non-loopback binding

## Unix-socket safety

The native `fm serve` currently creates permissive sockets and can replace unrelated paths. `afm` instead:

- uses `lstat` and refuses regular files, directories, symlinks, active sockets, and sockets owned by another user
- removes only a stale socket whose owner/device/inode still match the inspected path
- creates the bound socket with mode `0600`
- records the bound inode and removes it at shutdown only if the path still identifies that same socket
- rejects shared writable parents unless they use the sticky bit

## Why SwiftNIO

Direct `NIOCore`/`NIOPosix`/`NIOHTTP1` gives the CLI correct HTTP framing, parser limits, TCP/Unix transport, disconnect behavior, and future streaming backpressure without taking on a larger web framework. `NIOEmbedded` keeps protocol tests deterministic.

## Verification

- strict Core/CLI SwiftLint, including the new server target
- Xcode 27 full package tests
- Xcode 26.6 `afm` build plus AFMServer and AFMCLI suites
- 18 server tests covering live TCP, parser/body limits, auth, Host/Origin policy, keep-alive shutdown, socket `0600`, stale/active/file/symlink handling, insecure parents, and inode-safe cleanup
- 28 CLI tests covering help/dry-run, secret redaction, flushed JSON readiness, and SIGTERM cleanup
- combined Xcode 26 build after rebasing onto #167
- combined token/server deterministic suite after rebase; one pre-existing large-pipe stress test was rerun in isolation after a transient SIGPIPE and passed

## Deliberate boundary

This PR does not add inference, chat completions, SSE, schema output, client tools, generation concurrency, or model timeouts. Those remain isolated follow-ups on top of this transport. Non-loopback HTTP is plaintext and emits an explicit warning; use a local TLS reverse proxy when exposing it beyond the machine.

References: [SwiftNIO](https://github.com/apple/swift-nio) and [WWDC26: Use the Foundation Models framework from the command line](https://developer.apple.com/videos/play/wwdc2026/334/).
