### PR TITLE
Add entitlement-aware model status commands

### DIFF
--- a/FoundationLabCore/Sources/FoundationLabCore/Capabilities/InspectModelQuotaUsageUseCase.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Capabilities/InspectModelQuotaUsageUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct InspectModelQuotaUsageUseCase: Sendable {
+    public static let descriptor = CapabilityDescriptor(
+        id: "foundation-models.inspect-quota-usage",
+        displayName: "Inspect Model Quota Usage",
+        summary: "Reports Private Cloud Compute quota state without inventing numeric usage."
+    )
+
+    private let inspector: any ModelRuntimeInspecting
+
+    public init(inspector: any ModelRuntimeInspecting = FoundationModelsRuntimeInspector()) {
+        self.inspector = inspector
+    }
+
+    public func execute(
+        runtimes: [FoundationLabModelRuntime] = FoundationLabModelRuntime.allCases
+    ) -> [ModelQuotaUsageResult] {
+        runtimes.map(inspector.quotaUsage(for:))
+    }
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Capabilities/InspectModelRuntimeUseCase.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Capabilities/InspectModelRuntimeUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct InspectModelRuntimeUseCase: Sendable {
+    public static let descriptor = CapabilityDescriptor(
+        id: "foundation-models.inspect-runtime",
+        displayName: "Inspect Model Runtime",
+        summary: "Reports availability for on-device and Private Cloud Compute models."
+    )
+
+    private let inspector: any ModelRuntimeInspecting
+
+    public init(inspector: any ModelRuntimeInspecting = FoundationModelsRuntimeInspector()) {
+        self.inspector = inspector
+    }
+
+    public func execute(
+        runtimes: [FoundationLabModelRuntime] = FoundationLabModelRuntime.allCases
+    ) -> [ModelRuntimeStatusResult] {
+        runtimes.map(inspector.status(for:))
+    }
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsRuntimeInspector.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsRuntimeInspector.swift
@@ -89,12 +89,30 @@ public struct FoundationModelsRuntimeInspector: ModelRuntimeInspecting {
     func privateCloudUnavailableQuotaResult(
         for status: ModelRuntimeStatusResult
     ) -> ModelQuotaUsageResult? {
-        guard status.runtime == .privateCloudCompute,
-              !status.isRunnableInCurrentProcess else { return nil }
+        guard status.runtime == .privateCloudCompute else { return nil }
+        guard status.isSupported else {
+            return ModelQuotaUsageResult(
+                runtime: .privateCloudCompute,
+                status: .unsupported,
+                unavailableReason: status.reason ?? .unknown,
+                metadata: metadata(for: .privateCloudCompute)
+            )
+        }
+
+        let authorizationReason: ModelRuntimeUnavailableReason
+        switch status.authorization {
+        case .granted:
+            return nil
+        case .missing:
+            authorizationReason = .missingEntitlement
+        case .unknown, .notRequired:
+            authorizationReason = .unknown
+        }
+
         return ModelQuotaUsageResult(
             runtime: .privateCloudCompute,
-            status: status.isSupported ? .unavailable : .unsupported,
-            unavailableReason: status.reason ?? .unknown,
+            status: .unavailable,
+            unavailableReason: authorizationReason,
             metadata: metadata(for: .privateCloudCompute)
         )
     }

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsRuntimeInspector.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsRuntimeInspector.swift
@@ -1,0 +1,177 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsRuntimeInspector: ModelRuntimeInspecting {
+    public init() {}
+
+    public func status(for runtime: FoundationLabModelRuntime) -> ModelRuntimeStatusResult {
+        switch runtime {
+        case .onDevice:
+            return onDeviceStatus()
+        case .privateCloudCompute:
+            return privateCloudStatus()
+        }
+    }
+
+    public func quotaUsage(for runtime: FoundationLabModelRuntime) -> ModelQuotaUsageResult {
+        switch runtime {
+        case .onDevice:
+            return ModelQuotaUsageResult(
+                runtime: .onDevice,
+                status: .notApplicable,
+                metadata: metadata(for: .onDevice)
+            )
+        case .privateCloudCompute:
+            return privateCloudQuotaUsage()
+        }
+    }
+
+    private func onDeviceStatus() -> ModelRuntimeStatusResult {
+        let availability = FoundationModelsModelAvailabilityChecker().currentAvailability()
+        return ModelRuntimeStatusResult(
+            runtime: .onDevice,
+            isAvailable: availability.isAvailable,
+            reason: availability.reason.map(Self.runtimeReason),
+            metadata: metadata(for: .onDevice)
+        )
+    }
+
+    private func privateCloudStatus() -> ModelRuntimeStatusResult {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let model = PrivateCloudComputeLanguageModel()
+            switch model.availability {
+            case .available:
+                let authorization = PrivateCloudComputeEntitlementChecker().authorization()
+                return ModelRuntimeStatusResult(
+                    runtime: .privateCloudCompute,
+                    isAvailable: true,
+                    authorization: authorization,
+                    reason: authorization == .missing ? .missingEntitlement : nil,
+                    metadata: metadata(for: .privateCloudCompute)
+                )
+            case .unavailable(let reason):
+                return ModelRuntimeStatusResult(
+                    runtime: .privateCloudCompute,
+                    isAvailable: false,
+                    authorization: PrivateCloudComputeEntitlementChecker().authorization(),
+                    reason: Self.runtimeReason(reason),
+                    metadata: metadata(for: .privateCloudCompute)
+                )
+            }
+        }
+
+        return unsupportedPrivateCloudStatus(reason: .unsupportedOperatingSystem)
+        #else
+        return unsupportedPrivateCloudStatus(reason: .unsupportedToolchain)
+        #endif
+    }
+
+    private func privateCloudQuotaUsage() -> ModelQuotaUsageResult {
+        let status = privateCloudStatus()
+        guard status.isSupported else {
+            return ModelQuotaUsageResult(
+                runtime: .privateCloudCompute,
+                status: .unsupported,
+                unavailableReason: status.reason,
+                metadata: metadata(for: .privateCloudCompute)
+            )
+        }
+        guard status.isRunnableInCurrentProcess else {
+            return ModelQuotaUsageResult(
+                runtime: .privateCloudCompute,
+                status: .unavailable,
+                unavailableReason: status.reason,
+                metadata: metadata(for: .privateCloudCompute)
+            )
+        }
+
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            return quotaResult(PrivateCloudComputeLanguageModel().quotaUsage)
+        }
+        #endif
+
+        return ModelQuotaUsageResult(
+            runtime: .privateCloudCompute,
+            status: .unsupported,
+            unavailableReason: .unsupportedToolchain,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+
+    private func unsupportedPrivateCloudStatus(
+        reason: ModelRuntimeUnavailableReason
+    ) -> ModelRuntimeStatusResult {
+        ModelRuntimeStatusResult(
+            runtime: .privateCloudCompute,
+            isSupported: false,
+            isAvailable: false,
+            authorization: .unknown,
+            reason: reason,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+
+    private func metadata(for runtime: FoundationLabModelRuntime) -> CapabilityExecutionMetadata {
+        CapabilityExecutionMetadata(
+            provider: "Foundation Models",
+            modelIdentifier: runtime == .onDevice ? "system" : "pcc"
+        )
+    }
+
+    private static func runtimeReason(
+        _ reason: ModelAvailabilityUnavailableReason
+    ) -> ModelRuntimeUnavailableReason {
+        switch reason {
+        case .deviceNotEligible:
+            return .deviceNotEligible
+        case .appleIntelligenceNotEnabled:
+            return .appleIntelligenceNotEnabled
+        case .modelNotReady:
+            return .modelNotReady
+        case .unknown:
+            return .unknown
+        }
+    }
+}
+
+#if compiler(>=6.4)
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+private extension FoundationModelsRuntimeInspector {
+    static func runtimeReason(
+        _ reason: PrivateCloudComputeLanguageModel.Availability.UnavailableReason
+    ) -> ModelRuntimeUnavailableReason {
+        switch reason {
+        case .deviceNotEligible:
+            return .deviceNotEligible
+        case .systemNotReady:
+            return .systemNotReady
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    func quotaResult(
+        _ usage: PrivateCloudComputeLanguageModel.QuotaUsage
+    ) -> ModelQuotaUsageResult {
+        let status: ModelQuotaStatus
+        switch usage.status {
+        case .belowLimit(let details):
+            status = details.isApproachingLimit ? .approachingLimit : .belowLimit
+        case .limitReached:
+            status = .limitReached
+        @unknown default:
+            status = .unavailable
+        }
+
+        return ModelQuotaUsageResult(
+            runtime: .privateCloudCompute,
+            status: status,
+            resetDate: usage.resetDate,
+            canRequestLimitIncrease: usage.limitIncreaseSuggestion != nil,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+}
+#endif

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsRuntimeInspector.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsRuntimeInspector.swift
@@ -47,7 +47,6 @@ public struct FoundationModelsRuntimeInspector: ModelRuntimeInspecting {
                     runtime: .privateCloudCompute,
                     isAvailable: true,
                     authorization: authorization,
-                    reason: authorization == .missing ? .missingEntitlement : nil,
                     metadata: metadata(for: .privateCloudCompute)
                 )
             case .unavailable(let reason):
@@ -69,21 +68,8 @@ public struct FoundationModelsRuntimeInspector: ModelRuntimeInspecting {
 
     private func privateCloudQuotaUsage() -> ModelQuotaUsageResult {
         let status = privateCloudStatus()
-        guard status.isSupported else {
-            return ModelQuotaUsageResult(
-                runtime: .privateCloudCompute,
-                status: .unsupported,
-                unavailableReason: status.reason,
-                metadata: metadata(for: .privateCloudCompute)
-            )
-        }
-        guard status.isRunnableInCurrentProcess else {
-            return ModelQuotaUsageResult(
-                runtime: .privateCloudCompute,
-                status: .unavailable,
-                unavailableReason: status.reason,
-                metadata: metadata(for: .privateCloudCompute)
-            )
+        if let unavailableResult = privateCloudUnavailableQuotaResult(for: status) {
+            return unavailableResult
         }
 
         #if compiler(>=6.4)
@@ -96,6 +82,19 @@ public struct FoundationModelsRuntimeInspector: ModelRuntimeInspecting {
             runtime: .privateCloudCompute,
             status: .unsupported,
             unavailableReason: .unsupportedToolchain,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+
+    func privateCloudUnavailableQuotaResult(
+        for status: ModelRuntimeStatusResult
+    ) -> ModelQuotaUsageResult? {
+        guard status.runtime == .privateCloudCompute,
+              !status.isRunnableInCurrentProcess else { return nil }
+        return ModelQuotaUsageResult(
+            runtime: .privateCloudCompute,
+            status: status.isSupported ? .unavailable : .unsupported,
+            unavailableReason: status.reason ?? .unknown,
             metadata: metadata(for: .privateCloudCompute)
         )
     }

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/ModelRuntimeInspecting.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/ModelRuntimeInspecting.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol ModelRuntimeInspecting: Sendable {
+    func status(for runtime: FoundationLabModelRuntime) -> ModelRuntimeStatusResult
+    func quotaUsage(for runtime: FoundationLabModelRuntime) -> ModelQuotaUsageResult
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/PrivateCloudComputeEntitlementChecker.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/PrivateCloudComputeEntitlementChecker.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+#if os(macOS)
+import Security
+#endif
+
+public struct PrivateCloudComputeEntitlementChecker: Sendable {
+    public static let entitlement = "com.apple.developer.private-cloud-compute"
+
+    public init() {}
+
+    public func authorization() -> ModelRuntimeAuthorization {
+        #if os(macOS)
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            return .unknown
+        }
+        let value = SecTaskCopyValueForEntitlement(
+            task,
+            Self.entitlement as CFString,
+            nil
+        )
+        return (value as? Bool) == true ? .granted : .missing
+        #else
+        return .unknown
+        #endif
+    }
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Results/ModelQuotaUsageResult.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Results/ModelQuotaUsageResult.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum ModelQuotaStatus: String, Sendable, Hashable, Codable {
+    case notApplicable
+    case unavailable
+    case belowLimit
+    case approachingLimit
+    case limitReached
+    case unsupported
+}
+
+public struct ModelQuotaUsageResult: CapabilityResult, Sendable, Hashable, Codable {
+    public let runtime: FoundationLabModelRuntime
+    public let status: ModelQuotaStatus
+    public let resetDate: Date?
+    public let canRequestLimitIncrease: Bool
+    public let unavailableReason: ModelRuntimeUnavailableReason?
+    public let metadata: CapabilityExecutionMetadata
+
+    public init(
+        runtime: FoundationLabModelRuntime,
+        status: ModelQuotaStatus,
+        resetDate: Date? = nil,
+        canRequestLimitIncrease: Bool = false,
+        unavailableReason: ModelRuntimeUnavailableReason? = nil,
+        metadata: CapabilityExecutionMetadata = CapabilityExecutionMetadata()
+    ) {
+        self.runtime = runtime
+        self.status = status
+        self.resetDate = resetDate
+        self.canRequestLimitIncrease = canRequestLimitIncrease
+        self.unavailableReason = unavailableReason
+        self.metadata = metadata
+    }
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Results/ModelRuntimeStatusResult.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Results/ModelRuntimeStatusResult.swift
@@ -38,9 +38,11 @@ public struct ModelRuntimeStatusResult: CapabilityResult, Sendable, Hashable, Co
         self.runtime = runtime
         self.isSupported = isSupported
         self.isAvailable = isAvailable
+        let hasRequiredAuthorization = authorization == .granted
+            || (runtime == .onDevice && authorization == .notRequired)
         self.isRunnableInCurrentProcess = isSupported
             && isAvailable
-            && authorization != .missing
+            && hasRequiredAuthorization
         self.authorization = authorization
         self.reason = reason
         self.metadata = metadata

--- a/FoundationLabCore/Sources/FoundationLabCore/Results/ModelRuntimeStatusResult.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Results/ModelRuntimeStatusResult.swift
@@ -44,7 +44,25 @@ public struct ModelRuntimeStatusResult: CapabilityResult, Sendable, Hashable, Co
             && isAvailable
             && hasRequiredAuthorization
         self.authorization = authorization
-        self.reason = reason
+        self.reason = reason ?? Self.authorizationReason(
+            runtime: runtime,
+            authorization: authorization
+        )
         self.metadata = metadata
+    }
+
+    private static func authorizationReason(
+        runtime: FoundationLabModelRuntime,
+        authorization: ModelRuntimeAuthorization
+    ) -> ModelRuntimeUnavailableReason? {
+        guard runtime == .privateCloudCompute else { return nil }
+        switch authorization {
+        case .missing:
+            return .missingEntitlement
+        case .unknown, .notRequired:
+            return .unknown
+        case .granted:
+            return nil
+        }
     }
 }

--- a/FoundationLabCore/Sources/FoundationLabCore/Results/ModelRuntimeStatusResult.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Results/ModelRuntimeStatusResult.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum ModelRuntimeUnavailableReason: String, Sendable, Hashable, Codable {
+    case deviceNotEligible
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case systemNotReady
+    case unsupportedOperatingSystem
+    case unsupportedToolchain
+    case missingEntitlement
+    case unknown
+}
+
+public enum ModelRuntimeAuthorization: String, Sendable, Hashable, Codable {
+    case notRequired
+    case granted
+    case missing
+    case unknown
+}
+
+public struct ModelRuntimeStatusResult: CapabilityResult, Sendable, Hashable, Codable {
+    public let runtime: FoundationLabModelRuntime
+    public let isSupported: Bool
+    public let isAvailable: Bool
+    public let isRunnableInCurrentProcess: Bool
+    public let authorization: ModelRuntimeAuthorization
+    public let reason: ModelRuntimeUnavailableReason?
+    public let metadata: CapabilityExecutionMetadata
+
+    public init(
+        runtime: FoundationLabModelRuntime,
+        isSupported: Bool = true,
+        isAvailable: Bool,
+        authorization: ModelRuntimeAuthorization = .notRequired,
+        reason: ModelRuntimeUnavailableReason? = nil,
+        metadata: CapabilityExecutionMetadata = CapabilityExecutionMetadata()
+    ) {
+        self.runtime = runtime
+        self.isSupported = isSupported
+        self.isAvailable = isAvailable
+        self.isRunnableInCurrentProcess = isSupported
+            && isAvailable
+            && authorization != .missing
+        self.authorization = authorization
+        self.reason = reason
+        self.metadata = metadata
+    }
+}

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
@@ -58,8 +58,9 @@ func skippedPCCQuotaPreservesAuthorizationReason(
 ) throws {
     let runtimeStatus = ModelRuntimeStatusResult(
         runtime: .privateCloudCompute,
-        isAvailable: true,
-        authorization: authorization
+        isAvailable: false,
+        authorization: authorization,
+        reason: .systemNotReady
     )
 
     let result = try #require(
@@ -68,6 +69,39 @@ func skippedPCCQuotaPreservesAuthorizationReason(
 
     #expect(result.status == .unavailable)
     #expect(result.unavailableReason == expectedReason)
+}
+
+@Test("PCC quota remains inspectable while authorized inference is unavailable")
+func authorizedPCCQuotaIgnoresInferenceAvailability() {
+    let runtimeStatus = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: false,
+        authorization: .granted,
+        reason: .systemNotReady
+    )
+
+    let result = FoundationModelsRuntimeInspector()
+        .privateCloudUnavailableQuotaResult(for: runtimeStatus)
+
+    #expect(result == nil)
+}
+
+@Test("PCC quota preserves unsupported runtime reasons")
+func unsupportedPCCQuotaPreservesRuntimeReason() throws {
+    let runtimeStatus = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isSupported: false,
+        isAvailable: false,
+        authorization: .unknown,
+        reason: .unsupportedOperatingSystem
+    )
+
+    let result = try #require(
+        FoundationModelsRuntimeInspector().privateCloudUnavailableQuotaResult(for: runtimeStatus)
+    )
+
+    #expect(result.status == .unsupported)
+    #expect(result.unavailableReason == .unsupportedOperatingSystem)
 }
 
 @Test("Confirmed managed entitlement makes available PCC runnable")

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
@@ -21,18 +21,62 @@ func quotaInspectionReportsSystemAsNotApplicable() {
     #expect(results.map(\.status) == [.notApplicable, .approachingLimit])
 }
 
-@Test("Missing managed entitlement makes PCC non-runnable")
-func missingEntitlementMakesPCCNonRunnable() {
+@Test(
+    "Unconfirmed managed entitlement makes PCC non-runnable",
+    arguments: [ModelRuntimeAuthorization.missing, .unknown, .notRequired]
+)
+func unconfirmedEntitlementMakesPCCNonRunnable(
+    authorization: ModelRuntimeAuthorization
+) {
     let result = ModelRuntimeStatusResult(
         runtime: .privateCloudCompute,
         isAvailable: true,
-        authorization: .missing,
-        reason: .missingEntitlement
+        authorization: authorization
     )
 
     #expect(result.isSupported)
     #expect(!result.isRunnableInCurrentProcess)
-    #expect(result.authorization == .missing)
+    #expect(result.authorization == authorization)
+}
+
+@Test("Confirmed managed entitlement makes available PCC runnable")
+func grantedEntitlementMakesPCCRunnable() {
+    let result = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: .granted
+    )
+
+    #expect(result.isRunnableInCurrentProcess)
+}
+
+@Test("On-device runtime is runnable without managed PCC authorization")
+func onDeviceRuntimeDoesNotRequirePCCAuthorization() {
+    let result = ModelRuntimeStatusResult(
+        runtime: .onDevice,
+        isAvailable: true
+    )
+
+    #expect(result.isRunnableInCurrentProcess)
+    #expect(result.authorization == .notRequired)
+}
+
+@Test("Unsupported or unavailable runtimes remain non-runnable")
+func unsupportedOrUnavailableRuntimesRemainNonRunnable() {
+    let unavailable = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: false,
+        authorization: .granted
+    )
+    let unsupported = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isSupported: false,
+        isAvailable: true,
+        authorization: .granted
+    )
+
+    #expect(!unavailable.isRunnableInCurrentProcess)
+    #expect(!unsupported.isRunnableInCurrentProcess)
 }
 
 private struct StubRuntimeInspector: ModelRuntimeInspecting {

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import FoundationLabCore
+
+@Test("Runtime inspection preserves requested ordering")
+func runtimeInspectionPreservesOrdering() {
+    let useCase = InspectModelRuntimeUseCase(inspector: StubRuntimeInspector())
+
+    let results = useCase.execute(runtimes: [.privateCloudCompute, .onDevice])
+
+    #expect(results.map(\.runtime) == [.privateCloudCompute, .onDevice])
+    #expect(results.map(\.isRunnableInCurrentProcess) == [false, true])
+}
+
+@Test("Quota inspection reports system quota as not applicable")
+func quotaInspectionReportsSystemAsNotApplicable() {
+    let useCase = InspectModelQuotaUsageUseCase(inspector: StubRuntimeInspector())
+
+    let results = useCase.execute(runtimes: [.onDevice, .privateCloudCompute])
+
+    #expect(results.map(\.status) == [.notApplicable, .approachingLimit])
+}
+
+@Test("Missing managed entitlement makes PCC non-runnable")
+func missingEntitlementMakesPCCNonRunnable() {
+    let result = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: .missing,
+        reason: .missingEntitlement
+    )
+
+    #expect(result.isSupported)
+    #expect(!result.isRunnableInCurrentProcess)
+    #expect(result.authorization == .missing)
+}
+
+private struct StubRuntimeInspector: ModelRuntimeInspecting {
+    func status(for runtime: FoundationLabModelRuntime) -> ModelRuntimeStatusResult {
+        switch runtime {
+        case .onDevice:
+            return ModelRuntimeStatusResult(runtime: runtime, isAvailable: true)
+        case .privateCloudCompute:
+            return ModelRuntimeStatusResult(
+                runtime: runtime,
+                isAvailable: true,
+                authorization: .missing,
+                reason: .missingEntitlement
+            )
+        }
+    }
+
+    func quotaUsage(for runtime: FoundationLabModelRuntime) -> ModelQuotaUsageResult {
+        switch runtime {
+        case .onDevice:
+            return ModelQuotaUsageResult(runtime: runtime, status: .notApplicable)
+        case .privateCloudCompute:
+            return ModelQuotaUsageResult(runtime: runtime, status: .approachingLimit)
+        }
+    }
+}

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/ModelRuntimeInspectionTests.swift
@@ -23,10 +23,15 @@ func quotaInspectionReportsSystemAsNotApplicable() {
 
 @Test(
     "Unconfirmed managed entitlement makes PCC non-runnable",
-    arguments: [ModelRuntimeAuthorization.missing, .unknown, .notRequired]
+    arguments: [
+        (ModelRuntimeAuthorization.missing, ModelRuntimeUnavailableReason.missingEntitlement),
+        (.unknown, .unknown),
+        (.notRequired, .unknown)
+    ]
 )
 func unconfirmedEntitlementMakesPCCNonRunnable(
-    authorization: ModelRuntimeAuthorization
+    authorization: ModelRuntimeAuthorization,
+    expectedReason: ModelRuntimeUnavailableReason
 ) {
     let result = ModelRuntimeStatusResult(
         runtime: .privateCloudCompute,
@@ -37,6 +42,32 @@ func unconfirmedEntitlementMakesPCCNonRunnable(
     #expect(result.isSupported)
     #expect(!result.isRunnableInCurrentProcess)
     #expect(result.authorization == authorization)
+    #expect(result.reason == expectedReason)
+}
+
+@Test(
+    "Skipped PCC quota preserves the authorization failure reason",
+    arguments: [
+        (ModelRuntimeAuthorization.missing, ModelRuntimeUnavailableReason.missingEntitlement),
+        (.unknown, .unknown)
+    ]
+)
+func skippedPCCQuotaPreservesAuthorizationReason(
+    authorization: ModelRuntimeAuthorization,
+    expectedReason: ModelRuntimeUnavailableReason
+) throws {
+    let runtimeStatus = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: authorization
+    )
+
+    let result = try #require(
+        FoundationModelsRuntimeInspector().privateCloudUnavailableQuotaResult(for: runtimeStatus)
+    )
+
+    #expect(result.status == .unavailable)
+    #expect(result.unavailableReason == expectedReason)
 }
 
 @Test("Confirmed managed entitlement makes available PCC runnable")

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -46,6 +46,8 @@ These are good starting points after install:
 afm model status
 afm token-count "What is Swift?"
 afm token-count -i @instructions.md --prompt @prompt.md --breakdown
+afm available
+afm quota-usage --model pcc
 afm session respond --prompt "Summarize Foundation Models in one paragraph."
 afm session respond --adapter ~/MyAdapter.fmadapter --prompt "Rewrite this in my house style."
 afm session stream --prompt "Write a short poem about rain."
@@ -67,6 +69,21 @@ afm model languages
 afm model use-cases
 afm model guardrails
 ```
+
+Use the native-style runtime commands when automation needs both system and PCC
+status in one stable JSON shape:
+
+```bash
+afm available --output json
+afm available --model pcc
+afm quota-usage --model pcc --output json
+```
+
+PCC requires macOS 27, an Xcode 27-built `afm`, and Apple's managed
+`com.apple.developer.private-cloud-compute` entitlement in the running
+executable. The commands report those states separately. They do not treat the
+framework's device-level availability result as proof that the current process
+is authorized, and they do not invent a numeric quota that Apple doesn't expose.
 
 ### Count and budget tokens
 

--- a/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
@@ -19,7 +19,8 @@ struct AFMEntryPoint {
         guard !firstArgument.hasPrefix("-") else { return nil }
 
         let rootCommands = [
-            "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"
+            "available", "quota-usage", "model", "token-count", "tag", "session",
+            "schema", "tool", "transcript", "feedback", "help", "version"
         ]
         if !rootCommands.contains(firstArgument) {
             if let suggestion = suggestRootCommand(for: firstArgument) {

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
@@ -14,6 +14,8 @@ struct AFMRootCommand: AsyncParsableCommand {
         discussion: HelpText.root,
         version: "0.1.0",
         subcommands: [
+            AvailableCommand.self,
+            QuotaUsageCommand.self,
             ModelCommand.self,
             TokenCountCommand.self,
             TagCommand.self,
@@ -41,7 +43,10 @@ struct AFMRootCommand: AsyncParsableCommand {
         let payload = RootStatusPayload(
             name: Self.configuration.commandName ?? "afm",
             summary: "Workflow-first CLI for Foundation Models sessions, schemas, tools, transcripts, and feedback.",
-            commands: ["model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback"]
+            commands: [
+                "available", "quota-usage", "model", "token-count", "tag", "session",
+                "schema", "tool", "transcript", "feedback"
+            ]
         )
         let human: String
         if options.verbose {

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AvailableCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AvailableCommand.swift
@@ -1,0 +1,70 @@
+import ArgumentParser
+import Foundation
+import FoundationLabCore
+
+struct AvailableCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "available",
+        abstract: "Inspect on-device and Private Cloud Compute availability."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var selection: ModelSelectionOptions
+
+    mutating func run() async throws {
+        let resolvedOutput = try options.resolvedOutput()
+        if options.dryRun {
+            try CLIOutput.emit(
+                payload: RuntimeDryRunPayload(
+                    command: "available",
+                    model: selection.model?.rawValue
+                ),
+                human: "[dry-run] afm available\(modelSuffix)",
+                options: resolvedOutput
+            )
+            return
+        }
+
+        let results = InspectModelRuntimeUseCase().execute(runtimes: selection.runtimes)
+        let payload = AvailablePayload(models: results.map(AvailablePayload.Model.init))
+        let human = results.map(availableDescription).joined(separator: "\n")
+        try CLIOutput.emit(payload: payload, human: human, options: resolvedOutput)
+    }
+
+    private var modelSuffix: String {
+        selection.model.map { " --model \($0.rawValue)" } ?? ""
+    }
+}
+
+private struct AvailablePayload: Encodable {
+    struct Model: Encodable {
+        let id: String
+        let runtime: FoundationLabModelRuntime
+        let isSupported: Bool
+        let isAvailable: Bool
+        let isRunnableInCurrentProcess: Bool
+        let authorization: ModelRuntimeAuthorization
+        let reason: ModelRuntimeUnavailableReason?
+
+        init(_ result: ModelRuntimeStatusResult) {
+            id = modelIdentifier(for: result.runtime)
+            runtime = result.runtime
+            isSupported = result.isSupported
+            isAvailable = result.isAvailable
+            isRunnableInCurrentProcess = result.isRunnableInCurrentProcess
+            authorization = result.authorization
+            reason = result.reason
+        }
+    }
+
+    let command = "available"
+    let models: [Model]
+}
+
+private func availableDescription(_ result: ModelRuntimeStatusResult) -> String {
+    let name = modelDisplayName(for: result.runtime)
+    if result.isRunnableInCurrentProcess {
+        return "\(name): available"
+    }
+    return "\(name): unavailable (\(runtimeReasonDescription(result.reason)))"
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AvailableCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AvailableCommand.swift
@@ -61,10 +61,14 @@ private struct AvailablePayload: Encodable {
     let models: [Model]
 }
 
-private func availableDescription(_ result: ModelRuntimeStatusResult) -> String {
+func availableDescription(_ result: ModelRuntimeStatusResult) -> String {
     let name = modelDisplayName(for: result.runtime)
     if result.isRunnableInCurrentProcess {
         return "\(name): available"
+    }
+    if result.isAvailable {
+        let authorization = runtimeAuthorizationDescription(result.authorization)
+        return "\(name): available, but not runnable in this process (\(authorization))"
     }
     return "\(name): unavailable (\(runtimeReasonDescription(result.reason)))"
 }

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
@@ -375,6 +375,10 @@ func currentSupportedLanguageDisplayName(from languages: [SupportedLanguageDescr
 
 enum HelpText {
     static let root = """
+    RUNTIME COMMANDS
+      available     Inspect system and PCC readiness for the current process.
+      quota-usage   Inspect PCC quota state without inventing numeric usage.
+
     MODEL COMMANDS
       model        Inspect model readiness and supported languages.
 
@@ -398,6 +402,8 @@ enum HelpText {
       feedback     Export Foundation Models feedback attachments.
 
     QUICK START
+      afm available
+      afm quota-usage --model pcc
       afm model status
       afm model use-cases
       afm model guardrails
@@ -436,7 +442,10 @@ enum HelpText {
 }
 
 func suggestRootCommand(for input: String) -> String? {
-    let commands = ["model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "help", "version"]
+    let commands = [
+        "available", "quota-usage", "model", "token-count", "tag", "session",
+        "schema", "tool", "transcript", "feedback", "help", "version"
+    ]
     return suggestCommand(input, in: commands)
 }
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelRuntimePresentation.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelRuntimePresentation.swift
@@ -1,0 +1,37 @@
+import Foundation
+import FoundationLabCore
+
+struct RuntimeDryRunPayload: Encodable {
+    let status = "dry_run"
+    let command: String
+    let model: String?
+}
+
+func modelIdentifier(for runtime: FoundationLabModelRuntime) -> String {
+    runtime == .onDevice ? "system" : "pcc"
+}
+
+func modelDisplayName(for runtime: FoundationLabModelRuntime) -> String {
+    runtime == .onDevice ? "System" : "PCC"
+}
+
+func runtimeReasonDescription(_ reason: ModelRuntimeUnavailableReason?) -> String {
+    switch reason {
+    case .deviceNotEligible:
+        return "device is not eligible"
+    case .appleIntelligenceNotEnabled:
+        return "Apple Intelligence is disabled"
+    case .modelNotReady:
+        return "model assets are not ready"
+    case .systemNotReady:
+        return "PCC is not ready"
+    case .unsupportedOperatingSystem:
+        return "requires macOS 27 or later"
+    case .unsupportedToolchain:
+        return "requires an Xcode 27-built afm"
+    case .missingEntitlement:
+        return "current process lacks the managed PCC entitlement"
+    case .unknown, .none:
+        return "unknown reason"
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelRuntimePresentation.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelRuntimePresentation.swift
@@ -35,3 +35,16 @@ func runtimeReasonDescription(_ reason: ModelRuntimeUnavailableReason?) -> Strin
         return "unknown reason"
     }
 }
+
+func runtimeAuthorizationDescription(_ authorization: ModelRuntimeAuthorization) -> String {
+    switch authorization {
+    case .notRequired:
+        return "current-process authorization is not required"
+    case .granted:
+        return "current-process authorization is granted"
+    case .missing:
+        return "current process lacks the managed PCC entitlement"
+    case .unknown:
+        return "current-process authorization is unknown"
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelSelectionOptions.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ModelSelectionOptions.swift
@@ -1,0 +1,29 @@
+import ArgumentParser
+import Foundation
+import FoundationLabCore
+
+struct ModelSelectionOptions: ParsableArguments {
+    enum Model: String, CaseIterable, ExpressibleByArgument, Encodable {
+        case system
+        case pcc
+
+        var runtime: FoundationLabModelRuntime {
+            switch self {
+            case .system:
+                return .onDevice
+            case .pcc:
+                return .privateCloudCompute
+            }
+        }
+    }
+
+    @Option(
+        name: [.short, .long],
+        help: "Model to inspect (system or pcc). Inspects both when omitted."
+    )
+    var model: Model?
+
+    var runtimes: [FoundationLabModelRuntime] {
+        model.map { [$0.runtime] } ?? FoundationLabModelRuntime.allCases
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/QuotaUsageCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/QuotaUsageCommand.swift
@@ -1,0 +1,82 @@
+import ArgumentParser
+import Foundation
+import FoundationLabCore
+
+struct QuotaUsageCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "quota-usage",
+        abstract: "Inspect the current Private Cloud Compute quota state."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var selection: ModelSelectionOptions
+
+    mutating func run() async throws {
+        let resolvedOutput = try options.resolvedOutput()
+        if options.dryRun {
+            try CLIOutput.emit(
+                payload: RuntimeDryRunPayload(
+                    command: "quota-usage",
+                    model: selection.model?.rawValue
+                ),
+                human: "[dry-run] afm quota-usage\(modelSuffix)",
+                options: resolvedOutput
+            )
+            return
+        }
+
+        let results = InspectModelQuotaUsageUseCase().execute(runtimes: selection.runtimes)
+        let payload = QuotaUsagePayload(models: results.map(QuotaUsagePayload.Model.init))
+        let human = results.map(quotaDescription).joined(separator: "\n")
+        try CLIOutput.emit(payload: payload, human: human, options: resolvedOutput)
+    }
+
+    private var modelSuffix: String {
+        selection.model.map { " --model \($0.rawValue)" } ?? ""
+    }
+}
+
+private struct QuotaUsagePayload: Encodable {
+    struct Model: Encodable {
+        let id: String
+        let runtime: FoundationLabModelRuntime
+        let status: ModelQuotaStatus
+        let resetDate: Date?
+        let canRequestLimitIncrease: Bool
+        let unavailableReason: ModelRuntimeUnavailableReason?
+
+        init(_ result: ModelQuotaUsageResult) {
+            id = modelIdentifier(for: result.runtime)
+            runtime = result.runtime
+            status = result.status
+            resetDate = result.resetDate
+            canRequestLimitIncrease = result.canRequestLimitIncrease
+            unavailableReason = result.unavailableReason
+        }
+    }
+
+    let command = "quota-usage"
+    let models: [Model]
+}
+
+private func quotaDescription(_ result: ModelQuotaUsageResult) -> String {
+    let name = modelDisplayName(for: result.runtime)
+    switch result.status {
+    case .notApplicable:
+        return "\(name): not applicable (quota only applies to PCC)"
+    case .unavailable:
+        return "\(name): unavailable (\(runtimeReasonDescription(result.unavailableReason)))"
+    case .belowLimit:
+        return "\(name): available (below limit)"
+    case .approachingLimit:
+        return "\(name): available (approaching limit)"
+    case .limitReached:
+        return "\(name): limit reached\(resetDescription(result.resetDate))"
+    case .unsupported:
+        return "\(name): unsupported (\(runtimeReasonDescription(result.unavailableReason)))"
+    }
+}
+
+private func resetDescription(_ date: Date?) -> String {
+    date.map { "; resets \($0.formatted(date: .abbreviated, time: .shortened))" } ?? ""
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIAvailablePresentationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIAvailablePresentationTests.swift
@@ -1,0 +1,36 @@
+import FoundationLabCore
+import Testing
+@testable import AFMCLI
+
+@Test("Available text distinguishes framework availability from process authorization")
+func availableTextDistinguishesAvailabilityFromAuthorization() {
+    let unavailable = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: false,
+        authorization: .granted,
+        reason: .systemNotReady
+    )
+    let missingAuthorization = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: .missing,
+        reason: .missingEntitlement
+    )
+    let unknownAuthorization = ModelRuntimeStatusResult(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: .unknown
+    )
+
+    #expect(availableDescription(unavailable) == "PCC: unavailable (PCC is not ready)")
+    #expect(
+        availableDescription(missingAuthorization)
+            == "PCC: available, but not runnable in this process "
+                + "(current process lacks the managed PCC entitlement)"
+    )
+    #expect(
+        availableDescription(unknownAuthorization)
+            == "PCC: available, but not runnable in this process "
+                + "(current-process authorization is unknown)"
+    )
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIAvailablePresentationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIAvailablePresentationTests.swift
@@ -34,3 +34,22 @@ func availableTextDistinguishesAvailabilityFromAuthorization() {
                 + "(current-process authorization is unknown)"
     )
 }
+
+@Test("Runtime commands expose truthful structured status")
+func runtimeCommandsExposeStructuredStatus() throws {
+    let available = try runAFM("available", "--output", "json")
+    let quota = try runAFM("quota-usage", "--output", "json")
+
+    #expect(available.status == 0)
+    #expect(quota.status == 0)
+
+    let availableJSON = try parseJSONObject(available.stdout)
+    let availableModels = try #require(availableJSON["models"] as? [[String: Any]])
+    #expect(availableModels.compactMap { $0["id"] as? String } == ["system", "pcc"])
+    #expect(availableModels.allSatisfy { $0["isRunnableInCurrentProcess"] is Bool })
+
+    let quotaJSON = try parseJSONObject(quota.stdout)
+    let quotaModels = try #require(quotaJSON["models"] as? [[String: Any]])
+    #expect(quotaModels.compactMap { $0["id"] as? String } == ["system", "pcc"])
+    #expect(quotaModels.first?["status"] as? String == "notApplicable")
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -39,6 +39,8 @@ func rootDryRun() throws {
 @Test("Leaf command help covers every shipped public workflow")
 func leafCommandHelpCoverage() throws {
     let commands: [[String]] = [
+        ["available", "--help"],
+        ["quota-usage", "--help"],
         ["model", "status", "--help"],
         ["model", "languages", "--help"],
         ["model", "use-cases", "--help"],
@@ -74,23 +76,50 @@ func leafCommandHelpCoverage() throws {
 
 @Test("Model and schema discovery commands honor dry-run")
 func discoveryCommandsHonorDryRun() throws {
+    let available = try runAFM("available", "--model", "pcc", "--output", "json", "--dry-run")
+    let quota = try runAFM("quota-usage", "--model", "system", "--output", "json", "--dry-run")
     let status = try runAFM("model", "status", "--output", "json", "--dry-run")
     let languages = try runAFM("model", "languages", "--output", "json", "--dry-run")
     let useCases = try runAFM("model", "use-cases", "--output", "json", "--dry-run")
     let guardrails = try runAFM("model", "guardrails", "--output", "json", "--dry-run")
     let schemaList = try runAFM("schema", "list", "--output", "json", "--dry-run")
 
+    #expect(available.status == 0)
+    #expect(quota.status == 0)
     #expect(status.status == 0)
     #expect(languages.status == 0)
     #expect(useCases.status == 0)
     #expect(guardrails.status == 0)
     #expect(schemaList.status == 0)
 
+    #expect((try parseJSONObject(available.stdout))["command"] as? String == "available")
+    #expect((try parseJSONObject(available.stdout))["model"] as? String == "pcc")
+    #expect((try parseJSONObject(quota.stdout))["command"] as? String == "quota-usage")
+    #expect((try parseJSONObject(quota.stdout))["model"] as? String == "system")
     #expect((try parseJSONObject(status.stdout))["command"] as? String == "model status")
     #expect((try parseJSONObject(languages.stdout))["command"] as? String == "model languages")
     #expect((try parseJSONObject(useCases.stdout))["command"] as? String == "model use-cases")
     #expect((try parseJSONObject(guardrails.stdout))["command"] as? String == "model guardrails")
     #expect((try parseJSONObject(schemaList.stdout))["command"] as? String == "schema list")
+}
+
+@Test("Runtime commands expose truthful structured status")
+func runtimeCommandsExposeStructuredStatus() throws {
+    let available = try runAFM("available", "--output", "json")
+    let quota = try runAFM("quota-usage", "--output", "json")
+
+    #expect(available.status == 0)
+    #expect(quota.status == 0)
+
+    let availableJSON = try parseJSONObject(available.stdout)
+    let availableModels = try #require(availableJSON["models"] as? [[String: Any]])
+    #expect(availableModels.compactMap { $0["id"] as? String } == ["system", "pcc"])
+    #expect(availableModels.allSatisfy { $0["isRunnableInCurrentProcess"] is Bool })
+
+    let quotaJSON = try parseJSONObject(quota.stdout)
+    let quotaModels = try #require(quotaJSON["models"] as? [[String: Any]])
+    #expect(quotaModels.compactMap { $0["id"] as? String } == ["system", "pcc"])
+    #expect(quotaModels.first?["status"] as? String == "notApplicable")
 }
 
 @Test("TTY-aware defaults choose text for terminals and json for pipes")

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -103,25 +103,6 @@ func discoveryCommandsHonorDryRun() throws {
     #expect((try parseJSONObject(schemaList.stdout))["command"] as? String == "schema list")
 }
 
-@Test("Runtime commands expose truthful structured status")
-func runtimeCommandsExposeStructuredStatus() throws {
-    let available = try runAFM("available", "--output", "json")
-    let quota = try runAFM("quota-usage", "--output", "json")
-
-    #expect(available.status == 0)
-    #expect(quota.status == 0)
-
-    let availableJSON = try parseJSONObject(available.stdout)
-    let availableModels = try #require(availableJSON["models"] as? [[String: Any]])
-    #expect(availableModels.compactMap { $0["id"] as? String } == ["system", "pcc"])
-    #expect(availableModels.allSatisfy { $0["isRunnableInCurrentProcess"] is Bool })
-
-    let quotaJSON = try parseJSONObject(quota.stdout)
-    let quotaModels = try #require(quotaJSON["models"] as? [[String: Any]])
-    #expect(quotaModels.compactMap { $0["id"] as? String } == ["system", "pcc"])
-    #expect(quotaModels.first?["status"] as? String == "notApplicable")
-}
-
 @Test("TTY-aware defaults choose text for terminals and json for pipes")
 func ttyAwareOutputDefaults() throws {
     let textResult = try runAFM(


### PR DESCRIPTION
## Summary

- add native-style `afm available` and `afm quota-usage` commands with text and structured JSON output
- add shared FoundationLabCore runtime and quota inspection results for the on-device and PCC models
- keep PCC APIs behind Swift 6.4/Xcode 27 and OS 27 checks while returning explicit unsupported results from Xcode 26 builds
- inspect the current macOS process for `com.apple.developer.private-cloud-compute` so device-level PCC availability is not misreported as executable authorization
- expose only Apple’s quota states (below, approaching, reached) and never invent a numeric quota

## Why the authorization check matters

On this macOS 27 machine, `PrivateCloudComputeLanguageModel.availability` reports available in an unsigned Swift process, but an actual request requires the managed entitlement. The new result keeps `isAvailable`, `authorization`, and `isRunnableInCurrentProcess` separate so automation can make the right decision.

## Validation

- `swiftlint lint --strict --config .swiftlint-core-cli.yml`
- Xcode 26.6 RC2: `swift build --product afm`
- Xcode 27 beta: `swift build --product afm`
- Xcode 26.6 RC2: all 25 AFM CLI tests
- Xcode 27 beta: all 25 AFM CLI tests
- FoundationLabCore tests under both toolchains
- live JSON checks for supported, missing-entitlement, unsupported-toolchain, and not-applicable quota states
- `git diff --check`