### PR TITLE
Add OpenAI-compatible chat completions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,7 @@ let package = Package(
         .target(
             name: "AFMServer",
             dependencies: [
+                "FoundationModelsKit",
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio")
@@ -114,6 +115,7 @@ let package = Package(
             name: "AFMServerTests",
             dependencies: [
                 "AFMServer",
+                "FoundationModelsKit",
                 .product(name: "NIOEmbedded", package: "swift-nio")
             ],
             path: "Tools/AFMCLI/Tests/AFMServerTests"

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -173,15 +173,30 @@ afm feedback export --prompt "What is the capital of France?" --sentiment positi
 
 ### Start the local server
 
-`afm serve` starts a transport for local integrations. This first server surface
-provides `GET /health` and `GET /v1/models`; model inference endpoints are added
-separately.
+`afm serve` starts a transport for local integrations. It provides `GET /health`,
+`GET /v1/models`, and non-streaming `POST /v1/chat/completions`.
 
 ```bash
 afm serve
 curl http://127.0.0.1:1976/health
 curl http://127.0.0.1:1976/v1/models
+curl http://127.0.0.1:1976/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"system","messages":[{"role":"user","content":"Hello"}]}'
 ```
+
+Chat requests are stateless: send the complete system, developer, user,
+assistant, and tool history each time. String content and typed text parts are
+supported, along with `temperature`, `top_p`, `max_completion_tokens`, and the
+legacy `max_tokens` alias. Streaming, image parts, response formats, and
+client-defined tools return a precise `400` until their dedicated endpoints are
+implemented. Responses include input/output usage plus an `afm_measurement`
+value of `observed`, `tokenized`, or `estimated` so fallback counts are never
+presented as runtime observation.
+
+Generation concurrency defaults to one and excess requests receive `429`
+without being queued. Configure it with `--max-concurrent-generations`; use
+`--model-timeout` to change the default 120-second timeout.
 
 The default listener is loopback-only. Cross-site requests are rejected unless
 their exact origin is passed with `--allow-origin`. Add bearer authentication

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ServeCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ServeCommand.swift
@@ -36,6 +36,18 @@ struct ServeCommand: AsyncParsableCommand {
     )
     var allowedOrigins: [String] = []
 
+    @Option(
+        name: .customLong("max-concurrent-generations"),
+        help: "Maximum in-flight model generations. Defaults to 1."
+    )
+    var maximumConcurrentGenerations = 1
+
+    @Option(
+        name: .customLong("model-timeout"),
+        help: "Model generation timeout in seconds. Defaults to 120."
+    )
+    var modelTimeoutSeconds: Double = 120
+
     mutating func run() async throws {
         let output = try options.resolvedOutput()
         let serverConfiguration = try resolvedServerConfiguration()
@@ -115,6 +127,10 @@ struct ServeCommand: AsyncParsableCommand {
                 allowNetwork: allowNetwork,
                 bearerToken: bearerToken ?? environmentToken,
                 allowedOrigins: Set(allowedOrigins)
+            ),
+            generation: .init(
+                maximumConcurrentGenerations: maximumConcurrentGenerations,
+                timeoutSeconds: modelTimeoutSeconds
             )
         )
         do {
@@ -148,6 +164,8 @@ private struct ServeDryRunPayload: Encodable {
     let endpoint: String
     let authenticationEnabled: Bool
     let allowedOrigins: [String]
+    let maximumConcurrentGenerations: Int
+    let modelTimeoutSeconds: Double
 
     init(configuration: AFMServerConfiguration) {
         switch configuration.endpoint {
@@ -158,6 +176,8 @@ private struct ServeDryRunPayload: Encodable {
         }
         authenticationEnabled = configuration.security.bearerToken != nil
         allowedOrigins = configuration.security.allowedOrigins.sorted()
+        maximumConcurrentGenerations = configuration.generation.maximumConcurrentGenerations
+        modelTimeoutSeconds = configuration.generation.timeoutSeconds
     }
 }
 
@@ -169,6 +189,8 @@ private struct ServeStartedPayload: Encodable {
     let authenticationEnabled: Bool
     let allowedOrigins: [String]
     let networkExposed: Bool
+    let maximumConcurrentGenerations: Int
+    let modelTimeoutSeconds: Double
 
     init(address: AFMServerBoundAddress, configuration: AFMServerConfiguration) {
         switch address {
@@ -182,6 +204,8 @@ private struct ServeStartedPayload: Encodable {
         }
         authenticationEnabled = configuration.security.bearerToken != nil
         allowedOrigins = configuration.security.allowedOrigins.sorted()
+        maximumConcurrentGenerations = configuration.generation.maximumConcurrentGenerations
+        modelTimeoutSeconds = configuration.generation.timeoutSeconds
         if case .tcp(let host, _) = configuration.endpoint {
             let normalizedHost = host.lowercased()
             networkExposed = !normalizedHost.hasPrefix("127.")

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChatCompletionRequest.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChatCompletionRequest.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+public enum AFMChatRole: String, Sendable, Equatable {
+    case system
+    case developer
+    case user
+    case assistant
+    case tool
+}
+
+public struct AFMChatToolCall: Sendable, Equatable {
+    public let id: String
+    public let name: String
+    public let arguments: String
+
+    public init(id: String, name: String, arguments: String) {
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+    }
+}
+
+public struct AFMChatMessage: Sendable, Equatable {
+    public let role: AFMChatRole
+    public let contentSegments: [String]?
+    public let name: String?
+    public let toolCallID: String?
+    public let toolCalls: [AFMChatToolCall]
+
+    public init(
+        role: AFMChatRole,
+        contentSegments: [String]? = nil,
+        name: String? = nil,
+        toolCallID: String? = nil,
+        toolCalls: [AFMChatToolCall] = []
+    ) {
+        self.role = role
+        self.contentSegments = contentSegments
+        self.name = name
+        self.toolCallID = toolCallID
+        self.toolCalls = toolCalls
+    }
+}
+
+public struct AFMChatGenerationRequest: Sendable, Equatable {
+    public let model: String
+    public let messages: [AFMChatMessage]
+    public let temperature: Double?
+    public let topP: Double?
+    public let maximumCompletionTokens: Int?
+
+    public init(
+        model: String = "system",
+        messages: [AFMChatMessage],
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        maximumCompletionTokens: Int? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.temperature = temperature
+        self.topP = topP
+        self.maximumCompletionTokens = maximumCompletionTokens
+    }
+}
+
+extension AFMChatGenerationRequest: Decodable {
+    private static let allowedFields: Set<String> = [
+        "model", "messages", "stream", "temperature", "top_p",
+        "max_completion_tokens", "max_tokens", "tools", "tool_choice",
+        "response_format", "stream_options"
+    ]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        try rejectUnsupportedFields(
+            ["tools", "tool_choice", "response_format", "stream_options"],
+            in: container,
+            decoder: decoder
+        )
+
+        if try container.decodeIfPresent(Bool.self, forKey: .init("stream")) == true {
+            throw AFMChatRequestValidationError.unsupportedField("stream")
+        }
+
+        let model = try container.decodeIfPresent(String.self, forKey: .init("model")) ?? "system"
+        guard container.contains(.init("messages")) else {
+            throw AFMChatRequestValidationError.missingField("messages")
+        }
+        let messages = try container.decode([AFMChatMessage].self, forKey: .init("messages"))
+        let temperature = try container.decodeIfPresent(Double.self, forKey: .init("temperature"))
+        let topP = try container.decodeIfPresent(Double.self, forKey: .init("top_p"))
+        let maximumCompletionTokens = try container.decodeIfPresent(
+            Int.self,
+            forKey: .init("max_completion_tokens")
+        )
+        let legacyMaximumTokens = try container.decodeIfPresent(Int.self, forKey: .init("max_tokens"))
+
+        try Self.validateModel(model)
+        try Self.validateOptions(
+            temperature: temperature,
+            topP: topP,
+            maximumCompletionTokens: maximumCompletionTokens,
+            legacyMaximumTokens: legacyMaximumTokens
+        )
+        try Self.validateMessages(messages)
+
+        self.init(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            topP: topP,
+            maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens
+        )
+    }
+
+    static func decode(_ data: Data) throws -> Self {
+        do {
+            return try JSONDecoder().decode(Self.self, from: data)
+        } catch let error as AFMChatRequestValidationError {
+            throw error
+        } catch let error as DecodingError {
+            throw AFMChatRequestValidationError(decodingError: error)
+        } catch {
+            throw AFMChatRequestValidationError.malformedJSON
+        }
+    }
+
+    private static func validateModel(_ model: String) throws {
+        guard !model.isEmpty, model == model.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            throw AFMChatRequestValidationError.invalidField("model", message: "Model must be a non-empty identifier.")
+        }
+    }
+
+    private static func validateOptions(
+        temperature: Double?,
+        topP: Double?,
+        maximumCompletionTokens: Int?,
+        legacyMaximumTokens: Int?
+    ) throws {
+        if let temperature, !temperature.isFinite || !(0...1).contains(temperature) {
+            throw AFMChatRequestValidationError.invalidField(
+                "temperature",
+                message: "Temperature must be between 0 and 1."
+            )
+        }
+        if let topP, !topP.isFinite || topP <= 0 || topP > 1 {
+            throw AFMChatRequestValidationError.invalidField("top_p", message: "top_p must be greater than 0 and at most 1.")
+        }
+        if maximumCompletionTokens != nil, legacyMaximumTokens != nil {
+            throw AFMChatRequestValidationError.invalidField(
+                "max_tokens",
+                message: "Use either max_completion_tokens or max_tokens, not both."
+            )
+        }
+        if let maximumTokens = maximumCompletionTokens ?? legacyMaximumTokens, maximumTokens <= 0 {
+            let parameter = maximumCompletionTokens == nil ? "max_tokens" : "max_completion_tokens"
+            throw AFMChatRequestValidationError.invalidField(parameter, message: "The token limit must be greater than zero.")
+        }
+    }
+}
+
+struct AFMChatRequestValidationError: Error, Equatable, Sendable {
+    let message: String
+    let parameter: String?
+    let code: String
+
+    static let malformedJSON = Self(
+        message: "The request body must be a valid JSON object.",
+        parameter: nil,
+        code: "invalid_json"
+    )
+
+    static func missingField(_ parameter: String) -> Self {
+        .init(message: "Missing required field '\(parameter)'.", parameter: parameter, code: "missing_field")
+    }
+
+    static func invalidField(_ parameter: String, message: String) -> Self {
+        .init(message: message, parameter: parameter, code: "invalid_field")
+    }
+
+    static func unsupportedField(_ parameter: String) -> Self {
+        .init(
+            message: "Field '\(parameter)' is not supported by non-streaming chat completions yet.",
+            parameter: parameter,
+            code: "unsupported_field"
+        )
+    }
+
+    static func unknownField(_ parameter: String) -> Self {
+        .init(message: "Unknown field '\(parameter)'.", parameter: parameter, code: "unknown_field")
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChatCompletionResponse.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChatCompletionResponse.swift
@@ -1,0 +1,155 @@
+import Foundation
+import FoundationModelsKit
+
+public enum AFMChatFinishReason: String, Sendable, Equatable, Encodable {
+    case stop
+    case contentFilter = "content_filter"
+}
+
+public struct AFMChatGenerationResult: Sendable, Equatable {
+    public let content: String?
+    public let refusal: String?
+    public let finishReason: AFMChatFinishReason
+    public let usage: ModelTokenUsage
+
+    public init(
+        content: String?,
+        refusal: String? = nil,
+        finishReason: AFMChatFinishReason = .stop,
+        usage: ModelTokenUsage
+    ) {
+        self.content = content
+        self.refusal = refusal
+        self.finishReason = finishReason
+        self.usage = usage
+    }
+}
+
+public protocol AFMChatCompletionGenerating: Sendable {
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult
+}
+
+public enum AFMChatGenerationError: Error, Sendable, Equatable {
+    case contextLengthExceeded
+    case modelUnavailable
+    case rateLimited
+    case safetyViolation
+    case unsupportedInput
+    case concurrentRequest
+    case timedOut
+}
+
+struct AFMChatCompletionPayload: Encodable {
+    struct Choice: Encodable {
+        struct Message: Encodable {
+            let role = "assistant"
+            let content: String?
+            let refusal: String?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(role, forKey: .role)
+                try container.encodeIfPresentOrNil(content, forKey: .content)
+                try container.encodeIfPresentOrNil(refusal, forKey: .refusal)
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case role
+                case content
+                case refusal
+            }
+        }
+
+        let index: Int
+        let message: Message
+        let finishReason: AFMChatFinishReason
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(index, forKey: .index)
+            try container.encode(message, forKey: .message)
+            try container.encodeNil(forKey: .logprobs)
+            try container.encode(finishReason, forKey: .finishReason)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case index
+            case message
+            case logprobs
+            case finishReason = "finish_reason"
+        }
+    }
+
+    let id: String
+    let object = "chat.completion"
+    let created: Int64
+    let model: String
+    let choices: [Choice]
+    let usage: AFMChatUsagePayload
+}
+
+struct AFMChatUsagePayload: Encodable {
+    struct PromptDetails: Encodable {
+        let cachedTokens: Int?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresentOrNil(cachedTokens, forKey: .cachedTokens)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case cachedTokens = "cached_tokens"
+        }
+    }
+
+    struct CompletionDetails: Encodable {
+        let reasoningTokens: Int?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresentOrNil(reasoningTokens, forKey: .reasoningTokens)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case reasoningTokens = "reasoning_tokens"
+        }
+    }
+
+    let promptTokens: Int
+    let completionTokens: Int
+    let totalTokens: Int
+    let promptTokensDetails: PromptDetails
+    let completionTokensDetails: CompletionDetails
+    let measurement: ModelTokenUsage.Measurement
+    let scope: ModelTokenUsage.Scope
+
+    init(_ usage: ModelTokenUsage) {
+        promptTokens = usage.input.totalTokenCount
+        completionTokens = usage.output?.totalTokenCount ?? 0
+        totalTokens = usage.totalTokenCount
+        promptTokensDetails = .init(cachedTokens: usage.input.cachedTokenCount)
+        completionTokensDetails = .init(reasoningTokens: usage.output?.reasoningTokenCount)
+        measurement = usage.measurement
+        scope = usage.scope
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case completionTokens = "completion_tokens"
+        case totalTokens = "total_tokens"
+        case promptTokensDetails = "prompt_tokens_details"
+        case completionTokensDetails = "completion_tokens_details"
+        case measurement = "afm_measurement"
+        case scope = "afm_scope"
+    }
+}
+
+private extension KeyedEncodingContainer {
+    mutating func encodeIfPresentOrNil<T: Encodable>(_ value: T?, forKey key: Key) throws {
+        if let value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChatCompletionService.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChatCompletionService.swift
@@ -1,0 +1,209 @@
+import Foundation
+import NIOHTTP1
+
+actor AFMGenerationGate {
+    private var availablePermits: Int
+
+    init(limit: Int) {
+        availablePermits = limit
+    }
+
+    func tryAcquire() -> Bool {
+        guard availablePermits > 0 else { return false }
+        availablePermits -= 1
+        return true
+    }
+
+    func release() {
+        availablePermits += 1
+    }
+}
+
+struct AFMChatCompletionService: Sendable {
+    private let catalog: any AFMModelCatalog
+    private let generator: any AFMChatCompletionGenerating
+    private let clock: any AFMServerClock
+    private let gate: AFMGenerationGate
+    private let timeoutSeconds: Double
+
+    init(
+        catalog: any AFMModelCatalog,
+        generator: any AFMChatCompletionGenerating,
+        clock: any AFMServerClock,
+        policy: AFMServerGenerationPolicy
+    ) {
+        self.catalog = catalog
+        self.generator = generator
+        self.clock = clock
+        gate = AFMGenerationGate(limit: policy.maximumConcurrentGenerations)
+        timeoutSeconds = policy.timeoutSeconds
+    }
+
+    func response(for body: Data) async throws -> AFMHTTPResponse {
+        let request: AFMChatGenerationRequest
+        do {
+            request = try AFMChatGenerationRequest.decode(body)
+        } catch let error as AFMChatRequestValidationError {
+            return validationErrorResponse(error)
+        }
+
+        if let modelError = validateModel(request.model) {
+            return modelError
+        }
+        guard await gate.tryAcquire() else {
+            return .apiError(
+                status: .tooManyRequests,
+                message: "The local model is already handling the configured number of requests.",
+                code: "server_busy",
+                type: "rate_limit_error"
+            )
+        }
+
+        do {
+            let result = try await generateWithTimeout(request)
+            await gate.release()
+            return completionResponse(result, request: request)
+        } catch is CancellationError {
+            await gate.release()
+            throw CancellationError()
+        } catch {
+            await gate.release()
+            return generationErrorResponse(error)
+        }
+    }
+
+    private func validateModel(_ identifier: String) -> AFMHTTPResponse? {
+        guard let model = catalog.models().first(where: { $0.id == identifier }) else {
+            return .apiError(
+                status: .notFound,
+                message: "Model '\(identifier)' does not exist.",
+                code: "model_not_found",
+                parameter: "model"
+            )
+        }
+        guard model.isAvailable else {
+            return .apiError(
+                status: .serviceUnavailable,
+                message: "Model '\(identifier)' is not currently available on this Mac.",
+                code: "model_unavailable",
+                type: "server_error",
+                parameter: "model"
+            )
+        }
+        return nil
+    }
+
+    private func generateWithTimeout(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        try await withThrowingTaskGroup(of: AFMChatGenerationResult.self) { group in
+            group.addTask {
+                try await generator.generate(request)
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: .seconds(timeoutSeconds))
+                throw AFMChatServiceError.timedOut
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw AFMChatServiceError.missingResult
+            }
+            return result
+        }
+    }
+
+    private func completionResponse(
+        _ result: AFMChatGenerationResult,
+        request: AFMChatGenerationRequest
+    ) -> AFMHTTPResponse {
+        .json(
+            body: AFMChatCompletionPayload(
+                id: "chatcmpl-\(UUID().uuidString)",
+                created: clock.unixTime(),
+                model: request.model,
+                choices: [
+                    .init(
+                        index: 0,
+                        message: .init(content: result.content, refusal: result.refusal),
+                        finishReason: result.finishReason
+                    )
+                ],
+                usage: .init(result.usage)
+            )
+        )
+    }
+
+    private func validationErrorResponse(_ error: AFMChatRequestValidationError) -> AFMHTTPResponse {
+        .apiError(
+            status: .badRequest,
+            message: error.message,
+            code: error.code,
+            parameter: error.parameter
+        )
+    }
+
+    private func generationErrorResponse(_ error: Error) -> AFMHTTPResponse {
+        switch error {
+        case AFMChatServiceError.timedOut:
+            .apiError(
+                status: .gatewayTimeout,
+                message: "The local model did not finish before the configured timeout.",
+                code: "model_timeout",
+                type: "server_error"
+            )
+        case AFMChatGenerationError.contextLengthExceeded:
+            generationFailure(
+                .badRequest,
+                "The conversation exceeds the model context window.",
+                "context_length_exceeded",
+                type: "invalid_request_error"
+            )
+        case AFMChatGenerationError.modelUnavailable:
+            generationFailure(.serviceUnavailable, "The local model became unavailable.", "model_unavailable")
+        case AFMChatGenerationError.rateLimited:
+            generationFailure(
+                .tooManyRequests,
+                "The local model is temporarily rate limited.",
+                "rate_limited",
+                type: "rate_limit_error"
+            )
+        case AFMChatGenerationError.safetyViolation:
+            generationFailure(
+                .badRequest,
+                "The request was blocked by the model safety guardrails.",
+                "safety_violation",
+                type: "invalid_request_error"
+            )
+        case AFMChatGenerationError.unsupportedInput:
+            generationFailure(
+                .badRequest,
+                "The conversation contains content the model cannot process.",
+                "unsupported_input",
+                type: "invalid_request_error"
+            )
+        case AFMChatGenerationError.concurrentRequest:
+            generationFailure(
+                .tooManyRequests,
+                "The local model rejected a concurrent request.",
+                "server_busy",
+                type: "rate_limit_error"
+            )
+        case AFMChatGenerationError.timedOut:
+            generationFailure(.gatewayTimeout, "The local model request timed out.", "model_timeout")
+        default:
+            generationFailure(.internalServerError, "The local model request failed.", "model_error")
+        }
+    }
+
+    private func generationFailure(
+        _ status: HTTPResponseStatus,
+        _ message: String,
+        _ code: String,
+        type: String = "server_error"
+    ) -> AFMHTTPResponse {
+        .apiError(status: status, message: message, code: code, type: type)
+    }
+}
+
+private enum AFMChatServiceError: Error {
+    case timedOut
+    case missingResult
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChatMessageDecoding.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChatMessageDecoding.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+extension AFMChatMessage: Decodable {
+    private static let allowedFields: Set<String> = [
+        "role", "content", "name", "tool_call_id", "tool_calls", "reasoning_content"
+    ]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        try rejectUnsupportedFields(["reasoning_content"], in: container, decoder: decoder)
+
+        guard container.contains(.init("role")) else {
+            throw AFMChatRequestValidationError.missingField(parameterPath(decoder.codingPath, field: "role"))
+        }
+        let roleValue = try container.decode(String.self, forKey: .init("role"))
+        guard let role = AFMChatRole(rawValue: roleValue) else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "role"),
+                message: "Unsupported message role '\(roleValue)'."
+            )
+        }
+
+        let content = try container.decodeIfPresent(AFMChatContent.self, forKey: .init("content"))
+        let name = try container.decodeIfPresent(String.self, forKey: .init("name"))
+        let toolCallID = try container.decodeIfPresent(String.self, forKey: .init("tool_call_id"))
+        let toolCalls = try container.decodeIfPresent([AFMChatToolCall].self, forKey: .init("tool_calls")) ?? []
+        let fields = AFMChatMessageFields(
+            role: role,
+            content: content,
+            name: name,
+            toolCallID: toolCallID,
+            toolCalls: toolCalls
+        )
+        try Self.validateRoleFields(fields, codingPath: decoder.codingPath)
+
+        self.init(
+            role: role,
+            contentSegments: content?.segments,
+            name: name,
+            toolCallID: toolCallID,
+            toolCalls: toolCalls
+        )
+    }
+
+    private static func validateRoleFields(
+        _ fields: AFMChatMessageFields,
+        codingPath: [any CodingKey]
+    ) throws {
+        switch fields.role {
+        case .system, .developer, .user:
+            try requireContent(fields.content, codingPath: codingPath)
+            try rejectToolFields(
+                name: fields.name,
+                toolCallID: fields.toolCallID,
+                toolCalls: fields.toolCalls,
+                codingPath: codingPath
+            )
+        case .assistant:
+            guard fields.content?.hasMeaningfulText == true || !fields.toolCalls.isEmpty else {
+                throw AFMChatRequestValidationError.invalidField(
+                    parameterPath(codingPath, field: "content"),
+                    message: "Assistant messages require content or tool_calls."
+                )
+            }
+            if fields.name != nil {
+                throw AFMChatRequestValidationError.unsupportedField(parameterPath(codingPath, field: "name"))
+            }
+            if fields.toolCallID != nil {
+                throw AFMChatRequestValidationError.unsupportedField(
+                    parameterPath(codingPath, field: "tool_call_id")
+                )
+            }
+        case .tool:
+            try requireContent(fields.content, codingPath: codingPath)
+            guard let toolCallID = fields.toolCallID, !toolCallID.isEmpty else {
+                throw AFMChatRequestValidationError.missingField(parameterPath(codingPath, field: "tool_call_id"))
+            }
+            guard fields.toolCalls.isEmpty else {
+                throw AFMChatRequestValidationError.unsupportedField(parameterPath(codingPath, field: "tool_calls"))
+            }
+            if let name = fields.name, name.isEmpty {
+                throw AFMChatRequestValidationError.invalidField(
+                    parameterPath(codingPath, field: "name"),
+                    message: "Tool names cannot be empty."
+                )
+            }
+        }
+    }
+
+    private static func requireContent(_ content: AFMChatContent?, codingPath: [any CodingKey]) throws {
+        guard content?.hasMeaningfulText == true else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(codingPath, field: "content"),
+                message: "Message content must contain non-empty text."
+            )
+        }
+    }
+
+    private static func rejectToolFields(
+        name: String?,
+        toolCallID: String?,
+        toolCalls: [AFMChatToolCall],
+        codingPath: [any CodingKey]
+    ) throws {
+        if name != nil {
+            throw AFMChatRequestValidationError.unsupportedField(parameterPath(codingPath, field: "name"))
+        }
+        if toolCallID != nil {
+            throw AFMChatRequestValidationError.unsupportedField(parameterPath(codingPath, field: "tool_call_id"))
+        }
+        if !toolCalls.isEmpty {
+            throw AFMChatRequestValidationError.unsupportedField(parameterPath(codingPath, field: "tool_calls"))
+        }
+    }
+}
+
+private struct AFMChatMessageFields {
+    let role: AFMChatRole
+    let content: AFMChatContent?
+    let name: String?
+    let toolCallID: String?
+    let toolCalls: [AFMChatToolCall]
+}
+
+extension AFMChatToolCall: Decodable {
+    private static let allowedFields: Set<String> = ["id", "type", "function"]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        let id = try container.decode(String.self, forKey: .init("id"))
+        let type = try container.decode(String.self, forKey: .init("type"))
+        guard type == "function" else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "type"),
+                message: "Only function tool calls are supported in message history."
+            )
+        }
+        let function = try container.decode(AFMChatToolFunction.self, forKey: .init("function"))
+        guard !id.isEmpty else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "id"),
+                message: "Tool call IDs cannot be empty."
+            )
+        }
+        self.init(id: id, name: function.name, arguments: function.arguments)
+    }
+}
+
+private struct AFMChatToolFunction: Decodable {
+    let name: String
+    let arguments: String
+
+    private static let allowedFields: Set<String> = ["name", "arguments"]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        name = try container.decode(String.self, forKey: .init("name"))
+        arguments = try container.decode(String.self, forKey: .init("arguments"))
+        guard !name.isEmpty else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "name"),
+                message: "Tool names cannot be empty."
+            )
+        }
+        guard arguments.isJSONObject else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "arguments"),
+                message: "Tool arguments must be a JSON object encoded as a string."
+            )
+        }
+    }
+}
+
+private struct AFMChatContent: Decodable {
+    let segments: [String]
+
+    var hasMeaningfulText: Bool {
+        segments.contains { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            segments = [value]
+            return
+        }
+        do {
+            let parts = try container.decode([AFMChatContentPart].self)
+            guard !parts.isEmpty else {
+                throw AFMChatRequestValidationError.invalidField(
+                    parameterPath(decoder.codingPath),
+                    message: "Content arrays cannot be empty."
+                )
+            }
+            segments = parts.map(\.text)
+            return
+        } catch let error as AFMChatRequestValidationError {
+            throw error
+        } catch {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath),
+                message: "Content must be a string or an array of text parts."
+            )
+        }
+    }
+}
+
+private struct AFMChatContentPart: Decodable {
+    let text: String
+
+    private static let allowedFields: Set<String> = ["type", "text", "image_url"]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        if container.contains(.init("image_url")), try !container.decodeNil(forKey: .init("image_url")) {
+            throw AFMChatRequestValidationError.unsupportedField(
+                parameterPath(decoder.codingPath, field: "image_url")
+            )
+        }
+        let type = try container.decode(String.self, forKey: .init("type"))
+        guard type == "text" else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "type"),
+                message: "Only text content parts are supported by this endpoint."
+            )
+        }
+        text = try container.decode(String.self, forKey: .init("text"))
+    }
+}
+
+private extension String {
+    var isJSONObject: Bool {
+        guard let data = data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              object is [String: Any] else {
+            return false
+        }
+        return true
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMChatRequestValidation.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMChatRequestValidation.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+extension AFMChatGenerationRequest {
+    static func validateMessages(_ messages: [AFMChatMessage]) throws {
+        guard !messages.isEmpty else {
+            throw AFMChatRequestValidationError.invalidField(
+                "messages",
+                message: "At least one message is required."
+            )
+        }
+
+        var hasConversationStarted = false
+        var pendingToolCalls: [String: String] = [:]
+        var seenToolCallIDs: Set<String> = []
+        for (index, message) in messages.enumerated() {
+            let basePath = "messages[\(index)]"
+            if message.role == .system || message.role == .developer {
+                guard !hasConversationStarted else {
+                    throw AFMChatRequestValidationError.invalidField(
+                        "\(basePath).role",
+                        message: "System and developer messages must precede conversation history."
+                    )
+                }
+                continue
+            }
+
+            hasConversationStarted = true
+            if message.role != .tool, !pendingToolCalls.isEmpty {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(basePath).role",
+                    message: "Tool responses must immediately follow their assistant tool calls."
+                )
+            }
+            try registerToolCalls(
+                message.toolCalls,
+                at: basePath,
+                pending: &pendingToolCalls,
+                seen: &seenToolCallIDs
+            )
+            if message.role == .tool {
+                try consumeToolOutput(message, at: basePath, pending: &pendingToolCalls)
+            }
+        }
+
+        guard pendingToolCalls.isEmpty else {
+            throw AFMChatRequestValidationError.invalidField(
+                "messages",
+                message: "Every assistant tool call must have a matching tool response."
+            )
+        }
+        guard let finalRole = messages.last?.role, finalRole == .user || finalRole == .tool else {
+            throw AFMChatRequestValidationError.invalidField(
+                "messages",
+                message: "The final message must have role 'user' or 'tool'."
+            )
+        }
+    }
+
+    private static func registerToolCalls(
+        _ calls: [AFMChatToolCall],
+        at basePath: String,
+        pending: inout [String: String],
+        seen: inout Set<String>
+    ) throws {
+        for (index, call) in calls.enumerated() {
+            guard seen.insert(call.id).inserted else {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(basePath).tool_calls[\(index)].id",
+                    message: "Tool call IDs must be unique."
+                )
+            }
+            pending[call.id] = call.name
+        }
+    }
+
+    private static func consumeToolOutput(
+        _ message: AFMChatMessage,
+        at basePath: String,
+        pending: inout [String: String]
+    ) throws {
+        guard let toolCallID = message.toolCallID,
+              let expectedName = pending.removeValue(forKey: toolCallID) else {
+            throw AFMChatRequestValidationError.invalidField(
+                "\(basePath).tool_call_id",
+                message: "Tool responses must reference an earlier unmatched tool call."
+            )
+        }
+        if let name = message.name, name != expectedName {
+            throw AFMChatRequestValidationError.invalidField(
+                "\(basePath).name",
+                message: "Tool response name does not match its tool call."
+            )
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -228,36 +228,6 @@ private extension AFMFoundationModelsChatGenerator {
         return mapLegacyError(error) ?? error
     }
 
-    #if compiler(>=6.4)
-    @available(iOS 27.0, macOS 27.0, *)
-    static func mapModernError(_ error: Error) -> AFMChatGenerationError? {
-        if error is SystemLanguageModel.Error {
-            return .modelUnavailable
-        }
-        if error is LanguageModelSession.Error {
-            return .concurrentRequest
-        }
-        guard let modelError = error as? LanguageModelError else { return nil }
-        switch modelError {
-        case .contextSizeExceeded:
-            return .contextLengthExceeded
-        case .rateLimited:
-            return .rateLimited
-        case .guardrailViolation, .refusal:
-            return .safetyViolation
-        case .timeout:
-            return .timedOut
-        case .unsupportedCapability,
-             .unsupportedTranscriptContent,
-             .unsupportedGenerationGuide,
-             .unsupportedLanguageOrLocale:
-            return .unsupportedInput
-        @unknown default:
-            return nil
-        }
-    }
-    #endif
-
     static func mapLegacyError(_ error: Error) -> AFMChatGenerationError? {
         guard let generationError = error as? LanguageModelSession.GenerationError else { return nil }
         switch generationError {
@@ -278,3 +248,49 @@ private extension AFMFoundationModelsChatGenerator {
         }
     }
 }
+
+#if compiler(>=6.4)
+extension AFMFoundationModelsChatGenerator {
+    @available(iOS 27.0, macOS 27.0, *)
+    static func mapModernError(_ error: Error) -> AFMChatGenerationError? {
+        if error is SystemLanguageModel.Error {
+            return .modelUnavailable
+        }
+        if let sessionError = error as? LanguageModelSession.Error {
+            return mapModernSessionError(sessionError)
+        }
+        guard let modelError = error as? LanguageModelError else { return nil }
+        switch modelError {
+        case .contextSizeExceeded:
+            return .contextLengthExceeded
+        case .rateLimited:
+            return .rateLimited
+        case .guardrailViolation, .refusal:
+            return .safetyViolation
+        case .timeout:
+            return .timedOut
+        case .unsupportedCapability,
+             .unsupportedTranscriptContent,
+             .unsupportedGenerationGuide,
+             .unsupportedLanguageOrLocale:
+            return .unsupportedInput
+        @unknown default:
+            return nil
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, *)
+    private static func mapModernSessionError(
+        _ error: LanguageModelSession.Error
+    ) -> AFMChatGenerationError? {
+        switch error {
+        case .concurrentRequests:
+            return .concurrentRequest
+        case .transcriptMutationWhileResponding:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+}
+#endif

--- a/Tools/AFMCLI/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -1,0 +1,280 @@
+import Foundation
+import FoundationModels
+import FoundationModelsKit
+
+public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
+    public init() {}
+
+    public func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        let prepared = try AFMChatTranscriptBuilder.prepare(request)
+        let session = LanguageModelSession(model: .default, transcript: prepared.transcript)
+
+        do {
+            let response = try await session.respond(to: prepared.prompt, options: prepared.options)
+            let usage = await responseUsage(response, prepared: prepared)
+            return AFMChatGenerationResult(content: response.content, usage: usage)
+        } catch {
+            if Self.isRefusal(error) {
+                return await refusalResult(prepared: prepared)
+            }
+            throw Self.mappedError(error)
+        }
+    }
+
+    private func responseUsage(
+        _ response: LanguageModelSession.Response<String>,
+        prepared: AFMPreparedChatGeneration
+    ) async -> ModelTokenUsage {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            return ModelTokenUsage(observing: response.usage)
+        }
+        #endif
+
+        return await fallbackUsage(input: prepared.inputTranscript, output: response.content)
+    }
+
+    private func refusalResult(prepared: AFMPreparedChatGeneration) async -> AFMChatGenerationResult {
+        let inputUsage = await prepared.inputTranscript.tokenUsage(using: .default)
+        let usage = ModelTokenUsage(
+            input: .init(totalTokenCount: inputUsage.totalTokenCount),
+            output: .init(totalTokenCount: 0),
+            measurement: inputUsage.measurement,
+            scope: .response
+        )
+        return AFMChatGenerationResult(
+            content: nil,
+            refusal: "The model declined to answer this request.",
+            finishReason: .contentFilter,
+            usage: usage
+        )
+    }
+
+    private func fallbackUsage(input: Transcript, output: String) async -> ModelTokenUsage {
+        async let inputUsage = input.tokenUsage(using: .default)
+        async let outputUsage = outputEntry(output).tokenUsage(using: .default)
+        let (resolvedInput, resolvedOutput) = await (inputUsage, outputUsage)
+        let measurement: ModelTokenUsage.Measurement =
+            resolvedInput.measurement == .tokenized && resolvedOutput.measurement == .tokenized
+            ? .tokenized
+            : .estimated
+        return ModelTokenUsage(
+            input: .init(totalTokenCount: resolvedInput.totalTokenCount),
+            output: .init(totalTokenCount: resolvedOutput.totalTokenCount),
+            measurement: measurement,
+            scope: .response
+        )
+    }
+
+    private func outputEntry(_ content: String) -> Transcript.Entry {
+        .response(.init(assetIDs: [], segments: AFMChatTranscriptBuilder.segments([content])))
+    }
+}
+
+struct AFMPreparedChatGeneration {
+    let transcript: Transcript
+    let prompt: Prompt
+    let inputTranscript: Transcript
+    let options: GenerationOptions
+}
+
+enum AFMChatTranscriptBuilder {
+    static func prepare(_ request: AFMChatGenerationRequest) throws -> AFMPreparedChatGeneration {
+        guard !request.messages.isEmpty else {
+            throw AFMChatGenerationError.unsupportedInput
+        }
+        let finalMessage = request.messages[request.messages.index(before: request.messages.endIndex)]
+        let history = finalMessage.role == .user ? request.messages.dropLast() : request.messages[...]
+        let entries = try transcriptEntries(for: history)
+        let promptContent = activePromptContent(for: finalMessage)
+        let prompt = Prompt(promptContent)
+        let inputPrompt = Transcript.Prompt(segments: segments(promptContent))
+        let inputTranscript = Transcript(entries: entries + [.prompt(inputPrompt)])
+        let transcript = Transcript(entries: entries)
+        return AFMPreparedChatGeneration(
+            transcript: transcript,
+            prompt: prompt,
+            inputTranscript: inputTranscript,
+            options: generationOptions(for: request)
+        )
+    }
+
+    static func segments(_ content: [String]) -> [Transcript.Segment] {
+        content.map { .text(.init(content: $0)) }
+    }
+
+    private static func transcriptEntries(
+        for messages: ArraySlice<AFMChatMessage>
+    ) throws -> [Transcript.Entry] {
+        var entries: [Transcript.Entry] = []
+        var toolNames: [String: String] = [:]
+        let instructionMessages = messages.prefix { $0.role == .system || $0.role == .developer }
+        let instructionSegments = instructionMessages.flatMap { segments($0.contentSegments ?? []) }
+        if !instructionSegments.isEmpty {
+            entries.append(.instructions(.init(segments: instructionSegments, toolDefinitions: [])))
+        }
+
+        for message in messages.dropFirst(instructionMessages.count) {
+            try append(message, to: &entries, toolNames: &toolNames)
+        }
+        return entries
+    }
+
+    private static func append(
+        _ message: AFMChatMessage,
+        to entries: inout [Transcript.Entry],
+        toolNames: inout [String: String]
+    ) throws {
+        switch message.role {
+        case .system, .developer:
+            break
+        case .user:
+            entries.append(.prompt(.init(segments: segments(message.contentSegments ?? []))))
+        case .assistant:
+            try appendAssistant(message, to: &entries, toolNames: &toolNames)
+        case .tool:
+            try appendToolOutput(message, to: &entries, toolNames: toolNames)
+        }
+    }
+
+    private static func appendAssistant(
+        _ message: AFMChatMessage,
+        to entries: inout [Transcript.Entry],
+        toolNames: inout [String: String]
+    ) throws {
+        if let content = message.contentSegments {
+            entries.append(.response(.init(assetIDs: [], segments: segments(content))))
+        }
+        guard !message.toolCalls.isEmpty else { return }
+        let calls = try message.toolCalls.map { call in
+            toolNames[call.id] = call.name
+            return Transcript.ToolCall(
+                id: call.id,
+                toolName: call.name,
+                arguments: try GeneratedContent(json: call.arguments)
+            )
+        }
+        entries.append(.toolCalls(.init(calls)))
+    }
+
+    private static func appendToolOutput(
+        _ message: AFMChatMessage,
+        to entries: inout [Transcript.Entry],
+        toolNames: [String: String]
+    ) throws {
+        guard let identifier = message.toolCallID,
+              let toolName = message.name ?? toolNames[identifier] else {
+            throw AFMChatGenerationError.unsupportedInput
+        }
+        entries.append(
+            .toolOutput(
+                .init(
+                    id: identifier,
+                    toolName: toolName,
+                    segments: segments(message.contentSegments ?? [])
+                )
+            )
+        )
+    }
+
+    private static func activePromptContent(for finalMessage: AFMChatMessage) -> [String] {
+        if finalMessage.role == .user {
+            return finalMessage.contentSegments ?? []
+        }
+        return [""]
+    }
+
+    private static func generationOptions(for request: AFMChatGenerationRequest) -> GenerationOptions {
+        let sampling = request.topP.map { GenerationOptions.SamplingMode.random(probabilityThreshold: $0) }
+        #if compiler(>=6.4)
+        return GenerationOptions(
+            samplingMode: sampling,
+            temperature: request.temperature,
+            maximumResponseTokens: request.maximumCompletionTokens
+        )
+        #else
+        return GenerationOptions(
+            sampling: sampling,
+            temperature: request.temperature,
+            maximumResponseTokens: request.maximumCompletionTokens
+        )
+        #endif
+    }
+}
+
+private extension AFMFoundationModelsChatGenerator {
+    static func isRefusal(_ error: Error) -> Bool {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *), let modelError = error as? LanguageModelError {
+            if case .refusal = modelError {
+                return true
+            }
+        }
+        #endif
+        if let generationError = error as? LanguageModelSession.GenerationError {
+            if case .refusal = generationError {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func mappedError(_ error: Error) -> Error {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *), let mapped = mapModernError(error) {
+            return mapped
+        }
+        #endif
+        return mapLegacyError(error) ?? error
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, *)
+    static func mapModernError(_ error: Error) -> AFMChatGenerationError? {
+        if error is SystemLanguageModel.Error {
+            return .modelUnavailable
+        }
+        if error is LanguageModelSession.Error {
+            return .concurrentRequest
+        }
+        guard let modelError = error as? LanguageModelError else { return nil }
+        switch modelError {
+        case .contextSizeExceeded:
+            return .contextLengthExceeded
+        case .rateLimited:
+            return .rateLimited
+        case .guardrailViolation, .refusal:
+            return .safetyViolation
+        case .timeout:
+            return .timedOut
+        case .unsupportedCapability,
+             .unsupportedTranscriptContent,
+             .unsupportedGenerationGuide,
+             .unsupportedLanguageOrLocale:
+            return .unsupportedInput
+        @unknown default:
+            return nil
+        }
+    }
+    #endif
+
+    static func mapLegacyError(_ error: Error) -> AFMChatGenerationError? {
+        guard let generationError = error as? LanguageModelSession.GenerationError else { return nil }
+        switch generationError {
+        case .exceededContextWindowSize:
+            return .contextLengthExceeded
+        case .assetsUnavailable:
+            return .modelUnavailable
+        case .guardrailViolation, .refusal:
+            return .safetyViolation
+        case .rateLimited:
+            return .rateLimited
+        case .concurrentRequests:
+            return .concurrentRequest
+        case .unsupportedGuide, .unsupportedLanguageOrLocale, .decodingFailure:
+            return .unsupportedInput
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPHandler.swift
@@ -10,7 +10,9 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     private let limits: AFMServerLimits
     private var requestHead: HTTPRequestHead?
     private var receivedBodyBytes = 0
+    private var requestBody = Data()
     private var responseWasSent = false
+    private var generationTask: Task<Void, Never>?
 
     init(router: AFMRequestRouter, limits: AFMServerLimits) {
         self.router = router
@@ -29,6 +31,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
+        cancelGeneration()
         guard !responseWasSent else {
             context.close(promise: nil)
             return
@@ -56,8 +59,18 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         send(response, version: requestHead?.version ?? .http1_1, close: true, context: context)
     }
 
+    func channelInactive(context: ChannelHandlerContext) {
+        cancelGeneration()
+        context.fireChannelInactive()
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        cancelGeneration()
+    }
+
     private func receiveHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
         guard requestHead == nil, !responseWasSent else {
+            cancelGeneration()
             responseWasSent = true
             send(
                 .apiError(
@@ -74,6 +87,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
         requestHead = head
         receivedBodyBytes = 0
+        requestBody.removeAll(keepingCapacity: true)
 
         if let contentLength = declaredContentLength(head), contentLength > UInt64(limits.maximumBodyBytes) {
             responseWasSent = true
@@ -81,7 +95,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             return
         }
 
-        if declaresBody(head), !hasJSONContentType(head) {
+        if declaresBody(head) || router.requiresJSONBody(head), !hasJSONContentType(head) {
             responseWasSent = true
             sendUnsupportedMediaType(version: head.version, context: context)
         }
@@ -103,6 +117,9 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             return
         }
         receivedBodyBytes = newCount
+        if let bytes = buffer.getBytes(at: buffer.readerIndex, length: buffer.readableBytes) {
+            requestBody.append(contentsOf: bytes)
+        }
     }
 
     private func receiveEnd(context: ChannelHandlerContext) {
@@ -124,12 +141,64 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         }
         guard !responseWasSent else { return }
 
-        let response = router.response(for: head)
+        switch router.route(for: head) {
+        case .immediate(let response):
+            let shouldClose = !head.isKeepAlive
+            send(response, version: head.version, close: shouldClose, context: context)
+            resetRequestState()
+        case .chatCompletion(let origin):
+            startChatCompletion(head: head, body: requestBody, origin: origin, context: context)
+        }
+    }
+
+    private func startChatCompletion(
+        head: HTTPRequestHead,
+        body: Data,
+        origin: String?,
+        context: ChannelHandlerContext
+    ) {
+        let router = router
+        let contextReference = AFMChannelContextReference(context)
+        let eventLoop = context.eventLoop
+        generationTask = Task { [weak self] in
+            let response: AFMHTTPResponse
+            do {
+                response = try await router.chatCompletionResponse(body: body, origin: origin)
+            } catch is CancellationError {
+                return
+            } catch {
+                response = .apiError(
+                    status: .internalServerError,
+                    message: "The chat completion request failed.",
+                    code: "internal_error",
+                    type: "server_error"
+                )
+            }
+            guard !Task.isCancelled else { return }
+            eventLoop.execute { [weak self] in
+                self?.completeChatCompletion(
+                    response,
+                    head: head,
+                    context: contextReference.context
+                )
+            }
+        }
+    }
+
+    private func completeChatCompletion(
+        _ response: AFMHTTPResponse,
+        head: HTTPRequestHead,
+        context: ChannelHandlerContext
+    ) {
+        generationTask = nil
+        guard requestHead != nil, !responseWasSent, context.channel.isActive else { return }
         let shouldClose = !head.isKeepAlive
         send(response, version: head.version, close: shouldClose, context: context)
         resetRequestState()
     }
+}
 
+private extension AFMHTTPHandler {
     private func sendPayloadTooLarge(version: HTTPVersion, context: ChannelHandlerContext) {
         send(
             .apiError(
@@ -191,7 +260,13 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     private func resetRequestState() {
         requestHead = nil
         receivedBodyBytes = 0
+        requestBody.removeAll(keepingCapacity: true)
         responseWasSent = false
+    }
+
+    private func cancelGeneration() {
+        generationTask?.cancel()
+        generationTask = nil
     }
 
     private func declaredContentLength(_ head: HTTPRequestHead) -> UInt64? {
@@ -211,5 +286,13 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return mediaType == "application/json"
+    }
+}
+
+private final class AFMChannelContextReference: @unchecked Sendable {
+    let context: ChannelHandlerContext
+
+    init(_ context: ChannelHandlerContext) {
+        self.context = context
     }
 }

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPHandler.swift
@@ -12,6 +12,8 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     private var receivedBodyBytes = 0
     private var requestBody = Data()
     private var responseWasSent = false
+    private var shouldCloseForPipelinedRequest = false
+    private var isClosingResponse = false
     private var generationTask: Task<Void, Never>?
 
     init(router: AFMRequestRouter, limits: AFMServerLimits) {
@@ -20,6 +22,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        guard !isClosingResponse else { return }
         switch unwrapInboundIn(data) {
         case .head(let head):
             receiveHead(head, context: context)
@@ -32,6 +35,10 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         cancelGeneration()
+        guard !isClosingResponse else {
+            context.close(promise: nil)
+            return
+        }
         guard !responseWasSent else {
             context.close(promise: nil)
             return
@@ -70,6 +77,10 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func receiveHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
         guard requestHead == nil, !responseWasSent else {
+            if generationTask != nil {
+                shouldCloseForPipelinedRequest = true
+                return
+            }
             cancelGeneration()
             responseWasSent = true
             send(
@@ -102,6 +113,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func receiveBody(_ buffer: ByteBuffer, context: ChannelHandlerContext) {
+        guard !shouldCloseForPipelinedRequest else { return }
         guard let head = requestHead, !responseWasSent else { return }
 
         if receivedBodyBytes == 0, !declaresBody(head), !hasJSONContentType(head) {
@@ -123,6 +135,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     private func receiveEnd(context: ChannelHandlerContext) {
+        guard !shouldCloseForPipelinedRequest else { return }
         guard let head = requestHead else {
             if !responseWasSent {
                 responseWasSent = true
@@ -144,8 +157,8 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         switch router.route(for: head) {
         case .immediate(let response):
             let shouldClose = !head.isKeepAlive
-            send(response, version: head.version, close: shouldClose, context: context)
             resetRequestState()
+            send(response, version: head.version, close: shouldClose, context: context)
         case .chatCompletion(let origin):
             startChatCompletion(head: head, body: requestBody, origin: origin, context: context)
         }
@@ -192,9 +205,9 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     ) {
         generationTask = nil
         guard requestHead != nil, !responseWasSent, context.channel.isActive else { return }
-        let shouldClose = !head.isKeepAlive
-        send(response, version: head.version, close: shouldClose, context: context)
+        let shouldClose = !head.isKeepAlive || shouldCloseForPipelinedRequest
         resetRequestState()
+        send(response, version: head.version, close: shouldClose, context: context)
     }
 }
 
@@ -231,6 +244,9 @@ private extension AFMHTTPHandler {
         close: Bool,
         context: ChannelHandlerContext
     ) {
+        if close {
+            isClosingResponse = true
+        }
         var headers = response.headers
         headers.replaceOrAdd(name: "content-type", value: "application/json")
         headers.replaceOrAdd(name: "content-length", value: String(response.body.count))
@@ -262,6 +278,7 @@ private extension AFMHTTPHandler {
         receivedBodyBytes = 0
         requestBody.removeAll(keepingCapacity: true)
         responseWasSent = false
+        shouldCloseForPipelinedRequest = false
     }
 
     private func cancelGeneration() {

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPResponse.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPResponse.swift
@@ -30,13 +30,14 @@ struct AFMHTTPResponse {
         message: String,
         code: String,
         type: String = "invalid_request_error",
+        parameter: String? = nil,
         headers: HTTPHeaders = .init()
     ) -> Self {
         json(
             status: status,
             headers: headers,
             body: AFMErrorEnvelope(
-                error: .init(message: message, type: type, parameter: nil, code: code)
+                error: .init(message: message, type: type, parameter: parameter, code: code)
             )
         )
     }
@@ -67,10 +68,20 @@ private struct AFMErrorEnvelope: Encodable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(message, forKey: .message)
             try container.encode(type, forKey: .type)
-            try container.encodeNil(forKey: .parameter)
+            try container.encodeIfPresentOrNil(parameter, forKey: .parameter)
             try container.encode(code, forKey: .code)
         }
     }
 
     let error: Detail
+}
+
+private extension KeyedEncodingContainer {
+    mutating func encodeIfPresentOrNil<T: Encodable>(_ value: T?, forKey key: Key) throws {
+        if let value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
 }

--- a/Tools/AFMCLI/Sources/AFMServer/AFMHTTPServer.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMHTTPServer.swift
@@ -47,11 +47,23 @@ public actor AFMHTTPServer {
     public init(
         configuration: AFMServerConfiguration = .init(),
         catalog: any AFMModelCatalog,
-        clock: any AFMServerClock = AFMSystemServerClock()
+        clock: any AFMServerClock = AFMSystemServerClock(),
+        generator: any AFMChatCompletionGenerating = AFMFoundationModelsChatGenerator()
     ) throws {
         let configuration = try configuration.validated()
         self.configuration = configuration
-        router = AFMRequestRouter(configuration: configuration, catalog: catalog, clock: clock)
+        let chatCompletions = AFMChatCompletionService(
+            catalog: catalog,
+            generator: generator,
+            clock: clock,
+            policy: configuration.generation
+        )
+        router = AFMRequestRouter(
+            configuration: configuration,
+            catalog: catalog,
+            clock: clock,
+            chatCompletions: chatCompletions
+        )
     }
 
     public func start() async throws -> AFMServerBoundAddress {
@@ -183,9 +195,10 @@ public actor AFMHTTPServer {
         let childChannels = childChannels
         return ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: false)
             .childChannelInitializer { channel in
                 channel.pipeline.configureHTTPServerPipeline(
-                    withPipeliningAssistance: true,
+                    withPipeliningAssistance: false,
                     withErrorHandling: false,
                     withDecoderLimitConfiguration: configuredDecoderLimits
                 ).flatMap {

--- a/Tools/AFMCLI/Sources/AFMServer/AFMRequestRouter.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMRequestRouter.swift
@@ -1,68 +1,124 @@
 import Foundation
 import NIOHTTP1
 
+enum AFMRequestRoute {
+    case immediate(AFMHTTPResponse)
+    case chatCompletion(origin: String?)
+}
+
 struct AFMRequestRouter: Sendable {
     private let configuration: AFMServerConfiguration
     private let catalog: any AFMModelCatalog
     private let clock: any AFMServerClock
+    private let chatCompletions: AFMChatCompletionService?
 
     init(
         configuration: AFMServerConfiguration,
         catalog: any AFMModelCatalog,
-        clock: any AFMServerClock
+        clock: any AFMServerClock,
+        chatCompletions: AFMChatCompletionService? = nil
     ) {
         self.configuration = configuration
         self.catalog = catalog
         self.clock = clock
+        self.chatCompletions = chatCompletions
     }
 
     func response(for request: HTTPRequestHead) -> AFMHTTPResponse {
+        switch route(for: request) {
+        case .immediate(let response):
+            return response
+        case .chatCompletion:
+            return .apiError(
+                status: .internalServerError,
+                message: "This route requires asynchronous request handling.",
+                code: "internal_error",
+                type: "server_error"
+            )
+        }
+    }
+
+    func route(for request: HTTPRequestHead) -> AFMRequestRoute {
         if case .tcp(let host, _) = configuration.endpoint,
            AFMHostPolicy.isLoopbackBinding(host),
            !AFMHostPolicy.validatesLoopbackHostHeader(request.headers, bindingHost: host) {
-            return .apiError(
+            return .immediate(.apiError(
                 status: .forbidden,
                 message: "The Host header is not allowed for this loopback server.",
                 code: "forbidden_host"
-            )
+            ))
         }
 
         let originResult = validateOrigin(request.headers)
         guard originResult.isAllowed else {
-            return .apiError(
+            return .immediate(.apiError(
                 status: .forbidden,
                 message: "Cross-site requests are not allowed.",
                 code: "origin_not_allowed"
-            )
+            ))
         }
 
         guard validatesAuthorization(request.headers) else {
             var headers = HTTPHeaders()
             headers.add(name: "www-authenticate", value: "Bearer")
-            return AFMHTTPResponse.apiError(
+            return .immediate(AFMHTTPResponse.apiError(
                 status: .unauthorized,
                 message: "A valid bearer token is required.",
                 code: "invalid_api_key",
                 type: "authentication_error",
                 headers: headers
-            ).addingOrigin(originResult.origin)
+            ).addingOrigin(originResult.origin))
         }
 
         let path = request.uri.split(separator: "?", maxSplits: 1).first.map(String.init) ?? request.uri
-        let response: AFMHTTPResponse
+        let route: AFMRequestRoute
         switch path {
         case "/health":
-            response = responseForKnownRoute(request, body: healthResponse)
+            route = .immediate(responseForKnownRoute(request, body: healthResponse))
         case "/v1/models":
-            response = responseForKnownRoute(request, body: modelsResponse)
+            route = .immediate(responseForKnownRoute(request, body: modelsResponse))
+        case "/v1/chat/completions":
+            route = routeChatCompletion(request, origin: originResult.origin)
         default:
-            response = .apiError(
+            route = .immediate(.apiError(
                 status: .notFound,
                 message: "The requested endpoint was not found.",
                 code: "not_found"
+            ))
+        }
+        return route.addingOrigin(originResult.origin)
+    }
+
+    func chatCompletionResponse(body: Data, origin: String?) async throws -> AFMHTTPResponse {
+        guard let chatCompletions else {
+            return AFMHTTPResponse.apiError(
+                status: .notImplemented,
+                message: "Chat completions are not configured for this server.",
+                code: "not_implemented",
+                type: "server_error"
+            ).addingOrigin(origin)
+        }
+        return try await chatCompletions.response(for: body).addingOrigin(origin)
+    }
+
+    func requiresJSONBody(_ request: HTTPRequestHead) -> Bool {
+        request.method == .POST && normalizedPath(request.uri) == "/v1/chat/completions"
+    }
+
+    private func routeChatCompletion(_ request: HTTPRequestHead, origin: String?) -> AFMRequestRoute {
+        guard request.method == .POST else {
+            var headers = HTTPHeaders()
+            headers.add(name: "allow", value: "POST")
+            return .immediate(
+                .apiError(
+                    status: .methodNotAllowed,
+                    message: "This endpoint only accepts POST requests.",
+                    code: "method_not_allowed",
+                    headers: headers
+                )
             )
         }
-        return response.addingOrigin(originResult.origin)
+        return .chatCompletion(origin: origin)
     }
 
     private func responseForKnownRoute<T: Encodable>(
@@ -130,6 +186,21 @@ struct AFMRequestRouter: Sendable {
             difference |= UInt(lhsByte ^ rhsByte)
         }
         return difference == 0
+    }
+
+    private func normalizedPath(_ uri: String) -> String {
+        uri.split(separator: "?", maxSplits: 1).first.map(String.init) ?? uri
+    }
+}
+
+private extension AFMRequestRoute {
+    func addingOrigin(_ origin: String?) -> Self {
+        switch self {
+        case .immediate(let response):
+            return .immediate(response.addingOrigin(origin))
+        case .chatCompletion:
+            return self
+        }
     }
 }
 

--- a/Tools/AFMCLI/Sources/AFMServer/AFMServerConfiguration.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMServerConfiguration.swift
@@ -40,24 +40,41 @@ public struct AFMServerSecurity: Sendable, Equatable {
     }
 }
 
+public struct AFMServerGenerationPolicy: Sendable, Equatable {
+    public var maximumConcurrentGenerations: Int
+    public var timeoutSeconds: Double
+
+    public init(
+        maximumConcurrentGenerations: Int = 1,
+        timeoutSeconds: Double = 120
+    ) {
+        self.maximumConcurrentGenerations = maximumConcurrentGenerations
+        self.timeoutSeconds = timeoutSeconds
+    }
+}
+
 public struct AFMServerConfiguration: Sendable, Equatable {
     public var endpoint: AFMServerEndpoint
     public var limits: AFMServerLimits
     public var security: AFMServerSecurity
+    public var generation: AFMServerGenerationPolicy
 
     public init(
         endpoint: AFMServerEndpoint = .tcp(host: "127.0.0.1", port: 1976),
         limits: AFMServerLimits = .init(),
-        security: AFMServerSecurity = .init()
+        security: AFMServerSecurity = .init(),
+        generation: AFMServerGenerationPolicy = .init()
     ) {
         self.endpoint = endpoint
         self.limits = limits
         self.security = security
+        self.generation = generation
     }
 
     public func validated() throws -> Self {
         try validateLimits()
         try validateSecurity()
+        try validateGenerationPolicy()
 
         var validatedConfiguration = self
         validatedConfiguration.endpoint = try validatedEndpoint()
@@ -80,6 +97,15 @@ public struct AFMServerConfiguration: Sendable, Equatable {
         }
         if security.allowedOrigins.contains(where: { !Self.isValidOrigin($0) }) {
             throw AFMServerConfigurationError.invalidAllowedOrigin
+        }
+    }
+
+    private func validateGenerationPolicy() throws {
+        guard generation.maximumConcurrentGenerations > 0 else {
+            throw AFMServerConfigurationError.invalidGenerationConcurrency
+        }
+        guard generation.timeoutSeconds.isFinite, generation.timeoutSeconds > 0 else {
+            throw AFMServerConfigurationError.invalidGenerationTimeout
         }
     }
 
@@ -148,6 +174,8 @@ public enum AFMServerConfigurationError: Error, Equatable, LocalizedError {
     case emptyBearerToken
     case invalidAllowedOrigin
     case invalidSocketPath
+    case invalidGenerationConcurrency
+    case invalidGenerationTimeout
     case networkOptInRequired(String)
     case networkAuthenticationRequired(String)
 
@@ -165,6 +193,10 @@ public enum AFMServerConfigurationError: Error, Equatable, LocalizedError {
             "Allowed origins must be exact, non-empty origins; wildcards are not accepted."
         case .invalidSocketPath:
             "The Unix-domain socket path must be an absolute path."
+        case .invalidGenerationConcurrency:
+            "The maximum concurrent generation count must be greater than zero."
+        case .invalidGenerationTimeout:
+            "The model timeout must be a finite number greater than zero."
         case .networkOptInRequired(let host):
             "Binding to non-loopback host '\(host)' requires explicit network opt-in."
         case .networkAuthenticationRequired(let host):

--- a/Tools/AFMCLI/Sources/AFMServer/AFMStrictJSONDecoding.swift
+++ b/Tools/AFMCLI/Sources/AFMServer/AFMStrictJSONDecoding.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct AFMJSONKey: CodingKey, Hashable {
+    let stringValue: String
+    let intValue: Int?
+
+    init(_ stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(stringValue: String) {
+        self.init(stringValue)
+    }
+
+    init?(intValue: Int) {
+        stringValue = String(intValue)
+        self.intValue = intValue
+    }
+}
+
+func rejectUnknownFields(
+    in container: KeyedDecodingContainer<AFMJSONKey>,
+    allowed: Set<String>,
+    decoder: Decoder
+) throws {
+    if let unknownKey = container.allKeys
+        .filter({ !allowed.contains($0.stringValue) })
+        .sorted(by: { $0.stringValue < $1.stringValue })
+        .first {
+        throw AFMChatRequestValidationError.unknownField(
+            parameterPath(decoder.codingPath, field: unknownKey.stringValue)
+        )
+    }
+}
+
+func rejectUnsupportedFields(
+    _ fields: [String],
+    in container: KeyedDecodingContainer<AFMJSONKey>,
+    decoder: Decoder
+) throws {
+    for field in fields {
+        let key = AFMJSONKey(field)
+        if container.contains(key), try !container.decodeNil(forKey: key) {
+            throw AFMChatRequestValidationError.unsupportedField(
+                parameterPath(decoder.codingPath, field: field)
+            )
+        }
+    }
+}
+
+func parameterPath(_ codingPath: [any CodingKey], field: String? = nil) -> String {
+    var keys = codingPath
+    if let field {
+        keys.append(AFMJSONKey(field))
+    }
+    return keys.reduce(into: "") { result, key in
+        if let index = key.intValue {
+            result += "[\(index)]"
+        } else if result.isEmpty {
+            result = key.stringValue
+        } else {
+            result += ".\(key.stringValue)"
+        }
+    }
+}
+
+extension AFMChatRequestValidationError {
+    init(decodingError: DecodingError) {
+        switch decodingError {
+        case .keyNotFound(let key, let context):
+            self = .missingField(parameterPath(context.codingPath, field: key.stringValue))
+        case .typeMismatch(_, let context), .valueNotFound(_, let context):
+            let parameter = parameterPath(context.codingPath)
+            if parameter.isEmpty {
+                self = .malformedJSON
+            } else {
+                self = .invalidField(
+                    parameter,
+                    message: "Field '\(parameter)' has an invalid JSON type."
+                )
+            }
+        case .dataCorrupted(let context):
+            let parameter = parameterPath(context.codingPath)
+            if parameter.isEmpty {
+                self = .malformedJSON
+            } else {
+                self = .invalidField(parameter, message: "Field '\(parameter)' contains invalid data.")
+            }
+        @unknown default:
+            self = .malformedJSON
+        }
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIServeTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIServeTests.swift
@@ -11,7 +11,10 @@ func serveHelp() throws {
     #expect(root.stdout.contains("SERVER COMMANDS"))
     #expect(root.stdout.contains("afm serve"))
     #expect(serve.status == 0)
-    for flag in ["--host", "--port", "--socket", "--allow-network", "--token", "--allow-origin"] {
+    for flag in [
+        "--host", "--port", "--socket", "--allow-network", "--token", "--allow-origin",
+        "--max-concurrent-generations", "--model-timeout"
+    ] {
         #expect(serve.stdout.contains(flag))
     }
 }
@@ -27,6 +30,8 @@ func serveDryRun() throws {
     #expect(json["command"] as? String == "serve")
     #expect(json["endpoint"] as? String == "http://127.0.0.1:1976")
     #expect(json["authenticationEnabled"] as? Bool == true)
+    #expect(json["maximumConcurrentGenerations"] as? Int == 1)
+    #expect(json["modelTimeoutSeconds"] as? Double == 120)
 }
 
 @Test("Serve rejects unsafe binding combinations before listening")
@@ -54,6 +59,16 @@ func serveConfigurationValidation() throws {
     let wildcardOrigin = try runAFM("serve", "--dry-run", "--allow-origin", "*")
     #expect(wildcardOrigin.status == 64)
     #expect(wildcardOrigin.stderr.contains("exact, non-empty origins"))
+
+    let invalidConcurrency = try runAFM(
+        "serve", "--dry-run", "--max-concurrent-generations", "0"
+    )
+    #expect(invalidConcurrency.status == 64)
+    #expect(invalidConcurrency.stderr.contains("concurrent generation count"))
+
+    let invalidTimeout = try runAFM("serve", "--dry-run", "--model-timeout", "0")
+    #expect(invalidTimeout.status == 64)
+    #expect(invalidTimeout.stderr.contains("model timeout"))
 }
 
 @Test("SIGTERM gracefully removes a CLI Unix-domain socket")

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMChatCompletionServiceTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMChatCompletionServiceTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import FoundationModelsKit
+import Testing
+@testable import AFMServer
+
+@Test("Chat completion responses expose OpenAI fields and truthful token provenance")
+func chatCompletionResponseShape() async throws {
+    let usage = ModelTokenUsage(
+        input: .init(totalTokenCount: 11, cachedTokenCount: 2),
+        output: .init(totalTokenCount: 7, reasoningTokenCount: 3),
+        measurement: .observed,
+        scope: .response
+    )
+    let generator = RecordingGenerator(result: .init(content: "Hello", usage: usage))
+    let service = testChatService(generator: generator)
+
+    let response = try await service.response(for: chatBody())
+    #expect(response.status == .ok)
+    let json = try serviceJSONObject(response.body)
+    #expect(json["object"] as? String == "chat.completion")
+    #expect(json["created"] as? Int == 123)
+    #expect(json["model"] as? String == "system")
+    #expect((json["id"] as? String)?.hasPrefix("chatcmpl-") == true)
+
+    let choices = try #require(json["choices"] as? [[String: Any]])
+    let message = try #require(choices.first?["message"] as? [String: Any])
+    #expect(message["role"] as? String == "assistant")
+    #expect(message["content"] as? String == "Hello")
+    #expect(message["refusal"] is NSNull)
+    #expect(choices.first?["finish_reason"] as? String == "stop")
+    #expect(choices.first?["logprobs"] is NSNull)
+
+    let usageJSON = try #require(json["usage"] as? [String: Any])
+    #expect(usageJSON["prompt_tokens"] as? Int == 11)
+    #expect(usageJSON["completion_tokens"] as? Int == 7)
+    #expect(usageJSON["total_tokens"] as? Int == 18)
+    #expect(usageJSON["afm_measurement"] as? String == "observed")
+    #expect(usageJSON["afm_scope"] as? String == "response")
+    let promptDetails = try #require(usageJSON["prompt_tokens_details"] as? [String: Any])
+    let completionDetails = try #require(usageJSON["completion_tokens_details"] as? [String: Any])
+    #expect(promptDetails["cached_tokens"] as? Int == 2)
+    #expect(completionDetails["reasoning_tokens"] as? Int == 3)
+    let recorded = await generator.recordedRequests()
+    #expect(recorded.count == 1)
+}
+
+@Test("Refusals remain successful completions with null content")
+func chatCompletionRefusal() async throws {
+    let usage = ModelTokenUsage(inputTokenCount: 4, measurement: .estimated, scope: .response)
+    let generator = RecordingGenerator(
+        result: .init(
+            content: nil,
+            refusal: "Declined",
+            finishReason: .contentFilter,
+            usage: usage
+        )
+    )
+    let response = try await testChatService(generator: generator).response(for: chatBody())
+    let json = try serviceJSONObject(response.body)
+    let choices = try #require(json["choices"] as? [[String: Any]])
+    let message = try #require(choices.first?["message"] as? [String: Any])
+    #expect(message["content"] is NSNull)
+    #expect(message["refusal"] as? String == "Declined")
+    #expect(choices.first?["finish_reason"] as? String == "content_filter")
+}
+
+@Test("Model validation happens before the generator is called")
+func chatCompletionModelValidation() async throws {
+    let generator = RecordingGenerator(result: standardResult())
+    let catalog = AFMStaticModelCatalog(
+        models: [.init(id: "system", isAvailable: false)]
+    )
+    let service = testChatService(generator: generator, catalog: catalog)
+
+    let unavailable = try await service.response(for: chatBody())
+    #expect(unavailable.status == .serviceUnavailable)
+    #expect(try serviceErrorCode(unavailable.body) == "model_unavailable")
+
+    let unknown = try await service.response(for: chatBody(model: "missing"))
+    #expect(unknown.status == .notFound)
+    #expect(try serviceErrorCode(unknown.body) == "model_not_found")
+    #expect((await generator.recordedRequests()).isEmpty)
+}
+
+@Test("Generation concurrency is bounded without an implicit queue")
+func chatCompletionConcurrencyLimit() async throws {
+    let probe = GenerationProbe()
+    let service = testChatService(
+        generator: PausingGenerator(probe: probe),
+        policy: .init(maximumConcurrentGenerations: 1, timeoutSeconds: 30)
+    )
+    let first = Task { try await service.response(for: chatBody()) }
+    await probe.waitUntilStarted()
+
+    let overloaded = try await service.response(for: chatBody())
+    #expect(overloaded.status == .tooManyRequests)
+    #expect(try serviceErrorCode(overloaded.body) == "server_busy")
+    first.cancel()
+    _ = try? await first.value
+}
+
+@Test("Generation timeout cancels model work and returns a structured 504")
+func chatCompletionTimeout() async throws {
+    let probe = GenerationProbe()
+    let service = testChatService(
+        generator: PausingGenerator(probe: probe),
+        policy: .init(maximumConcurrentGenerations: 1, timeoutSeconds: 0.01)
+    )
+
+    let response = try await service.response(for: chatBody())
+    #expect(response.status == .gatewayTimeout)
+    #expect(try serviceErrorCode(response.body) == "model_timeout")
+    await probe.waitUntilCancelled()
+}
+
+private actor RecordingGenerator: AFMChatCompletionGenerating {
+    private let result: AFMChatGenerationResult
+    private var requests: [AFMChatGenerationRequest] = []
+
+    init(result: AFMChatGenerationResult) {
+        self.result = result
+    }
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        requests.append(request)
+        return result
+    }
+
+    func recordedRequests() -> [AFMChatGenerationRequest] {
+        requests
+    }
+}
+
+private struct PausingGenerator: AFMChatCompletionGenerating {
+    let probe: GenerationProbe
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        await probe.markStarted()
+        return try await withTaskCancellationHandler {
+            try await ContinuousClock().sleep(for: .seconds(30))
+            return standardResult()
+        } onCancel: {
+            Task { await probe.markCancelled() }
+        }
+    }
+}
+
+private actor GenerationProbe {
+    private var started = false
+    private var cancelled = false
+
+    func markStarted() { started = true }
+    func markCancelled() { cancelled = true }
+
+    func waitUntilStarted() async {
+        while !started { await Task.yield() }
+    }
+
+    func waitUntilCancelled() async {
+        while !cancelled { await Task.yield() }
+    }
+}
+
+private struct ServiceTestClock: AFMServerClock {
+    func unixTime() -> Int64 { 123 }
+}
+
+private func testChatService(
+    generator: any AFMChatCompletionGenerating,
+    catalog: any AFMModelCatalog = AFMStaticModelCatalog(
+        models: [.init(id: "system", isAvailable: true)]
+    ),
+    policy: AFMServerGenerationPolicy = .init()
+) -> AFMChatCompletionService {
+    AFMChatCompletionService(
+        catalog: catalog,
+        generator: generator,
+        clock: ServiceTestClock(),
+        policy: policy
+    )
+}
+
+private func standardResult() -> AFMChatGenerationResult {
+    .init(
+        content: "Done",
+        usage: .init(inputTokenCount: 1, measurement: .estimated, scope: .response)
+    )
+}
+
+private func chatBody(model: String = "system") -> Data {
+    Data(#"{"model":"\#(model)","messages":[{"role":"user","content":"Hi"}]}"#.utf8)
+}
+
+private func serviceJSONObject(_ data: Data) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func serviceErrorCode(_ data: Data) throws -> String? {
+    let json = try serviceJSONObject(data)
+    let error = try #require(json["error"] as? [String: Any])
+    return error["code"] as? String
+}

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMChatRequestTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMChatRequestTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("Chat requests accept string and typed text content plus the max_tokens alias")
+func chatRequestContentAndAlias() throws {
+    let request = try decodeChatRequest(
+        """
+        {
+          "model": "system",
+          "messages": [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": [
+              {"type": "text", "text": "First"},
+              {"type": "text", "text": "Second"}
+            ]}
+          ],
+          "temperature": 0.5,
+          "top_p": 0.9,
+          "max_tokens": 42,
+          "stream": false
+        }
+        """
+    )
+
+    #expect(request.model == "system")
+    #expect(request.messages[1].contentSegments == ["First", "Second"])
+    #expect(request.maximumCompletionTokens == 42)
+    #expect(request.temperature == 0.5)
+    #expect(request.topP == 0.9)
+}
+
+@Test("Chat requests reconstruct assistant tool calls and matching tool outputs")
+func chatRequestToolHistory() throws {
+    let request = try decodeChatRequest(validToolHistoryJSON)
+    #expect(request.messages.count == 4)
+    #expect(request.messages[1].toolCalls == [
+        .init(id: "call_1", name: "weather", arguments: #"{"city":"Paris"}"#)
+    ])
+    #expect(request.messages[2].toolCallID == "call_1")
+    #expect(request.messages[2].name == "weather")
+}
+
+@Test(
+    "Unsupported and unknown chat fields return precise validation errors",
+    arguments: [
+        (#"{"messages":[{"role":"user","content":"Hi"}],"stream":true}"#, "stream", "unsupported_field"),
+        (#"{"messages":[{"role":"user","content":"Hi"}],"tools":[]}"#, "tools", "unsupported_field"),
+        (#"{"messages":[{"role":"user","content":"Hi"}],"response_format":{}}"#, "response_format", "unsupported_field"),
+        (#"{"messages":[{"role":"user","content":"Hi"}],"surprise":1}"#, "surprise", "unknown_field"),
+        (
+            #"{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"x"}}]}]}"#,
+            "messages[0].content[0].image_url",
+            "unsupported_field"
+        )
+    ]
+)
+func chatRequestRejectedFields(json: String, parameter: String, code: String) {
+    expectChatValidationError(json, parameter: parameter, code: code)
+}
+
+@Test("Chat option conflicts and invalid ranges fail before generation")
+func chatRequestOptionValidation() {
+    expectChatValidationError(
+        #"{"messages":[{"role":"user","content":"Hi"}],"max_tokens":1,"max_completion_tokens":1}"#,
+        parameter: "max_tokens",
+        code: "invalid_field"
+    )
+    expectChatValidationError(
+        #"{"messages":[{"role":"user","content":"Hi"}],"temperature":1.1}"#,
+        parameter: "temperature",
+        code: "invalid_field"
+    )
+    expectChatValidationError(
+        #"{"messages":[{"role":"user","content":"Hi"}],"top_p":0}"#,
+        parameter: "top_p",
+        code: "invalid_field"
+    )
+}
+
+@Test("Tool history rejects missing, duplicate, and out-of-order outputs")
+func chatRequestToolSequenceValidation() {
+    expectChatValidationError(
+        #"""
+        {"messages":[
+          {"role":"assistant","tool_calls":[
+            {"id":"a","type":"function","function":{"name":"f","arguments":"{}"}}
+          ]},
+          {"role":"user","content":"continue"}
+        ]}
+        """#,
+        parameter: "messages[1].role",
+        code: "invalid_field"
+    )
+    expectChatValidationError(
+        #"{"messages":[{"role":"tool","tool_call_id":"missing","content":"x"}]}"#,
+        parameter: "messages[0].tool_call_id",
+        code: "invalid_field"
+    )
+    expectChatValidationError(
+        #"""
+        {"messages":[
+          {"role":"assistant","tool_calls":[
+            {"id":"a","type":"function","function":{"name":"f","arguments":"{}"}},
+            {"id":"a","type":"function","function":{"name":"f","arguments":"{}"}}
+          ]},
+          {"role":"tool","tool_call_id":"a","content":"x"}
+        ]}
+        """#,
+        parameter: "messages[0].tool_calls[1].id",
+        code: "invalid_field"
+    )
+}
+
+private let validToolHistoryJSON = #"""
+{
+  "messages": [
+    {"role":"user","content":"Weather?"},
+    {"role":"assistant","tool_calls":[
+      {"id":"call_1","type":"function","function":{"name":"weather","arguments":"{\"city\":\"Paris\"}"}}
+    ]},
+    {"role":"tool","tool_call_id":"call_1","name":"weather","content":"Sunny"},
+    {"role":"user","content":"Summarize"}
+  ]
+}
+"""#
+
+private func decodeChatRequest(_ json: String) throws -> AFMChatGenerationRequest {
+    try AFMChatGenerationRequest.decode(Data(json.utf8))
+}
+
+private func expectChatValidationError(_ json: String, parameter: String, code: String) {
+    do {
+        _ = try decodeChatRequest(json)
+        Issue.record("Expected chat request validation to fail")
+    } catch let error as AFMChatRequestValidationError {
+        #expect(error.parameter == parameter)
+        #expect(error.code == code)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMChatTranscriptBuilderTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMChatTranscriptBuilderTests.swift
@@ -3,6 +3,22 @@ import FoundationModels
 import Testing
 @testable import AFMServer
 
+#if compiler(>=6.4)
+@available(iOS 27.0, macOS 27.0, *)
+@Test("Modern session errors distinguish concurrency from transcript mutation")
+func modernSessionErrorMapping() {
+    let concurrent = AFMFoundationModelsChatGenerator.mapModernError(
+        LanguageModelSession.Error.concurrentRequests
+    )
+    let transcriptMutation = AFMFoundationModelsChatGenerator.mapModernError(
+        LanguageModelSession.Error.transcriptMutationWhileResponding
+    )
+
+    #expect(concurrent == .concurrentRequest)
+    #expect(transcriptMutation == nil)
+}
+#endif
+
 @Test("Transcript reconstruction preserves instructions, turns, tools, and the active prompt")
 func transcriptReconstruction() throws {
     let request = try AFMChatGenerationRequest.decode(Data(transcriptRequestJSON.utf8))

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMChatTranscriptBuilderTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMChatTranscriptBuilderTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import FoundationModels
+import Testing
+@testable import AFMServer
+
+@Test("Transcript reconstruction preserves instructions, turns, tools, and the active prompt")
+func transcriptReconstruction() throws {
+    let request = try AFMChatGenerationRequest.decode(Data(transcriptRequestJSON.utf8))
+    let prepared = try AFMChatTranscriptBuilder.prepare(request)
+    let entries = Array(prepared.transcript)
+
+    #expect(entries.count == 5)
+    guard case .instructions(let instructions) = entries[0] else {
+        Issue.record("Expected instructions entry")
+        return
+    }
+    #expect(text(instructions.segments) == ["System rules", "Developer rules"])
+
+    guard case .prompt(let historicalPrompt) = entries[1] else {
+        Issue.record("Expected historical prompt")
+        return
+    }
+    #expect(text(historicalPrompt.segments) == ["Question"])
+
+    guard case .response(let response) = entries[2] else {
+        Issue.record("Expected assistant response")
+        return
+    }
+    #expect(text(response.segments) == ["Checking"])
+
+    guard case .toolCalls(let calls) = entries[3] else {
+        Issue.record("Expected tool calls")
+        return
+    }
+    #expect(calls.first?.id == "call_1")
+    #expect(calls.first?.toolName == "weather")
+    let argumentsJSON = try #require(calls.first?.arguments.jsonString)
+    let arguments = try #require(
+        JSONSerialization.jsonObject(with: Data(argumentsJSON.utf8)) as? [String: String]
+    )
+    #expect(arguments == ["city": "Paris"])
+
+    guard case .toolOutput(let output) = entries[4] else {
+        Issue.record("Expected tool output")
+        return
+    }
+    #expect(output.id == "call_1")
+    #expect(output.toolName == "weather")
+    #expect(text(output.segments) == ["Sunny"])
+
+    let inputEntries = Array(prepared.inputTranscript)
+    guard case .prompt(let activePrompt) = inputEntries.last else {
+        Issue.record("Expected active prompt")
+        return
+    }
+    #expect(text(activePrompt.segments) == ["Final", "question"])
+}
+
+@Test("A final tool output remains in history and receives an empty continuation prompt")
+func finalToolOutputReconstruction() throws {
+    let request = try AFMChatGenerationRequest.decode(Data(finalToolRequestJSON.utf8))
+    let prepared = try AFMChatTranscriptBuilder.prepare(request)
+    let entries = Array(prepared.transcript)
+
+    guard case .toolOutput = entries.last else {
+        Issue.record("Expected the final tool output in the reconstructed transcript")
+        return
+    }
+    guard case .prompt(let activePrompt) = Array(prepared.inputTranscript).last else {
+        Issue.record("Expected the continuation prompt")
+        return
+    }
+    #expect(text(activePrompt.segments) == [""])
+}
+
+private func text(_ segments: [Transcript.Segment]) -> [String] {
+    segments.compactMap { segment in
+        guard case .text(let text) = segment else { return nil }
+        return text.content
+    }
+}
+
+private let transcriptRequestJSON = #"""
+{
+  "messages": [
+    {"role":"system","content":"System rules"},
+    {"role":"developer","content":"Developer rules"},
+    {"role":"user","content":"Question"},
+    {"role":"assistant","content":"Checking","tool_calls":[
+      {"id":"call_1","type":"function","function":{"name":"weather","arguments":"{\"city\":\"Paris\"}"}}
+    ]},
+    {"role":"tool","tool_call_id":"call_1","name":"weather","content":"Sunny"},
+    {"role":"user","content":[{"type":"text","text":"Final"},{"type":"text","text":"question"}]}
+  ]
+}
+"""#
+
+private let finalToolRequestJSON = #"""
+{
+  "messages": [
+    {"role":"user","content":"Question"},
+    {"role":"assistant","tool_calls":[
+      {"id":"call_1","type":"function","function":{"name":"weather","arguments":"{}"}}
+    ]},
+    {"role":"tool","tool_call_id":"call_1","content":"Sunny"}
+  ]
+}
+"""#

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPHandlerTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPHandlerTests.swift
@@ -177,6 +177,30 @@ func keepAliveRequests() throws {
     _ = try? channel.finish()
 }
 
+@Test("A closing response ignores request parts received before its flush completes")
+func closingResponseIgnoresLateRequest() throws {
+    let delayedEnd = DelayedResponseEndHandler()
+    let channel = EmbeddedChannel(handler: delayedEnd)
+    try channel.pipeline.syncOperations.addHandler(
+        AFMHTTPHandler(router: testRouter(), limits: .init())
+    )
+
+    try writeRequest(
+        path: "/health",
+        additionalHeaders: [("connection", "close")],
+        to: channel
+    )
+    try writeRequest(path: "/v1/models", to: channel)
+
+    let response = try readResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "connection") == "close")
+    #expect(try channel.readOutbound(as: HTTPServerResponsePart.self) == nil)
+    delayedEnd.completeWrites()
+    channel.embeddedEventLoop.run()
+    _ = try? channel.finish()
+}
+
 @Test("Chat POST requires JSON even when the body is empty")
 func chatRequiresJSONContentType() throws {
     let channel = EmbeddedChannel(
@@ -198,6 +222,29 @@ private struct TestClock: AFMServerClock {
 private struct TestHTTPResponse {
     let head: HTTPResponseHead
     let body: Data
+}
+
+private final class DelayedResponseEndHandler: ChannelOutboundHandler, @unchecked Sendable {
+    typealias OutboundIn = HTTPServerResponsePart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private var completionPromises: [EventLoopPromise<Void>] = []
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        if case .end = unwrapOutboundIn(data) {
+            if let promise {
+                completionPromises.append(promise)
+            }
+            context.write(data, promise: nil)
+        } else {
+            context.write(data, promise: promise)
+        }
+    }
+
+    func completeWrites() {
+        completionPromises.forEach { $0.succeed(()) }
+        completionPromises.removeAll()
+    }
 }
 
 private func testRouter(

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPHandlerTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPHandlerTests.swift
@@ -177,6 +177,18 @@ func keepAliveRequests() throws {
     _ = try? channel.finish()
 }
 
+@Test("Chat POST requires JSON even when the body is empty")
+func chatRequiresJSONContentType() throws {
+    let channel = EmbeddedChannel(
+        handler: AFMHTTPHandler(router: testRouter(), limits: .init())
+    )
+    try writeRequest(method: .POST, path: "/v1/chat/completions", to: channel)
+    let response = try readResponse(from: channel)
+    #expect(response.head.status == .unsupportedMediaType)
+    #expect(try errorCode(response.body) == "unsupported_media_type")
+    _ = try? channel.finish()
+}
+
 private struct TestClock: AFMServerClock {
     let value: Int64
 

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import FoundationModelsKit
 import Testing
 @testable import AFMServer
 
@@ -42,6 +43,71 @@ func tcpTransportAndLimits() async throws {
         #expect(oversizedBody.hasPrefix("HTTP/1.1 413 Payload Too Large"))
         #expect(oversizedBody.contains("\"code\":\"request_too_large\""))
 
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("TCP transport serves an injected non-streaming chat completion")
+func tcpChatCompletion() async throws {
+    let server = try testServer(
+        configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)),
+        generator: IntegrationImmediateGenerator()
+    )
+
+    do {
+        let address = try await server.start()
+        guard case .tcp(_, let port) = address else {
+            Issue.record("Expected a TCP address")
+            try await server.stop()
+            return
+        }
+        let body = #"{"messages":[{"role":"user","content":"Hi"}]}"#
+        let request = chatHTTPRequest(body: body, port: port, close: true)
+        let response = try sendRawHTTPRequest(request, port: port)
+        #expect(response.hasPrefix("HTTP/1.1 200 OK"))
+        #expect(response.contains("\"content\":\"From TCP\""))
+        #expect(response.contains("\"afm_measurement\":\"estimated\""))
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("A TCP disconnect cancels its in-flight model generation")
+func tcpDisconnectCancelsChat() async throws {
+    let probe = IntegrationCancellationProbe()
+    let server = try testServer(
+        configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)),
+        generator: IntegrationPausingGenerator(probe: probe)
+    )
+
+    do {
+        let address = try await server.start()
+        guard case .tcp(_, let port) = address else {
+            Issue.record("Expected a TCP address")
+            try await server.stop()
+            return
+        }
+        let descriptor = try connectTCPSocket(port: port)
+        let body = #"{"messages":[{"role":"user","content":"Hi"}]}"#
+        try writeRawHTTPRequest(chatHTTPRequest(body: body, port: port, close: false), to: descriptor)
+        await probe.waitUntilStarted()
+        var reset = linger(l_onoff: 1, l_linger: 0)
+        #expect(
+            setsockopt(
+                descriptor,
+                SOL_SOCKET,
+                SO_LINGER,
+                &reset,
+                socklen_t(MemoryLayout<linger>.size)
+            ) == 0
+        )
+        #expect(Darwin.close(descriptor) == 0)
+        await probe.waitUntilCancelled()
         try await server.stop()
     } catch {
         try? await server.stop()
@@ -284,12 +350,87 @@ func unixSocketRejectsInsecureParent() async throws {
     await expectStartFailure(server, matching: .insecureParentDirectory)
 }
 
-private func testServer(configuration: AFMServerConfiguration) throws -> AFMHTTPServer {
+private func testServer(
+    configuration: AFMServerConfiguration,
+    generator: any AFMChatCompletionGenerating = AFMFoundationModelsChatGenerator()
+) throws -> AFMHTTPServer {
     try AFMHTTPServer(
         configuration: configuration,
         catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
-        clock: IntegrationTestClock()
+        clock: IntegrationTestClock(),
+        generator: generator
     )
+}
+
+private struct IntegrationImmediateGenerator: AFMChatCompletionGenerating {
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        .init(
+            content: "From TCP",
+            usage: .init(inputTokenCount: 2, measurement: .estimated, scope: .response)
+        )
+    }
+}
+
+private struct IntegrationPausingGenerator: AFMChatCompletionGenerating {
+    let probe: IntegrationCancellationProbe
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        await probe.markStarted()
+        return try await withTaskCancellationHandler {
+            try await ContinuousClock().sleep(for: .seconds(30))
+            return .init(
+                content: "Unexpected",
+                usage: .init(inputTokenCount: 1, measurement: .estimated, scope: .response)
+            )
+        } onCancel: {
+            Task { await probe.markCancelled() }
+        }
+    }
+}
+
+private actor IntegrationCancellationProbe {
+    private var started = false
+    private var cancelled = false
+
+    func markStarted() { started = true }
+    func markCancelled() { cancelled = true }
+
+    func waitUntilStarted() async {
+        while !started { await Task.yield() }
+    }
+
+    func waitUntilCancelled() async {
+        while !cancelled { await Task.yield() }
+    }
+}
+
+private func chatHTTPRequest(body: String, port: Int, close: Bool) -> String {
+    var request = "POST /v1/chat/completions HTTP/1.1\r\n"
+    request += "Host: 127.0.0.1:\(port)\r\n"
+    request += "Content-Type: application/json\r\n"
+    request += "Content-Length: \(body.utf8.count)\r\n"
+    if close {
+        request += "Connection: close\r\n"
+    }
+    return request + "\r\n" + body
+}
+
+private func writeRawHTTPRequest(_ request: String, to descriptor: CInt) throws {
+    let requestBytes = Array(request.utf8)
+    try requestBytes.withUnsafeBytes { buffer in
+        var sent = 0
+        while sent < buffer.count {
+            let result = Darwin.write(
+                descriptor,
+                buffer.baseAddress?.advanced(by: sent),
+                buffer.count - sent
+            )
+            guard result > 0 else {
+                throw POSIXTestError(operation: "write TCP request", code: errno)
+            }
+            sent += result
+        }
+    }
 }
 
 private struct IntegrationTestClock: AFMServerClock {
@@ -341,19 +482,7 @@ private func sendRawHTTPRequest(_ request: String, port: Int) throws -> String {
     let descriptor = try connectTCPSocket(port: port)
     defer { Darwin.close(descriptor) }
 
-    let requestBytes = Array(request.utf8)
-    try requestBytes.withUnsafeBytes { buffer in
-        var sent = 0
-        while sent < buffer.count {
-            let result = Darwin.write(
-                descriptor,
-                buffer.baseAddress?.advanced(by: sent),
-                buffer.count - sent
-            )
-            guard result > 0 else { throw POSIXTestError(operation: "write TCP request", code: errno) }
-            sent += result
-        }
-    }
+    try writeRawHTTPRequest(request, to: descriptor)
 
     var response = Data()
     var buffer = [UInt8](repeating: 0, count: 4_096)

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -4,6 +4,8 @@ import FoundationModelsKit
 import Testing
 @testable import AFMServer
 
+// swiftlint:disable file_length
+
 @Test("TCP transport serves health and enforces parser and body limits")
 func tcpTransportAndLimits() async throws {
     let limits = AFMServerLimits(
@@ -77,6 +79,43 @@ func tcpChatCompletion() async throws {
     }
 }
 
+@Test("A pipelined request cannot replace an in-flight chat response")
+func tcpPipelinedChatCompletion() async throws {
+    let probe = IntegrationCompletionProbe()
+    let server = try testServer(
+        configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)),
+        generator: IntegrationControlledGenerator(probe: probe)
+    )
+
+    do {
+        let address = try await server.start()
+        guard case .tcp(_, let port) = address else {
+            Issue.record("Expected a TCP address")
+            try await server.stop()
+            return
+        }
+        let body = #"{"messages":[{"role":"user","content":"Hi"}]}"#
+        let chat = chatHTTPRequest(body: body, port: port, close: false)
+        let health = "GET /health HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nConnection: close\r\n\r\n"
+        let responseTask = Task.detached {
+            try sendRawHTTPRequest(chat + health, port: port)
+        }
+
+        try await probe.waitUntilStarted()
+        await probe.complete()
+        let response = try await responseTask.value
+        #expect(response.components(separatedBy: "HTTP/1.1 200 OK").count == 2)
+        #expect(response.contains(#""object":"chat.completion""#))
+        #expect(response.contains("connection: close"))
+        #expect(!response.contains(#""status":"afm serve is running""#))
+        #expect(!response.contains("HTTP/1.1 400 Bad Request"))
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
 @Test("A TCP disconnect cancels its in-flight model generation")
 func tcpDisconnectCancelsChat() async throws {
     let probe = IntegrationCancellationProbe()
@@ -95,7 +134,7 @@ func tcpDisconnectCancelsChat() async throws {
         let descriptor = try connectTCPSocket(port: port)
         let body = #"{"messages":[{"role":"user","content":"Hi"}]}"#
         try writeRawHTTPRequest(chatHTTPRequest(body: body, port: port, close: false), to: descriptor)
-        await probe.waitUntilStarted()
+        try await probe.waitUntilStarted()
         var reset = linger(l_onoff: 1, l_linger: 0)
         #expect(
             setsockopt(
@@ -107,7 +146,7 @@ func tcpDisconnectCancelsChat() async throws {
             ) == 0
         )
         #expect(Darwin.close(descriptor) == 0)
-        await probe.waitUntilCancelled()
+        try await probe.waitUntilCancelled()
         try await server.stop()
     } catch {
         try? await server.stop()
@@ -371,6 +410,46 @@ private struct IntegrationImmediateGenerator: AFMChatCompletionGenerating {
     }
 }
 
+private struct IntegrationControlledGenerator: AFMChatCompletionGenerating {
+    let probe: IntegrationCompletionProbe
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        await probe.waitForCompletion()
+        return .init(
+            content: "First response",
+            usage: .init(inputTokenCount: 2, measurement: .estimated, scope: .response)
+        )
+    }
+}
+
+private actor IntegrationCompletionProbe {
+    private var started = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func waitForCompletion() async {
+        started = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilStarted() async throws {
+        try await waitUntil { started }
+    }
+
+    private func waitUntil(_ predicate: () -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while !predicate() {
+            guard clock.now < deadline else { throw IntegrationProbeError.timedOut }
+            await Task.yield()
+        }
+    }
+
+    func complete() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
 private struct IntegrationPausingGenerator: AFMChatCompletionGenerating {
     let probe: IntegrationCancellationProbe
 
@@ -395,13 +474,26 @@ private actor IntegrationCancellationProbe {
     func markStarted() { started = true }
     func markCancelled() { cancelled = true }
 
-    func waitUntilStarted() async {
-        while !started { await Task.yield() }
+    func waitUntilStarted() async throws {
+        try await waitUntil { started }
     }
 
-    func waitUntilCancelled() async {
-        while !cancelled { await Task.yield() }
+    func waitUntilCancelled() async throws {
+        try await waitUntil { cancelled }
     }
+
+    private func waitUntil(_ predicate: () -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while !predicate() {
+            guard clock.now < deadline else { throw IntegrationProbeError.timedOut }
+            await Task.yield()
+        }
+    }
+}
+
+private enum IntegrationProbeError: Error {
+    case timedOut
 }
 
 private func chatHTTPRequest(body: String, port: Int, close: Bool) -> String {

--- a/Tools/AFMCLI/Tests/AFMServerTests/AFMServerConfigurationTests.swift
+++ b/Tools/AFMCLI/Tests/AFMServerTests/AFMServerConfigurationTests.swift
@@ -78,3 +78,20 @@ func transportLimitValidation() throws {
         _ = try nullSocket.validated()
     }
 }
+
+@Test("Generation limits validate before the server starts")
+func generationLimitValidation() {
+    let invalidConcurrency = AFMServerConfiguration(
+        generation: .init(maximumConcurrentGenerations: 0)
+    )
+    #expect(throws: AFMServerConfigurationError.invalidGenerationConcurrency) {
+        _ = try invalidConcurrency.validated()
+    }
+
+    for timeout in [0, -1, .infinity, .nan] {
+        let invalidTimeout = AFMServerConfiguration(generation: .init(timeoutSeconds: timeout))
+        #expect(throws: AFMServerConfigurationError.invalidGenerationTimeout) {
+            _ = try invalidTimeout.validated()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add non-streaming `POST /v1/chat/completions` to `afm serve`
- reconstruct stateless system, developer, user, assistant, tool-call, and tool-output history into a Foundation Models transcript
- support text parts, temperature, top-p, and response-token limits with strict, parameter-addressed validation
- return OpenAI-shaped choices/errors plus shared input/output token usage and explicit observed/tokenized/estimated provenance
- bound generation concurrency, enforce timeouts, and cancel model work when the client disconnects

This is stacked on #170 (which is stacked on #167). Streaming, images, response schemas, and client-defined tool execution remain separate reviewable slices.

## Verification

- Xcode 26.6 full suite: 45 XCTest + 176 Swift Testing tests, 0 failures
- Xcode 27 full suite: passed
- focused server/CLI tests: 34 passed under each toolchain
- strict SwiftLint: 0 violations
- real loopback OS 27 calls: simple chat `200` with observed usage (61 input / 5 output); assistant + tool history `200` (124 / 15); final tool-output continuation `200` (105 / 25)
- integration tests exercise TCP response shape and disconnect-driven cancellation