### PR TITLE
Normalize Foundation Models runtime errors

### DIFF
--- a/FoundationLabCore/Sources/FoundationLabCore/Errors/FoundationLabModelErrorProjection.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Errors/FoundationLabModelErrorProjection.swift
@@ -1,0 +1,237 @@
+import Foundation
+import FoundationModels
+
+/// A stable, machine-readable view of Foundation Models failures across framework generations.
+public struct FoundationLabModelErrorProjection: Sendable, Hashable, Codable {
+    public enum Category: String, Sendable, Hashable, Codable {
+        case contextSizeExceeded = "context_size_exceeded"
+        case assetsUnavailable = "assets_unavailable"
+        case guardrailViolation = "guardrail_violation"
+        case refusal
+        case unsupportedCapability = "unsupported_capability"
+        case unsupportedTranscriptContent = "unsupported_transcript_content"
+        case unsupportedGenerationGuide = "unsupported_generation_guide"
+        case unsupportedLanguageOrLocale = "unsupported_language_or_locale"
+        case decodingFailure = "decoding_failure"
+        case rateLimited = "rate_limited"
+        case concurrentRequests = "concurrent_requests"
+        case transcriptMutationWhileResponding = "transcript_mutation_while_responding"
+        case timeout
+        case networkFailure = "network_failure"
+        case quotaLimitReached = "quota_limit_reached"
+        case serviceUnavailable = "service_unavailable"
+        case unknown
+    }
+
+    public enum Capability: String, Sendable, Hashable, Codable {
+        case vision
+        case guidedGeneration = "guided_generation"
+        case reasoning
+        case toolCalling = "tool_calling"
+        case unknown
+    }
+
+    public let category: Category
+    public let contextSize: Int?
+    public let attemptedTokenCount: Int?
+    public let resetDate: Date?
+    public let capability: Capability?
+    public let schemaName: String?
+    public let languageCode: String?
+    public let unsupportedTranscriptEntryCount: Int?
+    public let hasQuotaLimitIncreaseSuggestion: Bool?
+
+    public var isContextOverflow: Bool {
+        category == .contextSizeExceeded
+    }
+
+    public static func isContextOverflow(_ error: any Error) -> Bool {
+        project(error)?.isContextOverflow == true
+    }
+
+    public static func project(_ error: any Error) -> Self? {
+        if let generationError = error as? LanguageModelSession.GenerationError {
+            return project(generationError)
+        }
+
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            if let modelError = error as? FoundationModels.LanguageModelError {
+                return project(modelError)
+            }
+            if let systemModelError = error as? SystemLanguageModel.Error {
+                return project(systemModelError)
+            }
+            if let sessionError = error as? LanguageModelSession.Error {
+                return project(sessionError)
+            }
+            if let privateCloudError = error as? PrivateCloudComputeLanguageModel.Error {
+                return project(privateCloudError)
+            }
+            if let parsingError = error as? GeneratedContent.ParsingError {
+                return project(parsingError)
+            }
+        }
+        #endif
+
+        return nil
+    }
+
+    private init(
+        category: Category,
+        contextSize: Int? = nil,
+        attemptedTokenCount: Int? = nil,
+        resetDate: Date? = nil,
+        capability: Capability? = nil,
+        schemaName: String? = nil,
+        languageCode: String? = nil,
+        unsupportedTranscriptEntryCount: Int? = nil,
+        hasQuotaLimitIncreaseSuggestion: Bool? = nil
+    ) {
+        self.category = category
+        self.contextSize = contextSize
+        self.attemptedTokenCount = attemptedTokenCount
+        self.resetDate = resetDate
+        self.capability = capability
+        self.schemaName = schemaName
+        self.languageCode = languageCode
+        self.unsupportedTranscriptEntryCount = unsupportedTranscriptEntryCount
+        self.hasQuotaLimitIncreaseSuggestion = hasQuotaLimitIncreaseSuggestion
+    }
+}
+
+private extension FoundationLabModelErrorProjection {
+    static func project(_ error: LanguageModelSession.GenerationError) -> Self {
+        switch error {
+        case .exceededContextWindowSize:
+            Self(category: .contextSizeExceeded)
+        case .assetsUnavailable:
+            Self(category: .assetsUnavailable)
+        case .guardrailViolation:
+            Self(category: .guardrailViolation)
+        case .unsupportedGuide:
+            Self(category: .unsupportedGenerationGuide)
+        case .unsupportedLanguageOrLocale:
+            Self(category: .unsupportedLanguageOrLocale)
+        case .decodingFailure:
+            Self(category: .decodingFailure)
+        case .rateLimited:
+            Self(category: .rateLimited)
+        case .concurrentRequests:
+            Self(category: .concurrentRequests)
+        case .refusal:
+            Self(category: .refusal)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: FoundationModels.LanguageModelError) -> Self {
+        switch error {
+        case .contextSizeExceeded(let context):
+            Self(
+                category: .contextSizeExceeded,
+                contextSize: context.contextSize,
+                attemptedTokenCount: context.tokenCount
+            )
+        case .rateLimited(let context):
+            Self(
+                category: .rateLimited,
+                resetDate: context.resetDate
+            )
+        case .guardrailViolation:
+            Self(category: .guardrailViolation)
+        case .refusal:
+            Self(category: .refusal)
+        case .unsupportedCapability(let context):
+            Self(
+                category: .unsupportedCapability,
+                capability: project(context.capability)
+            )
+        case .unsupportedTranscriptContent(let context):
+            Self(
+                category: .unsupportedTranscriptContent,
+                unsupportedTranscriptEntryCount: context.unsupportedContent.count
+            )
+        case .unsupportedGenerationGuide(let context):
+            Self(
+                category: .unsupportedGenerationGuide,
+                schemaName: context.schemaName
+            )
+        case .unsupportedLanguageOrLocale(let context):
+            Self(
+                category: .unsupportedLanguageOrLocale,
+                languageCode: context.languageCode.identifier
+            )
+        case .timeout:
+            Self(category: .timeout)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: SystemLanguageModel.Error) -> Self {
+        switch error {
+        case .assetsUnavailable:
+            Self(category: .assetsUnavailable)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: LanguageModelSession.Error) -> Self {
+        switch error {
+        case .concurrentRequests:
+            Self(category: .concurrentRequests)
+        case .transcriptMutationWhileResponding:
+            Self(category: .transcriptMutationWhileResponding)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: PrivateCloudComputeLanguageModel.Error) -> Self {
+        switch error {
+        case .networkFailure:
+            Self(category: .networkFailure)
+        case .quotaLimitReached(let context):
+            Self(
+                category: .quotaLimitReached,
+                resetDate: context.resetDate,
+                hasQuotaLimitIncreaseSuggestion: context.limitIncreaseSuggestion != nil
+            )
+        case .serviceUnavailable:
+            Self(category: .serviceUnavailable)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_: GeneratedContent.ParsingError) -> Self {
+        Self(category: .decodingFailure)
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ capability: LanguageModelCapabilities.Capability) -> Capability {
+        if capability == .vision {
+            return .vision
+        }
+        if capability == .guidedGeneration {
+            return .guidedGeneration
+        }
+        if capability == .reasoning {
+            return .reasoning
+        }
+        if capability == .toolCalling {
+            return .toolCalling
+        }
+        return .unknown
+    }
+    #endif
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationLabConversationEngine.swift
@@ -170,7 +170,7 @@ public final class FoundationLabConversationEngine {
             )
             await updateTokenCount()
             return response
-        } catch LanguageModelSession.GenerationError.exceededContextWindowSize {
+        } catch where FoundationLabModelErrorProjection.isContextOverflow(error) {
             return try await recoverFromContextOverflow(
                 userMessage: prompt,
                 generationOptions: generationOptions,
@@ -196,7 +196,7 @@ public final class FoundationLabConversationEngine {
             )
             await updateTokenCount()
             return response
-        } catch LanguageModelSession.GenerationError.exceededContextWindowSize {
+        } catch where FoundationLabModelErrorProjection.isContextOverflow(error) {
             return try await recoverFromContextOverflow(
                 userMessage: prompt,
                 generationOptions: generationOptions,

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabModelErrorProjectionModernTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabModelErrorProjectionModernTests.swift
@@ -1,0 +1,181 @@
+#if compiler(>=6.4)
+import Foundation
+import FoundationModels
+import XCTest
+@testable import FoundationLabCore
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+final class FoundationLabModelErrorProjectionModernTests: XCTestCase {
+    func testLanguageModelErrorPreservesStableContextAndRateLimitDetails() throws {
+        let resetDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let overflowContext = FoundationModels.LanguageModelError.ContextSizeExceeded(
+            contextSize: 8_192,
+            tokenCount: 8_321,
+            debugDescription: "Modern context overflow",
+            metadata: ["fixture": "context-overflow"]
+        )
+        let overflow = FoundationModels.LanguageModelError.contextSizeExceeded(overflowContext)
+        let rateLimit = FoundationModels.LanguageModelError.rateLimited(
+            .init(
+                resetDate: resetDate,
+                debugDescription: "Modern rate limit",
+                metadata: ["scope": "model"]
+            )
+        )
+
+        let overflowProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(overflow)
+        )
+        let rateLimitProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(rateLimit)
+        )
+
+        XCTAssertEqual(overflowProjection.category, .contextSizeExceeded)
+        XCTAssertEqual(overflowProjection.contextSize, 8_192)
+        XCTAssertEqual(overflowProjection.attemptedTokenCount, 8_321)
+        XCTAssertTrue(FoundationLabModelErrorProjection.isContextOverflow(overflow))
+        XCTAssertEqual(rateLimitProjection.category, .rateLimited)
+        XCTAssertEqual(rateLimitProjection.resetDate, resetDate)
+        XCTAssertFalse(FoundationLabModelErrorProjection.isContextOverflow(rateLimit))
+
+        let encoded = try JSONEncoder().encode(overflowProjection)
+        let decoded = try JSONDecoder().decode(
+            FoundationLabModelErrorProjection.self,
+            from: encoded
+        )
+        XCTAssertEqual(decoded, overflowProjection)
+        let payload = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertFalse(payload.contains("Modern context overflow"))
+        XCTAssertFalse(payload.contains("context-overflow"))
+    }
+
+    func testLanguageModelErrorPreservesPolicyAndCapabilityCategories() throws {
+        let guardrail = FoundationModels.LanguageModelError.guardrailViolation(
+            .init(debugDescription: "Modern guardrail", metadata: ["policy": "safety"])
+        )
+        let refusal = FoundationModels.LanguageModelError.refusal(
+            .init(debugDescription: "Modern refusal", metadata: ["reason": "policy"])
+        )
+        let unsupportedCapability = FoundationModels.LanguageModelError.unsupportedCapability(
+            .init(
+                capability: .reasoning,
+                debugDescription: "Reasoning unsupported",
+                metadata: ["model": "system"]
+            )
+        )
+
+        let guardrailProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(guardrail)
+        )
+        let refusalProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(refusal)
+        )
+        let capabilityProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(unsupportedCapability)
+        )
+
+        XCTAssertEqual(guardrailProjection.category, .guardrailViolation)
+        XCTAssertEqual(refusalProjection.category, .refusal)
+        XCTAssertEqual(capabilityProjection.category, .unsupportedCapability)
+        XCTAssertEqual(capabilityProjection.capability, .reasoning)
+    }
+
+    func testLanguageModelErrorPreservesAdditionalPublicDetails() throws {
+        let unsupportedContent = FoundationModels.LanguageModelError.unsupportedTranscriptContent(
+            .init(unsupportedContent: [], debugDescription: "Unsupported transcript")
+        )
+        let unsupportedGuide = FoundationModels.LanguageModelError.unsupportedGenerationGuide(
+            .init(schemaName: "Recipe", debugDescription: "Unsupported guide")
+        )
+        let unsupportedLanguage = FoundationModels.LanguageModelError.unsupportedLanguageOrLocale(
+            .init(languageCode: Locale.LanguageCode("fr"), debugDescription: "Unsupported language")
+        )
+        let timeout = FoundationModels.LanguageModelError.timeout(
+            .init(debugDescription: "Timed out")
+        )
+        let parsingError = GeneratedContent.ParsingError(
+            rawContent: "{}",
+            underlyingError: FoundationLabCoreError.invalidRequest("Fixture parsing failure"),
+            debugDescription: "Parsing failed"
+        )
+
+        let contentProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(unsupportedContent)
+        )
+        let guideProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(unsupportedGuide)
+        )
+        let languageProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(unsupportedLanguage)
+        )
+        let timeoutProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(timeout)
+        )
+        let parsingProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(parsingError)
+        )
+
+        XCTAssertEqual(contentProjection.category, .unsupportedTranscriptContent)
+        XCTAssertEqual(contentProjection.unsupportedTranscriptEntryCount, 0)
+        XCTAssertEqual(guideProjection.category, .unsupportedGenerationGuide)
+        XCTAssertEqual(guideProjection.schemaName, "Recipe")
+        XCTAssertEqual(languageProjection.category, .unsupportedLanguageOrLocale)
+        XCTAssertEqual(languageProjection.languageCode, "fr")
+        XCTAssertEqual(timeoutProjection.category, .timeout)
+        XCTAssertEqual(parsingProjection.category, .decodingFailure)
+
+        let payload = try XCTUnwrap(
+            String(data: try JSONEncoder().encode(parsingProjection), encoding: .utf8)
+        )
+        XCTAssertFalse(payload.contains("Fixture parsing failure"))
+        XCTAssertFalse(payload.contains("Parsing failed"))
+    }
+
+    func testRelatedModelErrorsUseStableCategories() throws {
+        let resetDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixtures: [(any Error, FoundationLabModelErrorProjection.Category)] = [
+            (
+                SystemLanguageModel.Error.assetsUnavailable(
+                    .init(debugDescription: "Assets unavailable")
+                ),
+                .assetsUnavailable
+            ),
+            (LanguageModelSession.Error.concurrentRequests, .concurrentRequests),
+            (
+                LanguageModelSession.Error.transcriptMutationWhileResponding,
+                .transcriptMutationWhileResponding
+            ),
+            (
+                PrivateCloudComputeLanguageModel.Error.networkFailure(
+                    .init(debugDescription: "Network failure")
+                ),
+                .networkFailure
+            ),
+            (
+                PrivateCloudComputeLanguageModel.Error.quotaLimitReached(
+                    .init(resetDate: resetDate, debugDescription: "Quota reached")
+                ),
+                .quotaLimitReached
+            ),
+            (
+                PrivateCloudComputeLanguageModel.Error.serviceUnavailable(
+                    .init(debugDescription: "Service unavailable")
+                ),
+                .serviceUnavailable
+            )
+        ]
+
+        for (error, expectedCategory) in fixtures {
+            let projection = try XCTUnwrap(FoundationLabModelErrorProjection.project(error))
+            XCTAssertEqual(projection.category, expectedCategory)
+            XCTAssertFalse(projection.isContextOverflow)
+        }
+
+        let quotaProjection = try XCTUnwrap(
+            FoundationLabModelErrorProjection.project(fixtures[4].0)
+        )
+        XCTAssertEqual(quotaProjection.resetDate, resetDate)
+        XCTAssertEqual(quotaProjection.hasQuotaLimitIncreaseSuggestion, false)
+    }
+}
+#endif

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabModelErrorProjectionTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabModelErrorProjectionTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import FoundationModels
+import XCTest
+@testable import FoundationLabCore
+
+final class FoundationLabModelErrorProjectionTests: XCTestCase {
+    func testGenerationErrorContextOverflowDoesNotInventUnavailableDetails() throws {
+        let error = LanguageModelSession.GenerationError.exceededContextWindowSize(
+            .init(debugDescription: "Legacy context overflow")
+        )
+        let projection = try XCTUnwrap(FoundationLabModelErrorProjection.project(error))
+
+        XCTAssertEqual(projection.category, .contextSizeExceeded)
+        XCTAssertNil(projection.contextSize)
+        XCTAssertNil(projection.attemptedTokenCount)
+        XCTAssertNil(projection.resetDate)
+        XCTAssertNil(projection.capability)
+        XCTAssertTrue(projection.isContextOverflow)
+        XCTAssertTrue(FoundationLabModelErrorProjection.isContextOverflow(error))
+
+        let encoded = try JSONEncoder().encode(projection)
+        let decoded = try JSONDecoder().decode(
+            FoundationLabModelErrorProjection.self,
+            from: encoded
+        )
+        XCTAssertEqual(decoded, projection)
+        let payload = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertFalse(payload.contains("Legacy context overflow"))
+    }
+
+    func testGenerationErrorCategoriesRemainDistinctFromOverflow() throws {
+        let fixtures: [(
+            LanguageModelSession.GenerationError,
+            FoundationLabModelErrorProjection.Category
+        )] = [
+            (.assetsUnavailable(.init(debugDescription: "Assets")), .assetsUnavailable),
+            (.guardrailViolation(.init(debugDescription: "Guardrail")), .guardrailViolation),
+            (.unsupportedGuide(.init(debugDescription: "Guide")), .unsupportedGenerationGuide),
+            (
+                .unsupportedLanguageOrLocale(.init(debugDescription: "Language")),
+                .unsupportedLanguageOrLocale
+            ),
+            (.decodingFailure(.init(debugDescription: "Decoding")), .decodingFailure),
+            (.rateLimited(.init(debugDescription: "Rate")), .rateLimited),
+            (.concurrentRequests(.init(debugDescription: "Concurrent")), .concurrentRequests),
+            (
+                .refusal(
+                    .init(transcriptEntries: []),
+                    .init(debugDescription: "Refusal")
+                ),
+                .refusal
+            )
+        ]
+
+        for (error, expectedCategory) in fixtures {
+            let projection = try XCTUnwrap(FoundationLabModelErrorProjection.project(error))
+            XCTAssertEqual(projection.category, expectedCategory)
+            XCTAssertFalse(FoundationLabModelErrorProjection.isContextOverflow(error))
+        }
+    }
+
+    func testUnrelatedErrorsAreNotProjectedAsOverflow() {
+        struct UnrelatedError: Error {}
+        let error = UnrelatedError()
+
+        XCTAssertNil(FoundationLabModelErrorProjection.project(error))
+        XCTAssertFalse(FoundationLabModelErrorProjection.isContextOverflow(error))
+    }
+}


### PR DESCRIPTION
## Summary

- add one stable `FoundationLabModelErrorProjection` for OS 26 generation errors and the expanded OS 27 model, session, system-model, PCC, and parsing error families
- preserve only closed, Codable categories and documented typed details such as context size, attempted token count, reset date, capability, schema, language, and quota suggestion presence
- intentionally exclude opaque framework metadata, debug descriptions, and arbitrary underlying localized errors from the public boundary
- make conversation overflow recovery recognize both framework generations without broadening retry behavior

## Verification

- Xcode 26.6: 3 projection tests passed
- Xcode 27: 7 legacy + modern projection tests passed
- Codable round-trip and privacy-boundary assertions passed
- strict SwiftLint: 0 violations
- prior full deterministic package suites and all four generic Xcode 26/27 app builds passed for this slice; the API hardening was recompiled and retested under both toolchains
- `git diff --check`: clean