### PR TITLE
Add runnable schema object authoring

### DIFF
--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -103,6 +103,8 @@ afm tag run --prompt "A joyful dog playing in a sunny park."
 Use `afm schema` when you want the model to return data in a predictable shape.
 
 ```bash
+afm schema object --name Person --string name --integer age --optional > person.json
+afm schema object --format yaml --name Restaurant --string name --string address.street > restaurant.yaml
 afm schema list
 afm schema run typed-person --input "Alex Rivera is a designer in Berlin."
 afm schema run basic-object --preset product
@@ -111,6 +113,13 @@ afm schema run enum-schema --preset sentiment
 afm schema run custom --schema person-card --schema-dir .afm/schemas --input @person.txt
 afm schema run custom --schema person-card --input @person.txt --no-include-schema-in-prompt
 ```
+
+`schema object` follows the native `fm` declaration order: `--array`,
+`--description`, and `--optional` modify the property immediately before them.
+Dot-separated names create referenced nested objects. Use `--object <name>
+--schema <json>` for an explicit object, or `--anyOf` followed by repeated
+`--schema` values for a union. Prefix a schema path with `@` to compose JSON or
+YAML artifacts without shell substitution.
 
 ### Inspect and call tool manifests
 

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMSchemaObjectBuilder.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMSchemaObjectBuilder.swift
@@ -1,0 +1,267 @@
+import ArgumentParser
+import Foundation
+
+enum AFMSchemaObjectBuilder {
+    static func build(_ request: AFMSchemaObjectRequest) throws -> AFMSchemaDocument {
+        let document: AFMSchemaDocument
+        switch request.mode {
+        case .object(let properties):
+            document = try buildObject(name: request.name, properties: properties)
+        case .union(let schemas):
+            document = try buildUnion(name: request.name, schemas: schemas)
+        }
+        _ = try document.generationSchema(fallbackName: request.name)
+        return document
+    }
+
+    private static func buildObject(
+        name: String,
+        properties: [AFMSchemaObjectProperty]
+    ) throws -> AFMSchemaDocument {
+        let root = AFMSchemaObjectNode(name: name)
+        for property in properties {
+            try root.insert(property)
+        }
+
+        var definitions: [String: AFMSchemaDocumentBox] = [:]
+        var components = try objectComponents(for: root, definitions: &definitions)
+        components.definitions = definitions.isEmpty ? nil : definitions
+        return AFMSchemaDocument(components)
+    }
+
+    private static func buildUnion(
+        name: String,
+        schemas: [AFMSchemaDocument]
+    ) throws -> AFMSchemaDocument {
+        var definitions: [String: AFMSchemaDocumentBox] = [:]
+        var choices: [AFMSchemaDocumentBox] = []
+
+        for schema in schemas {
+            _ = try schema.generationSchema(fallbackName: "\(name)Choice")
+            try mergeDefinitions(from: schema, into: &definitions)
+            let choice = schemaWithoutDefinitions(schema)
+            if let title = choice.title, !title.isEmpty {
+                try mergeDefinition(named: title, document: choice, into: &definitions)
+                choices.append(AFMSchemaDocumentBox(referenceDocument(to: title)))
+            } else {
+                choices.append(AFMSchemaDocumentBox(choice))
+            }
+        }
+
+        var components = AFMSchemaDocument.Components()
+        components.title = name
+        components.anyOf = choices
+        components.definitions = definitions.isEmpty ? nil : definitions
+        return AFMSchemaDocument(components)
+    }
+
+    private static func objectComponents(
+        for node: AFMSchemaObjectNode,
+        definitions: inout [String: AFMSchemaDocumentBox]
+    ) throws -> AFMSchemaDocument.Components {
+        var properties: [String: AFMSchemaDocumentBox] = [:]
+        var required: [String] = []
+        let orderedNames = node.orderedPropertyNames
+
+        for propertyName in orderedNames {
+            guard let value = node.properties[propertyName] else {
+                throw ValidationError("Missing schema object property '\(propertyName)'.")
+            }
+            switch value {
+            case .nested(let child):
+                let childComponents = try objectComponents(for: child, definitions: &definitions)
+                let childDocument = AFMSchemaDocument(childComponents)
+                try mergeDefinition(named: child.name, document: childDocument, into: &definitions)
+                properties[propertyName] = AFMSchemaDocumentBox(referenceDocument(to: child.name))
+                required.append(propertyName)
+            case .leaf(let property):
+                properties[propertyName] = AFMSchemaDocumentBox(
+                    try propertyDocument(property, definitions: &definitions)
+                )
+                if !property.isOptional {
+                    required.append(propertyName)
+                }
+            }
+        }
+
+        var components = AFMSchemaDocument.Components()
+        components.title = node.name
+        components.type = "object"
+        components.properties = properties
+        components.required = required
+        components.additionalProperties = false
+        components.propertyOrder = orderedNames
+        return components
+    }
+
+    private static func propertyDocument(
+        _ property: AFMSchemaObjectProperty,
+        definitions: inout [String: AFMSchemaDocumentBox]
+    ) throws -> AFMSchemaDocument {
+        let base: AFMSchemaDocument
+        switch property.kind {
+        case .primitive(let type):
+            var components = AFMSchemaDocument.Components()
+            components.type = type
+            base = AFMSchemaDocument(components)
+        case .object(let schema):
+            guard let schema else {
+                throw ValidationError("--object '\(property.path.joined(separator: "."))' is missing --schema.")
+            }
+            guard schemaRepresentsObject(schema) else {
+                throw ValidationError("--object schemas must describe an object.")
+            }
+            _ = try schema.generationSchema(fallbackName: property.path.last?.camelizedSchemaName() ?? "Object")
+            try mergeDefinitions(from: schema, into: &definitions)
+            let objectDocument = schemaWithoutDefinitions(schema)
+            if let title = objectDocument.title, !title.isEmpty {
+                try mergeDefinition(named: title, document: objectDocument, into: &definitions)
+                base = referenceDocument(to: title)
+            } else {
+                base = objectDocument
+            }
+        }
+
+        let decorated = document(base, replacingDescriptionWith: property.description)
+        guard property.isArray else {
+            return decorated
+        }
+        var arrayComponents = AFMSchemaDocument.Components()
+        arrayComponents.description = property.description
+        arrayComponents.type = "array"
+        arrayComponents.items = AFMSchemaDocumentBox(document(base, replacingDescriptionWith: nil))
+        return AFMSchemaDocument(arrayComponents)
+    }
+
+    private static func referenceDocument(to definitionName: String) -> AFMSchemaDocument {
+        var components = AFMSchemaDocument.Components()
+        components.reference = "#/$defs/\(afmJSONPointerEscaped(definitionName))"
+        return AFMSchemaDocument(components)
+    }
+
+    private static func document(
+        _ document: AFMSchemaDocument,
+        replacingDescriptionWith description: String?
+    ) -> AFMSchemaDocument {
+        var components = components(from: document)
+        components.description = description ?? document.description
+        return AFMSchemaDocument(components)
+    }
+
+    private static func schemaWithoutDefinitions(_ schema: AFMSchemaDocument) -> AFMSchemaDocument {
+        var components = components(from: schema)
+        components.definitions = nil
+        return AFMSchemaDocument(components)
+    }
+
+    private static func components(from schema: AFMSchemaDocument) -> AFMSchemaDocument.Components {
+        var components = AFMSchemaDocument.Components()
+        components.title = schema.title
+        components.description = schema.description
+        components.type = schema.type
+        components.properties = schema.properties
+        components.required = schema.required
+        components.items = schema.items
+        components.minimumItems = schema.minimumItems
+        components.maximumItems = schema.maximumItems
+        components.enumValues = schema.enumValues
+        components.additionalProperties = schema.additionalProperties
+        components.definitions = schema.definitions
+        components.reference = schema.reference
+        components.anyOf = schema.anyOf
+        components.propertyOrder = schema.propertyOrder
+        return components
+    }
+
+    private static func schemaRepresentsObject(_ schema: AFMSchemaDocument) -> Bool {
+        guard schema.reference == nil, schema.anyOf == nil, schema.enumValues == nil else {
+            return false
+        }
+        return schema.type == "object" || (schema.type == nil && schema.properties != nil)
+    }
+
+    private static func mergeDefinitions(
+        from schema: AFMSchemaDocument,
+        into definitions: inout [String: AFMSchemaDocumentBox]
+    ) throws {
+        for name in (schema.definitions ?? [:]).keys.sorted() {
+            guard let document = schema.definitions?[name]?.value else {
+                continue
+            }
+            try mergeDefinition(named: name, document: document, into: &definitions)
+        }
+    }
+
+    private static func mergeDefinition(
+        named name: String,
+        document: AFMSchemaDocument,
+        into definitions: inout [String: AFMSchemaDocumentBox]
+    ) throws {
+        guard let existing = definitions[name]?.value else {
+            definitions[name] = AFMSchemaDocumentBox(document)
+            return
+        }
+        guard try encodedSchema(existing) == encodedSchema(document) else {
+            throw ValidationError("Conflicting schema definitions named '\(name)'.")
+        }
+    }
+
+    private static func encodedSchema(_ schema: AFMSchemaDocument) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(schema)
+    }
+}
+
+private final class AFMSchemaObjectNode {
+    enum Value {
+        case nested(AFMSchemaObjectNode)
+        case leaf(AFMSchemaObjectProperty)
+    }
+
+    let name: String
+    private(set) var properties: [String: Value] = [:]
+    private var insertionOrder: [String] = []
+
+    init(name: String) {
+        self.name = name
+    }
+
+    var orderedPropertyNames: [String] {
+        let leafNames = insertionOrder.filter {
+            if case .leaf = properties[$0] { return true }
+            return false
+        }
+        let nestedNames = insertionOrder.filter {
+            if case .nested = properties[$0] { return true }
+            return false
+        }
+        return leafNames + nestedNames
+    }
+
+    func insert(_ property: AFMSchemaObjectProperty) throws {
+        var current = self
+        for component in property.path.dropLast() {
+            if let existing = current.properties[component] {
+                guard case .nested(let child) = existing else {
+                    throw ValidationError("Property path '\(property.path.joined(separator: "."))' conflicts with '\(component)'.")
+                }
+                current = child
+            } else {
+                let child = AFMSchemaObjectNode(name: component.camelizedSchemaName())
+                current.properties[component] = .nested(child)
+                current.insertionOrder.append(component)
+                current = child
+            }
+        }
+
+        guard let propertyName = property.path.last else {
+            throw ValidationError("Property paths cannot be empty.")
+        }
+        guard current.properties[propertyName] == nil else {
+            throw ValidationError("Schema contains multiple '\(property.path.joined(separator: "."))' properties.")
+        }
+        current.properties[propertyName] = .leaf(property)
+        current.insertionOrder.append(propertyName)
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMSchemaObjectParser.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMSchemaObjectParser.swift
@@ -1,0 +1,300 @@
+import ArgumentParser
+import Foundation
+
+enum AFMSchemaObjectSerializationFormat: String, Sendable {
+    case json
+    case yaml
+}
+
+enum AFMSchemaObjectPropertyKind: Sendable {
+    case primitive(String)
+    case object(AFMSchemaDocument?)
+}
+
+struct AFMSchemaObjectProperty: Sendable {
+    let path: [String]
+    var kind: AFMSchemaObjectPropertyKind
+    var description: String?
+    var isOptional = false
+    var isArray = false
+}
+
+struct AFMSchemaObjectRequest: Sendable {
+    enum Mode: Sendable {
+        case object([AFMSchemaObjectProperty])
+        case union([AFMSchemaDocument])
+    }
+
+    let name: String
+    let mode: Mode
+    let format: AFMSchemaObjectSerializationFormat
+}
+
+enum AFMSchemaObjectParser {
+    static func parse(_ arguments: [String]) throws -> AFMSchemaObjectRequest {
+        var state = ParserState()
+        var index = 0
+
+        while index < arguments.count {
+            let option = try ParsedOption(arguments[index])
+            index += 1
+            try consume(option, arguments: arguments, index: &index, state: &state)
+        }
+
+        return try state.request()
+    }
+
+    private static func consume(
+        _ option: ParsedOption,
+        arguments: [String],
+        index: inout Int,
+        state: inout ParserState
+    ) throws {
+        if try consumeDeclaration(option, arguments: arguments, index: &index, state: &state) {
+            return
+        }
+        if try consumeModifier(option, arguments: arguments, index: &index, state: &state) {
+            return
+        }
+
+        switch option.name {
+        case "name":
+            guard state.name == nil else {
+                throw ValidationError("Provide --name only once.")
+            }
+            state.name = try optionValue(option, arguments: arguments, index: &index)
+        case "schema":
+            let rawSchema = try optionValue(option, arguments: arguments, index: &index)
+            try state.appendSchema(try decodeSchema(rawSchema))
+        case "anyOf", "any-of":
+            try option.requireFlag()
+            try state.beginUnion()
+        case "format":
+            let rawFormat = try optionValue(option, arguments: arguments, index: &index)
+            guard let format = AFMSchemaObjectSerializationFormat(rawValue: rawFormat.lowercased()) else {
+                throw ValidationError("--format must be json or yaml.")
+            }
+            state.format = format
+        default:
+            throw ValidationError("Unknown schema object option '--\(option.name)'.")
+        }
+    }
+
+    private static func consumeDeclaration(
+        _ option: ParsedOption,
+        arguments: [String],
+        index: inout Int,
+        state: inout ParserState
+    ) throws -> Bool {
+        let type: AFMSchemaObjectPropertyKind
+        switch option.name {
+        case "string": type = .primitive("string")
+        case "integer", "int": type = .primitive("integer")
+        case "double": type = .primitive("number")
+        case "boolean": type = .primitive("boolean")
+        case "object": type = .object(nil)
+        default: return false
+        }
+        let path = try optionValue(option, arguments: arguments, index: &index)
+        try state.appendProperty(path: path, kind: type)
+        return true
+    }
+
+    private static func consumeModifier(
+        _ option: ParsedOption,
+        arguments: [String],
+        index: inout Int,
+        state: inout ParserState
+    ) throws -> Bool {
+        switch option.name {
+        case "array":
+            try option.requireFlag()
+            try state.modifyCurrentProperty { property in
+                guard !property.isArray else {
+                    throw ValidationError("Apply --array to a property only once.")
+                }
+                property.isArray = true
+            }
+        case "description":
+            let description = try optionValue(option, arguments: arguments, index: &index)
+            try state.modifyCurrentProperty { property in
+                guard property.description == nil else {
+                    throw ValidationError("Apply --description to a property only once.")
+                }
+                property.description = description
+            }
+        case "optional":
+            try option.requireFlag()
+            try state.modifyCurrentProperty { property in
+                guard !property.isOptional else {
+                    throw ValidationError("Apply --optional to a property only once.")
+                }
+                property.isOptional = true
+            }
+        default:
+            return false
+        }
+        return true
+    }
+
+    private static func optionValue(
+        _ option: ParsedOption,
+        arguments: [String],
+        index: inout Int
+    ) throws -> String {
+        if let inlineValue = option.inlineValue {
+            return try validatedValue(inlineValue, option: option.name)
+        }
+        guard index < arguments.count, !arguments[index].hasPrefix("--") else {
+            throw ValidationError("--\(option.name) requires a value.")
+        }
+        defer { index += 1 }
+        return try validatedValue(arguments[index], option: option.name)
+    }
+
+    private static func validatedValue(_ value: String, option: String) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ValidationError("--\(option) requires a non-empty value.")
+        }
+        return trimmed
+    }
+
+    private static func decodeSchema(_ rawValue: String) throws -> AFMSchemaDocument {
+        guard rawValue.hasPrefix("@") else {
+            return try AFMArtifactRegistry.decodeSchemaDocument(from: rawValue)
+        }
+
+        let path = expandedPathString(String(rawValue.dropFirst()))
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw ValidationError("Could not find --schema file at \(path).")
+        }
+        let url = URL(fileURLWithPath: path)
+        return try AFMArtifactRegistry.loadSchemaDocument(
+            from: ResolvedArtifactReference(
+                rawValue: rawValue,
+                identifier: url.deletingPathExtension().lastPathComponent,
+                filePath: path,
+                directory: url.deletingLastPathComponent().path()
+            )
+        )
+    }
+}
+
+private struct ParsedOption {
+    let name: String
+    let inlineValue: String?
+
+    init(_ argument: String) throws {
+        guard argument.hasPrefix("--"), argument.count > 2 else {
+            throw ValidationError("Unexpected schema object argument '\(argument)'.")
+        }
+        let body = argument.dropFirst(2)
+        if let separator = body.firstIndex(of: "=") {
+            name = String(body[..<separator])
+            inlineValue = String(body[body.index(after: separator)...])
+        } else {
+            name = String(body)
+            inlineValue = nil
+        }
+    }
+
+    func requireFlag() throws {
+        guard inlineValue == nil else {
+            throw ValidationError("--\(name) does not accept a value.")
+        }
+    }
+}
+
+private struct ParserState {
+    var name: String?
+    var properties: [AFMSchemaObjectProperty] = []
+    var unionSchemas: [AFMSchemaDocument]?
+    var currentPropertyIndex: Int?
+    var format: AFMSchemaObjectSerializationFormat = .json
+
+    mutating func appendProperty(path: String, kind: AFMSchemaObjectPropertyKind) throws {
+        guard unionSchemas == nil else {
+            throw ValidationError("Property declarations cannot follow --anyOf.")
+        }
+        try requireCompletedObjectProperty()
+        properties.append(
+            AFMSchemaObjectProperty(
+                path: try propertyPath(path),
+                kind: kind
+            )
+        )
+        currentPropertyIndex = properties.index(before: properties.endIndex)
+    }
+
+    mutating func appendSchema(_ schema: AFMSchemaDocument) throws {
+        if unionSchemas != nil {
+            unionSchemas?.append(schema)
+            return
+        }
+        guard let currentPropertyIndex else {
+            throw ValidationError("--schema must follow --object or --anyOf.")
+        }
+        guard case .object(nil) = properties[currentPropertyIndex].kind else {
+            throw ValidationError("--schema must follow an --object property without a schema.")
+        }
+        properties[currentPropertyIndex].kind = .object(schema)
+    }
+
+    mutating func beginUnion() throws {
+        guard unionSchemas == nil else {
+            throw ValidationError("Provide --anyOf only once.")
+        }
+        guard properties.isEmpty else {
+            throw ValidationError("--anyOf cannot be combined with property declarations.")
+        }
+        unionSchemas = []
+        currentPropertyIndex = nil
+    }
+
+    mutating func modifyCurrentProperty(
+        _ update: (inout AFMSchemaObjectProperty) throws -> Void
+    ) throws {
+        guard unionSchemas == nil, let currentPropertyIndex else {
+            throw ValidationError("Property modifiers must follow a property declaration.")
+        }
+        try update(&properties[currentPropertyIndex])
+    }
+
+    func request() throws -> AFMSchemaObjectRequest {
+        guard let name else {
+            throw ValidationError("Please provide --name.")
+        }
+        try requireCompletedObjectProperty()
+
+        let mode: AFMSchemaObjectRequest.Mode
+        if let unionSchemas {
+            guard !unionSchemas.isEmpty else {
+                throw ValidationError("--anyOf requires at least one --schema.")
+            }
+            mode = .union(unionSchemas)
+        } else {
+            mode = .object(properties)
+        }
+        return AFMSchemaObjectRequest(name: name, mode: mode, format: format)
+    }
+
+    private func requireCompletedObjectProperty() throws {
+        guard let currentPropertyIndex else {
+            return
+        }
+        if case .object(nil) = properties[currentPropertyIndex].kind {
+            let propertyName = properties[currentPropertyIndex].path.joined(separator: ".")
+            throw ValidationError("--object '\(propertyName)' must be followed by --schema.")
+        }
+    }
+
+    private func propertyPath(_ rawValue: String) throws -> [String] {
+        let components = rawValue.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard !components.isEmpty,
+              components.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            throw ValidationError("Property paths cannot contain empty components.")
+        }
+        return components
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
@@ -404,6 +404,7 @@ enum HelpText {
       afm session chat --message "Hello" --message "Now answer in French."
       afm tag run --prompt "A joyful dog playing in a sunny park."
       afm session respond --prompt @prompt.txt --tool demo-weather
+      afm schema object --name Person --string name --integer age --optional
       afm schema list
       afm schema run typed-person --input "Alex Rivera is a designer in Berlin."
       afm schema run custom --schema demo-person --input @input.txt
@@ -423,6 +424,7 @@ enum HelpText {
 
     static let schema = """
     SCHEMA COMMANDS
+      object      Generate a runnable JSON or YAML schema artifact.
       list        Show available typed and dynamic schema workflows.
       run         Execute one schema workflow.
     """

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaCommands.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaCommands.swift
@@ -9,6 +9,7 @@ struct SchemaCommand: AsyncParsableCommand {
         abstract: "Run typed and dynamic schema workflows.",
         discussion: HelpText.schema,
         subcommands: [
+            SchemaObjectCommand.self,
             SchemaListCommand.self,
             SchemaRunCommand.self
         ]
@@ -110,6 +111,9 @@ struct SchemaCustomCommand: AsyncParsableCommand {
         let adapterPath = try adapterOptions.resolveAdapterPath(guardrails: generation.guardrails)
         let schemaReference = try schemaSource.resolve()
         let schemaDocument = try AFMArtifactRegistry.loadSchemaDocument(from: schemaReference)
+        let generationSchema = try schemaDocument.generationSchema(
+            fallbackName: schemaReference.identifier.camelizedSchemaName()
+        )
         let resolvedInput = try inputSource.resolve()
 
         if options.dryRun {
@@ -139,7 +143,7 @@ struct SchemaCustomCommand: AsyncParsableCommand {
         let result = try await GenerateDynamicSchemaContentUseCase().execute(
             DynamicSchemaGenerationRequest(
                 prompt: resolvedInput.value,
-                schema: try schemaDocument.generationSchema(fallbackName: schemaReference.identifier.camelizedSchemaName()),
+                schema: generationSchema,
                 systemPrompt: generation.systemPrompt,
                 modelUseCase: useCaseFlags.useCase,
                 guardrails: generation.guardrails,

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaObjectCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/SchemaObjectCommand.swift
@@ -1,0 +1,62 @@
+import ArgumentParser
+import Foundation
+import Yams
+
+struct SchemaObjectCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "object",
+        abstract: "Generate a runnable JSON or YAML schema for an object or union.",
+        discussion: """
+        PROPERTY DECLARATIONS
+          --string <name>       Declare a string property.
+          --integer <name>      Declare an integer property. --int is an alias.
+          --double <name>       Declare a floating-point property.
+          --boolean <name>      Declare a Boolean property.
+          --object <name>       Declare an object property followed by --schema.
+          --schema <json>       Supply an object or anyOf choice schema. Use @path for a file.
+          --anyOf               Build a root union from subsequent --schema values.
+
+        PROPERTY MODIFIERS
+          --array               Make the preceding property an array.
+          --description <text>  Describe the preceding property.
+          --optional            Make the preceding property optional.
+
+        OUTPUT
+          --format <json|yaml>  Artifact format. Defaults to json.
+
+        Dot-separated property names create referenced nested objects.
+
+        EXAMPLES
+          afm schema object --name Person --string name --integer age --optional
+          afm schema object --name Restaurant --string name --string address.street
+          afm schema object --name SearchResult --anyOf --schema @found.json --schema @missing.json
+        """
+    )
+
+    @Argument(parsing: .allUnrecognized)
+    var arguments: [String] = []
+
+    mutating func run() async throws {
+        let request = try AFMSchemaObjectParser.parse(arguments)
+        let document = try AFMSchemaObjectBuilder.build(request)
+        print(try Self.render(document, format: request.format))
+    }
+
+    static func render(
+        _ document: AFMSchemaDocument,
+        format: AFMSchemaObjectSerializationFormat
+    ) throws -> String {
+        switch format {
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            let data = try encoder.encode(document)
+            guard let output = String(data: data, encoding: .utf8) else {
+                throw AFMRuntimeError.providerFailure("Could not encode schema JSON.")
+            }
+            return output
+        case .yaml:
+            return try YAMLEncoder().encode(document)
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMArtifactRegistry.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMArtifactRegistry.swift
@@ -4,6 +4,10 @@ import FoundationModels
 import Yams
 
 enum AFMArtifactRegistry {
+    static func decodeSchemaDocument(from text: String, source: String = "--schema") throws -> AFMSchemaDocument {
+        try decodeArtifact(AFMSchemaDocument.self, from: text, path: source)
+    }
+
     static func loadSchemaDocument(from reference: ResolvedArtifactReference) throws -> AFMSchemaDocument {
         let text = try String(contentsOfFile: reference.filePath, encoding: .utf8)
         return try decodeArtifact(AFMSchemaDocument.self, from: text, path: reference.filePath)
@@ -33,6 +37,7 @@ enum AFMArtifactRegistry {
                 throw ValidationError("Could not decode \(path) as YAML: \(error.localizedDescription)")
             }
         default:
+            try AFMJSONDuplicateKeyPreflight.validate(text, source: path)
             do {
                 let data = Data(text.utf8)
                 return try JSONDecoder().decode(type, from: data)
@@ -46,147 +51,268 @@ enum AFMArtifactRegistry {
     }
 }
 
-struct AFMSchemaDocument: Sendable, Codable {
-    let title: String?
-    let description: String?
-    let type: String?
-    let properties: [String: AFMSchemaDocumentBox]?
-    let required: [String]?
-    let items: AFMSchemaDocumentBox?
-    let minimumItems: Int?
-    let maximumItems: Int?
-    let enumValues: [String]?
-    let additionalProperties: Bool?
-
-    private enum SchemaCodingKeys: String, CodingKey {
-        case title
-        case description
-        case type
-        case properties
-        case required
-        case items
-        case minimumItems = "minItems"
-        case maximumItems = "maxItems"
-        case enumValues = "enum"
-        case definitions = "$defs"
-        case reference = "$ref"
-        case anyOf
-        case propertyOrder = "x-order"
-        case additionalProperties
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: SchemaCodingKeys.self)
-
-        try Self.rejectUnsupportedKeyword(.definitions, in: container, decoder: decoder)
-        try Self.rejectUnsupportedKeyword(.reference, in: container, decoder: decoder)
-        try Self.rejectUnsupportedKeyword(.anyOf, in: container, decoder: decoder)
-        try Self.rejectUnsupportedKeyword(.propertyOrder, in: container, decoder: decoder)
-
-        if container.contains(.additionalProperties) {
-            let value: Bool
-            do {
-                value = try container.decode(Bool.self, forKey: .additionalProperties)
-            } catch {
-                throw AFMSchemaValidationError.unsupportedKeyword(
-                    SchemaCodingKeys.additionalProperties.rawValue,
-                    codingPath: decoder.codingPath,
-                    detail: "Only the boolean value false is supported."
-                )
-            }
-            guard !value else {
-                throw AFMSchemaValidationError.unsupportedKeyword(
-                    SchemaCodingKeys.additionalProperties.rawValue,
-                    codingPath: decoder.codingPath,
-                    detail: "Only the boolean value false is supported."
-                )
-            }
-            additionalProperties = value
-        } else {
-            additionalProperties = nil
+extension AFMSchemaDocument {
+    func generationSchema(fallbackName: String = "RootSchema") throws -> GenerationSchema {
+        let definitionDocuments = definitions ?? [:]
+        let definitionNames = Set(definitionDocuments.keys)
+        guard !definitionNames.contains("") else {
+            throw schemaValidationError("Definition names cannot be empty", at: "/$defs")
         }
 
-        title = try container.decodeIfPresent(String.self, forKey: .title)
-        description = try container.decodeIfPresent(String.self, forKey: .description)
-        type = try container.decodeIfPresent(String.self, forKey: .type)
-        properties = try container.decodeIfPresent([String: AFMSchemaDocumentBox].self, forKey: .properties)
-        required = try container.decodeIfPresent([String].self, forKey: .required)
-        items = try container.decodeIfPresent(AFMSchemaDocumentBox.self, forKey: .items)
-        minimumItems = try container.decodeIfPresent(Int.self, forKey: .minimumItems)
-        maximumItems = try container.decodeIfPresent(Int.self, forKey: .maximumItems)
-        enumValues = try container.decodeIfPresent([String].self, forKey: .enumValues)
+        let dependencies = try definitionDocuments.keys.sorted().map { definitionName in
+            guard let document = definitionDocuments[definitionName]?.value else {
+                throw schemaValidationError(
+                    "Missing schema for definition '\(definitionName)'",
+                    at: afmJSONPointer(appending: definitionName, to: "/$defs")
+                )
+            }
+            return try document.dynamicSchema(
+                nameHint: definitionName,
+                forcedName: definitionName,
+                availableDefinitions: definitionNames,
+                pointer: afmJSONPointer(appending: definitionName, to: "/$defs")
+            )
+        }
+        let root = try dynamicSchema(
+            nameHint: title ?? fallbackName,
+            availableDefinitions: definitionNames,
+            pointer: "",
+            allowsDefinitions: true
+        )
+        try AFMSchemaProductivityValidator.validate(root: self, definitions: definitionDocuments)
+        return try GenerationSchema(root: root, dependencies: dependencies)
     }
+}
 
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: SchemaCodingKeys.self)
-        try container.encodeIfPresent(title, forKey: .title)
-        try container.encodeIfPresent(description, forKey: .description)
-        try container.encodeIfPresent(type, forKey: .type)
-        try container.encodeIfPresent(properties, forKey: .properties)
-        try container.encodeIfPresent(required, forKey: .required)
-        try container.encodeIfPresent(items, forKey: .items)
-        try container.encodeIfPresent(minimumItems, forKey: .minimumItems)
-        try container.encodeIfPresent(maximumItems, forKey: .maximumItems)
-        try container.encodeIfPresent(enumValues, forKey: .enumValues)
-        try container.encodeIfPresent(additionalProperties, forKey: .additionalProperties)
-    }
-
-    func generationSchema(fallbackName: String = "RootSchema") throws -> GenerationSchema {
-        try GenerationSchema(root: dynamicSchema(nameHint: title ?? fallbackName), dependencies: [])
-    }
-
-    private func dynamicSchema(nameHint: String) throws -> DynamicGenerationSchema {
-        if let enumValues, !enumValues.isEmpty {
-            return DynamicGenerationSchema(
-                name: title ?? nameHint,
-                description: description,
-                anyOf: enumValues
+private extension AFMSchemaDocument {
+    func dynamicSchema(
+        nameHint: String,
+        forcedName: String? = nil,
+        availableDefinitions: Set<String>,
+        pointer: String,
+        allowsDefinitions: Bool = false
+    ) throws -> DynamicGenerationSchema {
+        if !allowsDefinitions, definitions != nil {
+            throw schemaValidationError(
+                "Nested $defs are not supported; move definitions to the document root",
+                at: afmJSONPointer(appending: "$defs", to: pointer)
             )
         }
 
-        let resolvedType = resolvedSchemaType()
+        if let reference {
+            return try referenceSchema(
+                reference,
+                availableDefinitions: availableDefinitions,
+                pointer: pointer
+            )
+        }
+
+        if let anyOf {
+            return try unionSchema(
+                anyOf,
+                nameHint: nameHint,
+                forcedName: forcedName,
+                availableDefinitions: availableDefinitions,
+                pointer: pointer
+            )
+        }
+
+        if let enumValues {
+            return try enumSchema(enumValues, nameHint: nameHint, forcedName: forcedName, pointer: pointer)
+        }
+
+        return try typedSchema(
+            resolvedSchemaType(),
+            nameHint: nameHint,
+            forcedName: forcedName,
+            availableDefinitions: availableDefinitions,
+            pointer: pointer
+        )
+    }
+
+    func typedSchema(
+        _ resolvedType: String,
+        nameHint: String,
+        forcedName: String?,
+        availableDefinitions: Set<String>,
+        pointer: String
+    ) throws -> DynamicGenerationSchema {
         switch resolvedType {
         case "object":
-            let properties = self.properties ?? [:]
-            let requiredProperties = Set(self.required ?? Array(properties.keys))
-            let dynamicProperties = try properties.keys.sorted().map { propertyName in
-                guard let propertySchema = properties[propertyName]?.value else {
-                    throw ValidationError("Missing schema for property '\(propertyName)'")
-                }
-                return DynamicGenerationSchema.Property(
-                    name: propertyName,
-                    description: propertySchema.description,
-                    schema: try propertySchema.dynamicSchema(nameHint: propertySchema.title ?? propertyName.camelizedSchemaName()),
-                    isOptional: !requiredProperties.contains(propertyName)
-                )
-            }
-            return DynamicGenerationSchema(
-                name: title ?? nameHint,
-                description: description,
-                properties: dynamicProperties
+            return try objectSchema(
+                nameHint: nameHint,
+                forcedName: forcedName,
+                availableDefinitions: availableDefinitions,
+                pointer: pointer
             )
         case "array":
-            guard let items = items?.value else {
-                throw ValidationError("Array schema '\(title ?? nameHint)' is missing an items definition")
-            }
-            return DynamicGenerationSchema(
-                arrayOf: try items.dynamicSchema(nameHint: items.title ?? "\(nameHint)Item"),
-                minimumElements: minimumItems,
-                maximumElements: maximumItems
+            return try arraySchema(
+                nameHint: nameHint,
+                availableDefinitions: availableDefinitions,
+                pointer: pointer
             )
         case "string":
+            try validatePrimitiveShape(pointer: pointer)
             return DynamicGenerationSchema(type: String.self)
         case "integer":
+            try validatePrimitiveShape(pointer: pointer)
             return DynamicGenerationSchema(type: Int.self)
         case "number":
+            try validatePrimitiveShape(pointer: pointer)
             return DynamicGenerationSchema(type: Double.self)
         case "boolean":
+            try validatePrimitiveShape(pointer: pointer)
             return DynamicGenerationSchema(type: Bool.self)
         default:
-            throw ValidationError("Unsupported schema type '\(resolvedType)' in '\(title ?? nameHint)'")
+            throw schemaValidationError(
+                "Unsupported schema type '\(resolvedType)' in '\(title ?? nameHint)'",
+                at: afmJSONPointer(appending: "type", to: pointer)
+            )
         }
     }
 
+    func referenceSchema(
+        _ reference: String,
+        availableDefinitions: Set<String>,
+        pointer: String
+    ) throws -> DynamicGenerationSchema {
+        try validateReferenceShape(pointer: pointer)
+        let definitionName = try referencedDefinitionName(reference, pointer: pointer)
+        guard availableDefinitions.contains(definitionName) else {
+            throw schemaValidationError(
+                "Undefined schema reference '\(reference)'",
+                at: afmJSONPointer(appending: "$ref", to: pointer)
+            )
+        }
+        return DynamicGenerationSchema(referenceTo: definitionName)
+    }
+
+    func unionSchema(
+        _ anyOf: [AFMSchemaDocumentBox],
+        nameHint: String,
+        forcedName: String?,
+        availableDefinitions: Set<String>,
+        pointer: String
+    ) throws -> DynamicGenerationSchema {
+        try validateUnionShape(pointer: pointer)
+        guard !anyOf.isEmpty else {
+            throw schemaValidationError(
+                "anyOf must contain at least one schema",
+                at: afmJSONPointer(appending: "anyOf", to: pointer)
+            )
+        }
+        let schemaName = try resolvedSchemaName(nameHint: nameHint, forcedName: forcedName, pointer: pointer)
+        let choices = try anyOf.enumerated().map { index, choice in
+            let choicePointer = afmJSONPointer(
+                appending: String(index),
+                to: afmJSONPointer(appending: "anyOf", to: pointer)
+            )
+            return try choice.value.dynamicSchema(
+                nameHint: "\(schemaName)Choice\(index + 1)",
+                availableDefinitions: availableDefinitions,
+                pointer: choicePointer
+            )
+        }
+        return DynamicGenerationSchema(name: schemaName, description: description, anyOf: choices)
+    }
+
+    func enumSchema(
+        _ enumValues: [String],
+        nameHint: String,
+        forcedName: String?,
+        pointer: String
+    ) throws -> DynamicGenerationSchema {
+        try validateEnumShape(pointer: pointer)
+        guard !enumValues.isEmpty else {
+            throw schemaValidationError(
+                "enum must contain at least one string",
+                at: afmJSONPointer(appending: "enum", to: pointer)
+            )
+        }
+        return DynamicGenerationSchema(
+            name: try resolvedSchemaName(nameHint: nameHint, forcedName: forcedName, pointer: pointer),
+            description: description,
+            anyOf: enumValues
+        )
+    }
+
+    func objectSchema(
+        nameHint: String,
+        forcedName: String?,
+        availableDefinitions: Set<String>,
+        pointer: String
+    ) throws -> DynamicGenerationSchema {
+        try validateObjectShape(pointer: pointer)
+        let properties = self.properties ?? [:]
+        let orderedNames = try orderedPropertyNames(in: properties, pointer: pointer)
+        let requiredNames = try requiredPropertyNames(in: properties, pointer: pointer)
+        let dynamicProperties = try orderedNames.map { propertyName in
+            try dynamicProperty(
+                named: propertyName,
+                properties: properties,
+                requiredNames: requiredNames,
+                availableDefinitions: availableDefinitions,
+                pointer: pointer
+            )
+        }
+        return DynamicGenerationSchema(
+            name: try resolvedSchemaName(nameHint: nameHint, forcedName: forcedName, pointer: pointer),
+            description: description,
+            properties: dynamicProperties
+        )
+    }
+
+    func dynamicProperty(
+        named propertyName: String,
+        properties: [String: AFMSchemaDocumentBox],
+        requiredNames: Set<String>,
+        availableDefinitions: Set<String>,
+        pointer: String
+    ) throws -> DynamicGenerationSchema.Property {
+        let propertyPointer = afmJSONPointer(
+            appending: propertyName,
+            to: afmJSONPointer(appending: "properties", to: pointer)
+        )
+        guard let propertySchema = properties[propertyName]?.value else {
+            throw schemaValidationError("Missing schema for property '\(propertyName)'", at: propertyPointer)
+        }
+        return DynamicGenerationSchema.Property(
+            name: propertyName,
+            description: propertySchema.description,
+            schema: try propertySchema.dynamicSchema(
+                nameHint: propertySchema.title ?? propertyName.camelizedSchemaName(),
+                availableDefinitions: availableDefinitions,
+                pointer: propertyPointer
+            ),
+            isOptional: !requiredNames.contains(propertyName)
+        )
+    }
+
+    func arraySchema(
+        nameHint: String,
+        availableDefinitions: Set<String>,
+        pointer: String
+    ) throws -> DynamicGenerationSchema {
+        try validateArrayShape(pointer: pointer)
+        guard let items = items?.value else {
+            throw schemaValidationError(
+                "Array schema '\(title ?? nameHint)' is missing an items definition",
+                at: afmJSONPointer(appending: "items", to: pointer)
+            )
+        }
+        return DynamicGenerationSchema(
+            arrayOf: try items.dynamicSchema(
+                nameHint: items.title ?? "\(nameHint)Item",
+                availableDefinitions: availableDefinitions,
+                pointer: afmJSONPointer(appending: "items", to: pointer)
+            ),
+            minimumElements: minimumItems,
+            maximumElements: maximumItems
+        )
+    }
+}
+
+private extension AFMSchemaDocument {
     private func resolvedSchemaType() -> String {
         if let type {
             return type
@@ -203,22 +329,218 @@ struct AFMSchemaDocument: Sendable, Codable {
         return "object"
     }
 
-    private static func rejectUnsupportedKeyword(
-        _ key: SchemaCodingKeys,
-        in container: KeyedDecodingContainer<SchemaCodingKeys>,
-        decoder: Decoder
-    ) throws {
-        guard container.contains(key) else {
-            return
+    private func resolvedSchemaName(
+        nameHint: String,
+        forcedName: String?,
+        pointer: String
+    ) throws -> String {
+        let name = forcedName ?? title ?? nameHint
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw schemaValidationError("Schema names cannot be empty", at: pointer)
         }
-        throw AFMSchemaValidationError.unsupportedKeyword(
-            key.rawValue,
-            codingPath: decoder.codingPath
-        )
+        return name
+    }
+
+    private func orderedPropertyNames(
+        in properties: [String: AFMSchemaDocumentBox],
+        pointer: String
+    ) throws -> [String] {
+        guard let propertyOrder else {
+            return properties.keys.sorted()
+        }
+        let orderPointer = afmJSONPointer(appending: "x-order", to: pointer)
+        guard Set(propertyOrder).count == propertyOrder.count else {
+            throw schemaValidationError("x-order contains duplicate property names", at: orderPointer)
+        }
+        guard Set(propertyOrder) == Set(properties.keys) else {
+            throw schemaValidationError("x-order must list every object property exactly once", at: orderPointer)
+        }
+        return propertyOrder
+    }
+
+    private func requiredPropertyNames(
+        in properties: [String: AFMSchemaDocumentBox],
+        pointer: String
+    ) throws -> Set<String> {
+        let required = self.required ?? Array(properties.keys)
+        let requiredPointer = afmJSONPointer(appending: "required", to: pointer)
+        guard Set(required).count == required.count else {
+            throw schemaValidationError("required contains duplicate property names", at: requiredPointer)
+        }
+        let unknownNames = Set(required).subtracting(properties.keys)
+        guard unknownNames.isEmpty else {
+            throw schemaValidationError(
+                "required contains unknown properties: \(unknownNames.sorted().joined(separator: ", "))",
+                at: requiredPointer
+            )
+        }
+        return Set(required)
+    }
+
+    private func validateReferenceShape(pointer: String) throws {
+        guard type == nil,
+              properties == nil,
+              required == nil,
+              items == nil,
+              minimumItems == nil,
+              maximumItems == nil,
+              enumValues == nil,
+              anyOf == nil,
+              propertyOrder == nil,
+              additionalProperties == nil else {
+            throw schemaValidationError(
+                "$ref cannot be combined with structural schema keywords",
+                at: afmJSONPointer(appending: "$ref", to: pointer)
+            )
+        }
+    }
+
+    private func validateUnionShape(pointer: String) throws {
+        guard type == nil,
+              properties == nil,
+              required == nil,
+              items == nil,
+              minimumItems == nil,
+              maximumItems == nil,
+              enumValues == nil,
+              reference == nil,
+              propertyOrder == nil,
+              additionalProperties == nil else {
+            throw schemaValidationError(
+                "anyOf cannot be combined with other structural schema keywords",
+                at: afmJSONPointer(appending: "anyOf", to: pointer)
+            )
+        }
+    }
+
+    private func validateEnumShape(pointer: String) throws {
+        guard type == nil || type == "string",
+              properties == nil,
+              required == nil,
+              items == nil,
+              minimumItems == nil,
+              maximumItems == nil,
+              reference == nil,
+              anyOf == nil,
+              propertyOrder == nil,
+              additionalProperties == nil else {
+            throw schemaValidationError(
+                "enum only supports string schemas without other structural keywords",
+                at: afmJSONPointer(appending: "enum", to: pointer)
+            )
+        }
+        guard let enumValues, Set(enumValues).count == enumValues.count else {
+            throw schemaValidationError(
+                "enum contains duplicate values",
+                at: afmJSONPointer(appending: "enum", to: pointer)
+            )
+        }
+    }
+
+    private func validateObjectShape(pointer: String) throws {
+        guard items == nil,
+              minimumItems == nil,
+              maximumItems == nil,
+              enumValues == nil,
+              reference == nil,
+              anyOf == nil else {
+            throw schemaValidationError("Object schema contains incompatible keywords", at: pointer)
+        }
+    }
+
+    private func validateArrayShape(pointer: String) throws {
+        guard properties == nil,
+              required == nil,
+              enumValues == nil,
+              reference == nil,
+              anyOf == nil,
+              propertyOrder == nil,
+              additionalProperties == nil else {
+            throw schemaValidationError("Array schema contains incompatible keywords", at: pointer)
+        }
+        if let minimumItems, minimumItems < 0 {
+            throw schemaValidationError(
+                "minItems cannot be negative",
+                at: afmJSONPointer(appending: "minItems", to: pointer)
+            )
+        }
+        if let maximumItems, maximumItems < 0 {
+            throw schemaValidationError(
+                "maxItems cannot be negative",
+                at: afmJSONPointer(appending: "maxItems", to: pointer)
+            )
+        }
+        if let minimumItems, let maximumItems, maximumItems < minimumItems {
+            throw schemaValidationError(
+                "maxItems cannot be less than minItems",
+                at: afmJSONPointer(appending: "maxItems", to: pointer)
+            )
+        }
+    }
+
+    private func validatePrimitiveShape(pointer: String) throws {
+        guard properties == nil,
+              required == nil,
+              items == nil,
+              minimumItems == nil,
+              maximumItems == nil,
+              enumValues == nil,
+              reference == nil,
+              anyOf == nil,
+              propertyOrder == nil,
+              additionalProperties == nil else {
+            throw schemaValidationError("Primitive schema contains incompatible keywords", at: pointer)
+        }
+    }
+
+    private func referencedDefinitionName(_ reference: String, pointer: String) throws -> String {
+        let prefix = "#/$defs/"
+        let encodedName = String(reference.dropFirst(prefix.count))
+        let decodedName = encodedName
+            .replacingOccurrences(of: "~1", with: "/")
+            .replacingOccurrences(of: "~0", with: "~")
+        guard reference.hasPrefix(prefix),
+              !encodedName.isEmpty,
+              afmJSONPointerEscaped(decodedName) == encodedName else {
+            throw schemaValidationError(
+                "Only local references in the form '#/$defs/Name' are supported",
+                at: afmJSONPointer(appending: "$ref", to: pointer)
+            )
+        }
+        return decodedName
     }
 }
 
-private struct AFMSchemaValidationError: LocalizedError {
+struct AFMSchemaCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = String(intValue)
+        self.intValue = intValue
+    }
+}
+
+func afmJSONPointer(appending component: String, to pointer: String) -> String {
+    "\(pointer)/\(afmJSONPointerEscaped(component))"
+}
+
+func afmJSONPointerEscaped(_ component: String) -> String {
+    component
+        .replacingOccurrences(of: "~", with: "~0")
+        .replacingOccurrences(of: "/", with: "~1")
+}
+
+private func schemaValidationError(_ message: String, at pointer: String) -> ValidationError {
+    ValidationError("\(message) at JSON pointer '\(pointer.isEmpty ? "/" : pointer)'.")
+}
+
+struct AFMSchemaValidationError: LocalizedError {
     let keyword: String
     let jsonPointer: String
     let detail: String
@@ -229,7 +551,7 @@ private struct AFMSchemaValidationError: LocalizedError {
         detail: String = "This keyword is not supported."
     ) -> Self {
         let components = codingPath.map(\.stringValue) + [keyword]
-        let pointer = "/" + components.map(jsonPointerEscaped).joined(separator: "/")
+        let pointer = "/" + components.map(afmJSONPointerEscaped).joined(separator: "/")
         return Self(keyword: keyword, jsonPointer: pointer, detail: detail)
     }
 
@@ -259,232 +581,4 @@ private struct AFMSchemaValidationError: LocalizedError {
         return find(in: underlyingError)
     }
 
-    private static func jsonPointerEscaped(_ component: String) -> String {
-        component
-            .replacingOccurrences(of: "~", with: "~0")
-            .replacingOccurrences(of: "/", with: "~1")
-    }
-}
-
-final class AFMSchemaDocumentBox: Codable, @unchecked Sendable {
-    let value: AFMSchemaDocument
-
-    init(_ value: AFMSchemaDocument) {
-        self.value = value
-    }
-
-    init(from decoder: Decoder) throws {
-        self.value = try AFMSchemaDocument(from: decoder)
-    }
-
-    func encode(to encoder: Encoder) throws {
-        try value.encode(to: encoder)
-    }
-}
-
-struct AFMToolManifest: Sendable, Codable {
-    let name: String
-    let description: String
-    let parameters: AFMSchemaDocument
-    let runner: AFMToolRunnerManifest
-}
-
-struct AFMToolRunnerManifest: Sendable, Codable {
-    enum Kind: String, Sendable, Codable {
-        case shell
-        case `static`
-    }
-
-    enum OutputFormat: String, Sendable, Codable {
-        case text
-        case json
-    }
-
-    let kind: Kind
-    let outputFormat: OutputFormat?
-    let command: String?
-    let args: [String]?
-    let workingDirectory: String?
-    let environment: [String: String]?
-    let text: String?
-    let json: AFMJSONValue?
-}
-
-struct AFMManifestTool: Tool {
-    typealias Arguments = GeneratedContent
-    typealias Output = GeneratedContent
-
-    let manifest: AFMToolManifest
-    let sourcePath: String
-    let parameters: GenerationSchema
-
-    init(manifest: AFMToolManifest, sourcePath: String) throws {
-        self.manifest = manifest
-        self.sourcePath = sourcePath
-        self.parameters = try manifest.parameters.generationSchema(fallbackName: manifest.name.camelizedSchemaName())
-    }
-
-    var name: String { manifest.name }
-    var description: String { manifest.description }
-
-    func call(arguments: GeneratedContent) async throws -> GeneratedContent {
-        switch manifest.runner.kind {
-        case .static:
-            return try staticOutput()
-        case .shell:
-            return try await shellOutput(arguments: arguments)
-        }
-    }
-
-    private func staticOutput() throws -> GeneratedContent {
-        switch manifest.runner.outputFormat ?? .json {
-        case .json:
-            guard let json = manifest.runner.json else {
-                throw AFMRuntimeError.invalidRequest("Static tool '\(name)' is missing runner.json output")
-            }
-            return try GeneratedContent(json: json.jsonString(pretty: false))
-        case .text:
-            guard let text = manifest.runner.text else {
-                throw AFMRuntimeError.invalidRequest("Static tool '\(name)' is missing runner.text output")
-            }
-            return GeneratedContent(text)
-        }
-    }
-
-    private func shellOutput(arguments: GeneratedContent) async throws -> GeneratedContent {
-        guard let command = manifest.runner.command, !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw AFMRuntimeError.invalidRequest("Shell tool '\(name)' is missing runner.command")
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: expandedPathString(command))
-        process.arguments = manifest.runner.args ?? []
-        if let workingDirectory = manifest.runner.workingDirectory, !workingDirectory.isEmpty {
-            process.currentDirectoryURL = URL(fileURLWithPath: expandedPathString(workingDirectory))
-        }
-        process.environment = ProcessInfo.processInfo.environment.merging(manifest.runner.environment ?? [:]) { _, new in new }
-
-        let inputPipe = Pipe()
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardInput = inputPipe
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        try process.run()
-        let outputHandle = outputPipe.fileHandleForReading
-        let errorHandle = errorPipe.fileHandleForReading
-        let outputTask = Task.detached {
-            try outputHandle.readToEnd() ?? Data()
-        }
-        let errorTask = Task.detached {
-            try errorHandle.readToEnd() ?? Data()
-        }
-
-        let inputData = Data(arguments.jsonString.utf8)
-        inputPipe.fileHandleForWriting.write(inputData)
-        try? inputPipe.fileHandleForWriting.close()
-        process.waitUntilExit()
-
-        let stdout = String(data: try await outputTask.value, encoding: .utf8) ?? ""
-        let stderr = String(data: try await errorTask.value, encoding: .utf8) ?? ""
-
-        guard process.terminationStatus == 0 else {
-            let trimmedError = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            let message = trimmedError.isEmpty
-                ? "Tool '\(name)' exited with status \(process.terminationStatus)"
-                : trimmedError
-            throw AFMRuntimeError.providerFailure(message)
-        }
-
-        switch manifest.runner.outputFormat ?? .json {
-        case .json:
-            let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else {
-                throw AFMRuntimeError.providerFailure("Tool '\(name)' returned empty JSON output")
-            }
-            return try GeneratedContent(json: trimmed)
-        case .text:
-            let trimmed = stdout.trimmingCharacters(in: .newlines)
-            guard !trimmed.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                throw AFMRuntimeError.providerFailure("Tool '\(name)' returned empty text output")
-            }
-            return GeneratedContent(trimmed)
-        }
-    }
-}
-
-enum AFMJSONValue: Sendable, Codable, Equatable {
-    case string(String)
-    case number(Double)
-    case bool(Bool)
-    case object([String: AFMJSONValue])
-    case array([AFMJSONValue])
-    case null
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if container.decodeNil() {
-            self = .null
-        } else if let value = try? container.decode(Bool.self) {
-            self = .bool(value)
-        } else if let value = try? container.decode(Double.self) {
-            self = .number(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else if let value = try? container.decode([String: AFMJSONValue].self) {
-            self = .object(value)
-        } else if let value = try? container.decode([AFMJSONValue].self) {
-            self = .array(value)
-        } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
-        }
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        switch self {
-        case .string(let value):
-            try container.encode(value)
-        case .number(let value):
-            try container.encode(value)
-        case .bool(let value):
-            try container.encode(value)
-        case .object(let value):
-            try container.encode(value)
-        case .array(let value):
-            try container.encode(value)
-        case .null:
-            try container.encodeNil()
-        }
-    }
-
-    func jsonString(pretty: Bool) throws -> String {
-        let encoder = JSONEncoder()
-        if pretty {
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        } else {
-            encoder.outputFormatting = [.sortedKeys]
-        }
-        let data = try encoder.encode(self)
-        guard let text = String(data: data, encoding: .utf8) else {
-            throw AFMRuntimeError.providerFailure("Could not encode JSON value")
-        }
-        return text
-    }
-}
-
-extension String {
-    func camelizedSchemaName() -> String {
-        split(whereSeparator: { !$0.isLetter && !$0.isNumber })
-            .map { segment in
-                segment.prefix(1).uppercased() + segment.dropFirst()
-            }
-            .joined()
-            .nonEmptyOrFallback("Schema")
-    }
-
-    func nonEmptyOrFallback(_ fallback: String) -> String {
-        isEmpty ? fallback : self
-    }
 }

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMJSONDuplicateKeyPreflight.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMJSONDuplicateKeyPreflight.swift
@@ -1,0 +1,277 @@
+import ArgumentParser
+import Foundation
+
+enum AFMJSONDuplicateKeyPreflight {
+    static func validate(_ text: String, source: String) throws {
+        do {
+            var scanner = JSONScanner(text)
+            guard let duplicate = try scanner.scanDocument() else {
+                return
+            }
+            throw ValidationError(
+                "Could not decode \(source) as JSON: Duplicate object key "
+                    + "\(duplicate.key.debugDescription) at JSON pointer '\(duplicate.pointer)'."
+            )
+        } catch let error as ExcessiveNesting {
+            throw ValidationError(
+                "Could not decode \(source) as JSON: JSON nesting exceeds the supported depth "
+                    + "at JSON pointer '\(error.pointer)'."
+            )
+        } catch is MalformedJSON {
+            // JSONDecoder remains the source of syntax and type diagnostics.
+        }
+    }
+}
+
+private extension AFMJSONDuplicateKeyPreflight {
+    struct DuplicateKey {
+        let key: String
+        let pointer: String
+    }
+
+    struct MalformedJSON: Error {}
+
+    struct ExcessiveNesting: Error {
+        let pointer: String
+    }
+
+    struct JSONScanner {
+        private let bytes: [UInt8]
+        private var index = 0
+        private var firstDuplicate: DuplicateKey?
+
+        init(_ text: String) {
+            bytes = Array(text.utf8)
+        }
+
+        mutating func scanDocument() throws -> DuplicateKey? {
+            skipWhitespace()
+            try scanValue(pointer: "", depth: 0)
+            skipWhitespace()
+            guard index == bytes.count else {
+                throw MalformedJSON()
+            }
+            return firstDuplicate
+        }
+
+        private mutating func scanValue(pointer: String, depth: Int) throws {
+            guard depth < 256 else {
+                throw ExcessiveNesting(pointer: pointer.isEmpty ? "/" : pointer)
+            }
+            skipWhitespace()
+            guard let byte = currentByte else {
+                throw MalformedJSON()
+            }
+
+            switch byte {
+            case ascii("{"):
+                try scanObject(pointer: pointer, depth: depth)
+            case ascii("["):
+                try scanArray(pointer: pointer, depth: depth)
+            case ascii("\""):
+                _ = try scanString()
+            case ascii("t"):
+                try scanLiteral("true")
+            case ascii("f"):
+                try scanLiteral("false")
+            case ascii("n"):
+                try scanLiteral("null")
+            case ascii("-"), ascii("0")...ascii("9"):
+                try scanNumber()
+            default:
+                throw MalformedJSON()
+            }
+        }
+
+        private mutating func scanObject(pointer: String, depth: Int) throws {
+            try consume(ascii("{"))
+            skipWhitespace()
+            if consumeIfPresent(ascii("}")) {
+                return
+            }
+
+            var keys: Set<String> = []
+            while true {
+                skipWhitespace()
+                let key = try scanString()
+                let keyPointer = afmJSONPointer(appending: key, to: pointer)
+                if !keys.insert(key).inserted, firstDuplicate == nil {
+                    firstDuplicate = DuplicateKey(key: key, pointer: keyPointer)
+                }
+
+                skipWhitespace()
+                try consume(ascii(":"))
+                try scanValue(pointer: keyPointer, depth: depth + 1)
+                skipWhitespace()
+                if consumeIfPresent(ascii("}")) {
+                    return
+                }
+                try consume(ascii(","))
+            }
+        }
+
+        private mutating func scanArray(pointer: String, depth: Int) throws {
+            try consume(ascii("["))
+            skipWhitespace()
+            if consumeIfPresent(ascii("]")) {
+                return
+            }
+
+            var elementIndex = 0
+            while true {
+                try scanValue(
+                    pointer: afmJSONPointer(appending: String(elementIndex), to: pointer),
+                    depth: depth + 1
+                )
+                elementIndex += 1
+                skipWhitespace()
+                if consumeIfPresent(ascii("]")) {
+                    return
+                }
+                try consume(ascii(","))
+            }
+        }
+
+        private mutating func scanString() throws -> String {
+            let start = index
+            try consume(ascii("\""))
+
+            while let byte = currentByte {
+                switch byte {
+                case ascii("\""):
+                    index += 1
+                    return try decodedString(startingAt: start)
+                case ascii("\\"):
+                    try scanEscape()
+                case 0x00...0x1F:
+                    throw MalformedJSON()
+                default:
+                    index += 1
+                }
+            }
+            throw MalformedJSON()
+        }
+
+        private func decodedString(startingAt start: Int) throws -> String {
+            let data = Data(bytes[start..<index])
+            do {
+                return try JSONDecoder().decode(String.self, from: data)
+            } catch {
+                throw MalformedJSON()
+            }
+        }
+
+        private mutating func scanEscape() throws {
+            index += 1
+            guard let escaped = currentByte else {
+                throw MalformedJSON()
+            }
+            guard escaped == ascii("u") else {
+                guard escapeBytes.contains(escaped) else {
+                    throw MalformedJSON()
+                }
+                index += 1
+                return
+            }
+
+            index += 1
+            for _ in 0..<4 {
+                guard let hexadecimal = currentByte, isHexadecimal(hexadecimal) else {
+                    throw MalformedJSON()
+                }
+                index += 1
+            }
+        }
+
+        private mutating func scanNumber() throws {
+            _ = consumeIfPresent(ascii("-"))
+            guard let firstDigit = currentByte else {
+                throw MalformedJSON()
+            }
+            if firstDigit == ascii("0") {
+                index += 1
+                if let next = currentByte, isDigit(next) {
+                    throw MalformedJSON()
+                }
+            } else {
+                guard isNonzeroDigit(firstDigit) else {
+                    throw MalformedJSON()
+                }
+                consumeDigits()
+            }
+
+            if consumeIfPresent(ascii(".")) {
+                guard let digit = currentByte, isDigit(digit) else {
+                    throw MalformedJSON()
+                }
+                consumeDigits()
+            }
+            if consumeIfPresent(ascii("e")) || consumeIfPresent(ascii("E")) {
+                _ = consumeIfPresent(ascii("+")) || consumeIfPresent(ascii("-"))
+                guard let digit = currentByte, isDigit(digit) else {
+                    throw MalformedJSON()
+                }
+                consumeDigits()
+            }
+        }
+
+        private mutating func scanLiteral(_ literal: StaticString) throws {
+            for byte in literal.withUTF8Buffer({ Array($0) }) {
+                try consume(byte)
+            }
+        }
+
+        private mutating func consumeDigits() {
+            while let byte = currentByte, isDigit(byte) {
+                index += 1
+            }
+        }
+
+        private mutating func skipWhitespace() {
+            while let byte = currentByte, whitespaceBytes.contains(byte) {
+                index += 1
+            }
+        }
+
+        private mutating func consume(_ byte: UInt8) throws {
+            guard consumeIfPresent(byte) else {
+                throw MalformedJSON()
+            }
+        }
+
+        private mutating func consumeIfPresent(_ byte: UInt8) -> Bool {
+            guard currentByte == byte else {
+                return false
+            }
+            index += 1
+            return true
+        }
+
+        private var currentByte: UInt8? {
+            index < bytes.count ? bytes[index] : nil
+        }
+    }
+
+    static func ascii(_ character: Character) -> UInt8 {
+        character.asciiValue ?? 0
+    }
+
+    static func isDigit(_ byte: UInt8) -> Bool {
+        ascii("0")...ascii("9") ~= byte
+    }
+
+    static func isNonzeroDigit(_ byte: UInt8) -> Bool {
+        ascii("1")...ascii("9") ~= byte
+    }
+
+    static func isHexadecimal(_ byte: UInt8) -> Bool {
+        isDigit(byte)
+            || ascii("a")...ascii("f") ~= byte
+            || ascii("A")...ascii("F") ~= byte
+    }
+
+    static let whitespaceBytes: Set<UInt8> = [0x20, 0x09, 0x0A, 0x0D]
+    static let escapeBytes: Set<UInt8> = [
+        ascii("\""), ascii("\\"), ascii("/"), ascii("b"), ascii("f"), ascii("n"), ascii("r"), ascii("t")
+    ]
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMSchemaDocument.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMSchemaDocument.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+struct AFMSchemaDocument: Sendable, Codable {
+    struct Components: Sendable {
+        var title: String?
+        var description: String?
+        var type: String?
+        var properties: [String: AFMSchemaDocumentBox]?
+        var required: [String]?
+        var items: AFMSchemaDocumentBox?
+        var minimumItems: Int?
+        var maximumItems: Int?
+        var enumValues: [String]?
+        var additionalProperties: Bool?
+        var definitions: [String: AFMSchemaDocumentBox]?
+        var reference: String?
+        var anyOf: [AFMSchemaDocumentBox]?
+        var propertyOrder: [String]?
+    }
+
+    let title: String?
+    let description: String?
+    let type: String?
+    let properties: [String: AFMSchemaDocumentBox]?
+    let required: [String]?
+    let items: AFMSchemaDocumentBox?
+    let minimumItems: Int?
+    let maximumItems: Int?
+    let enumValues: [String]?
+    let additionalProperties: Bool?
+    let definitions: [String: AFMSchemaDocumentBox]?
+    let reference: String?
+    let anyOf: [AFMSchemaDocumentBox]?
+    let propertyOrder: [String]?
+
+    private enum SchemaCodingKeys: String, CodingKey, CaseIterable {
+        case title
+        case description
+        case type
+        case properties
+        case required
+        case items
+        case minimumItems = "minItems"
+        case maximumItems = "maxItems"
+        case enumValues = "enum"
+        case definitions = "$defs"
+        case reference = "$ref"
+        case anyOf
+        case propertyOrder = "x-order"
+        case additionalProperties
+    }
+
+    init(_ components: Components) {
+        title = components.title
+        description = components.description
+        type = components.type
+        properties = components.properties
+        required = components.required
+        items = components.items
+        minimumItems = components.minimumItems
+        maximumItems = components.maximumItems
+        enumValues = components.enumValues
+        additionalProperties = components.additionalProperties
+        definitions = components.definitions
+        reference = components.reference
+        anyOf = components.anyOf
+        propertyOrder = components.propertyOrder
+    }
+
+    init(from decoder: Decoder) throws {
+        let rawContainer = try decoder.container(keyedBy: AFMSchemaCodingKey.self)
+        let supportedKeywords = Set(SchemaCodingKeys.allCases.map(\.rawValue))
+        if let unsupportedKey = rawContainer.allKeys
+            .map(\.stringValue)
+            .filter({ !supportedKeywords.contains($0) })
+            .sorted()
+            .first {
+            throw AFMSchemaValidationError.unsupportedKeyword(
+                unsupportedKey,
+                codingPath: decoder.codingPath
+            )
+        }
+
+        let container = try decoder.container(keyedBy: SchemaCodingKeys.self)
+        additionalProperties = try Self.decodeAdditionalProperties(from: container, decoder: decoder)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        type = try container.decodeIfPresent(String.self, forKey: .type)
+        properties = try container.decodeIfPresent([String: AFMSchemaDocumentBox].self, forKey: .properties)
+        required = try container.decodeIfPresent([String].self, forKey: .required)
+        items = try container.decodeIfPresent(AFMSchemaDocumentBox.self, forKey: .items)
+        minimumItems = try container.decodeIfPresent(Int.self, forKey: .minimumItems)
+        maximumItems = try container.decodeIfPresent(Int.self, forKey: .maximumItems)
+        enumValues = try container.decodeIfPresent([String].self, forKey: .enumValues)
+        definitions = try container.decodeIfPresent(
+            [String: AFMSchemaDocumentBox].self,
+            forKey: .definitions
+        )
+        reference = try container.decodeIfPresent(String.self, forKey: .reference)
+        anyOf = try container.decodeIfPresent([AFMSchemaDocumentBox].self, forKey: .anyOf)
+        propertyOrder = try container.decodeIfPresent([String].self, forKey: .propertyOrder)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: SchemaCodingKeys.self)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(properties, forKey: .properties)
+        try container.encodeIfPresent(required, forKey: .required)
+        try container.encodeIfPresent(items, forKey: .items)
+        try container.encodeIfPresent(minimumItems, forKey: .minimumItems)
+        try container.encodeIfPresent(maximumItems, forKey: .maximumItems)
+        try container.encodeIfPresent(enumValues, forKey: .enumValues)
+        try container.encodeIfPresent(additionalProperties, forKey: .additionalProperties)
+        try container.encodeIfPresent(definitions, forKey: .definitions)
+        try container.encodeIfPresent(reference, forKey: .reference)
+        try container.encodeIfPresent(anyOf, forKey: .anyOf)
+        try container.encodeIfPresent(propertyOrder, forKey: .propertyOrder)
+    }
+
+    private static func decodeAdditionalProperties(
+        from container: KeyedDecodingContainer<SchemaCodingKeys>,
+        decoder: Decoder
+    ) throws -> Bool? {
+        guard container.contains(.additionalProperties) else {
+            return nil
+        }
+        guard let value = try? container.decode(Bool.self, forKey: .additionalProperties), !value else {
+            throw AFMSchemaValidationError.unsupportedKeyword(
+                SchemaCodingKeys.additionalProperties.rawValue,
+                codingPath: decoder.codingPath,
+                detail: "Only the boolean value false is supported."
+            )
+        }
+        return value
+    }
+}
+
+final class AFMSchemaDocumentBox: Codable, @unchecked Sendable {
+    let value: AFMSchemaDocument
+
+    init(_ value: AFMSchemaDocument) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        self.value = try AFMSchemaDocument(from: decoder)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMSchemaProductivityValidator.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMSchemaProductivityValidator.swift
@@ -1,0 +1,289 @@
+import ArgumentParser
+import Foundation
+
+enum AFMSchemaProductivityValidator {
+    static func validate(
+        root: AFMSchemaDocument,
+        definitions: [String: AFMSchemaDocumentBox]
+    ) throws {
+        let productiveDefinitions = productiveDefinitionNames(in: definitions)
+        let unproductiveNames = Set(definitions.keys).subtracting(productiveDefinitions)
+
+        if let cycle = unproductiveCycle(
+            among: unproductiveNames,
+            definitions: definitions,
+            productiveDefinitions: productiveDefinitions
+        ) {
+            throw ValidationError(
+                "Schema reference cycle cannot produce a finite value: "
+                    + "\(cycle.names.joined(separator: " -> ")). "
+                    + "JSON pointer '\(cycle.pointer)'."
+            )
+        }
+
+        guard isProductive(root, productiveDefinitions: productiveDefinitions) else {
+            throw ValidationError("Schema cannot produce a finite value.")
+        }
+    }
+}
+
+private extension AFMSchemaProductivityValidator {
+    struct ReferenceEdge {
+        let target: String
+        let pointer: String
+    }
+
+    struct ReferenceCycle {
+        let names: [String]
+        let pointer: String
+    }
+
+    static func productiveDefinitionNames(
+        in definitions: [String: AFMSchemaDocumentBox]
+    ) -> Set<String> {
+        var productive: Set<String> = []
+
+        while true {
+            let newlyProductive = definitions.keys.sorted().filter { name in
+                guard !productive.contains(name), let document = definitions[name]?.value else {
+                    return false
+                }
+                return isProductive(document, productiveDefinitions: productive)
+            }
+            guard !newlyProductive.isEmpty else {
+                return productive
+            }
+            productive.formUnion(newlyProductive)
+        }
+    }
+
+    static func isProductive(
+        _ document: AFMSchemaDocument,
+        productiveDefinitions: Set<String>
+    ) -> Bool {
+        if let reference = document.reference {
+            guard let name = referencedDefinitionName(reference) else {
+                return false
+            }
+            return productiveDefinitions.contains(name)
+        }
+
+        if let choices = document.anyOf {
+            return choices.contains { choice in
+                isProductive(choice.value, productiveDefinitions: productiveDefinitions)
+            }
+        }
+
+        if let enumValues = document.enumValues {
+            return !enumValues.isEmpty
+        }
+
+        return isTypedSchemaProductive(document, productiveDefinitions: productiveDefinitions)
+    }
+
+    static func isTypedSchemaProductive(
+        _ document: AFMSchemaDocument,
+        productiveDefinitions: Set<String>
+    ) -> Bool {
+        switch resolvedType(of: document) {
+        case "object":
+            let properties = document.properties ?? [:]
+            let requiredNames = document.required ?? Array(properties.keys)
+            return requiredNames.allSatisfy { propertyName in
+                guard let property = properties[propertyName]?.value else {
+                    return false
+                }
+                return isProductive(property, productiveDefinitions: productiveDefinitions)
+            }
+        case "array":
+            if (document.minimumItems ?? 0) == 0 {
+                return true
+            }
+            guard let items = document.items?.value else {
+                return false
+            }
+            return isProductive(items, productiveDefinitions: productiveDefinitions)
+        case "string", "integer", "number", "boolean":
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func unproductiveCycle(
+        among unproductiveNames: Set<String>,
+        definitions: [String: AFMSchemaDocumentBox],
+        productiveDefinitions: Set<String>
+    ) -> ReferenceCycle? {
+        let graph = Dictionary(uniqueKeysWithValues: unproductiveNames.sorted().map { name in
+            let pointer = afmJSONPointer(appending: name, to: "/$defs")
+            let edges = definitions[name].map { box in
+                blockingReferences(
+                    in: box.value,
+                    pointer: pointer,
+                    productiveDefinitions: productiveDefinitions
+                )
+            } ?? []
+            return (name, edges.sorted(by: referenceEdgeOrder))
+        })
+
+        for start in unproductiveNames.sorted() {
+            var positions: [String: Int] = [:]
+            var path: [String] = []
+            var current = start
+            var incomingPointer = afmJSONPointer(appending: start, to: "/$defs")
+
+            while positions[current] == nil {
+                positions[current] = path.count
+                path.append(current)
+                guard let edge = graph[current]?.first else {
+                    break
+                }
+                current = edge.target
+                incomingPointer = edge.pointer
+            }
+
+            if let cycleStart = positions[current] {
+                return ReferenceCycle(
+                    names: Array(path[cycleStart...]) + [current],
+                    pointer: incomingPointer
+                )
+            }
+        }
+        return nil
+    }
+
+    static func blockingReferences(
+        in document: AFMSchemaDocument,
+        pointer: String,
+        productiveDefinitions: Set<String>
+    ) -> [ReferenceEdge] {
+        if let reference = document.reference,
+           let target = referencedDefinitionName(reference),
+           !productiveDefinitions.contains(target) {
+            return [
+                ReferenceEdge(
+                    target: target,
+                    pointer: afmJSONPointer(appending: "$ref", to: pointer)
+                )
+            ]
+        }
+
+        if let choices = document.anyOf {
+            return blockingUnionReferences(
+                choices,
+                pointer: pointer,
+                productiveDefinitions: productiveDefinitions
+            )
+        }
+
+        if document.enumValues != nil {
+            return []
+        }
+
+        switch resolvedType(of: document) {
+        case "object":
+            return blockingObjectReferences(
+                in: document,
+                pointer: pointer,
+                productiveDefinitions: productiveDefinitions
+            )
+        case "array":
+            guard (document.minimumItems ?? 0) > 0,
+                  let items = document.items?.value,
+                  !isProductive(items, productiveDefinitions: productiveDefinitions) else {
+                return []
+            }
+            return blockingReferences(
+                in: items,
+                pointer: afmJSONPointer(appending: "items", to: pointer),
+                productiveDefinitions: productiveDefinitions
+            )
+        default:
+            return []
+        }
+    }
+
+    static func blockingUnionReferences(
+        _ choices: [AFMSchemaDocumentBox],
+        pointer: String,
+        productiveDefinitions: Set<String>
+    ) -> [ReferenceEdge] {
+        choices.enumerated().flatMap { index, choice -> [ReferenceEdge] in
+            guard !isProductive(choice.value, productiveDefinitions: productiveDefinitions) else {
+                return []
+            }
+            let choicePointer = afmJSONPointer(
+                appending: String(index),
+                to: afmJSONPointer(appending: "anyOf", to: pointer)
+            )
+            return blockingReferences(
+                in: choice.value,
+                pointer: choicePointer,
+                productiveDefinitions: productiveDefinitions
+            )
+        }
+    }
+
+    static func blockingObjectReferences(
+        in document: AFMSchemaDocument,
+        pointer: String,
+        productiveDefinitions: Set<String>
+    ) -> [ReferenceEdge] {
+        let properties = document.properties ?? [:]
+        let requiredNames = document.required ?? Array(properties.keys)
+        return requiredNames.sorted().flatMap { propertyName -> [ReferenceEdge] in
+            guard let property = properties[propertyName]?.value,
+                  !isProductive(property, productiveDefinitions: productiveDefinitions) else {
+                return []
+            }
+            let propertyPointer = afmJSONPointer(
+                appending: propertyName,
+                to: afmJSONPointer(appending: "properties", to: pointer)
+            )
+            return blockingReferences(
+                in: property,
+                pointer: propertyPointer,
+                productiveDefinitions: productiveDefinitions
+            )
+        }
+    }
+
+    static func resolvedType(of document: AFMSchemaDocument) -> String {
+        if let type = document.type {
+            return type
+        }
+        if document.properties != nil {
+            return "object"
+        }
+        if document.items != nil {
+            return "array"
+        }
+        if document.enumValues != nil {
+            return "string"
+        }
+        return "object"
+    }
+
+    static func referencedDefinitionName(_ reference: String) -> String? {
+        let prefix = "#/$defs/"
+        guard reference.hasPrefix(prefix) else {
+            return nil
+        }
+        let encodedName = String(reference.dropFirst(prefix.count))
+        let decodedName = encodedName
+            .replacingOccurrences(of: "~1", with: "/")
+            .replacingOccurrences(of: "~0", with: "~")
+        guard !encodedName.isEmpty, afmJSONPointerEscaped(decodedName) == encodedName else {
+            return nil
+        }
+        return decodedName
+    }
+
+    static func referenceEdgeOrder(_ lhs: ReferenceEdge, _ rhs: ReferenceEdge) -> Bool {
+        if lhs.target == rhs.target {
+            return lhs.pointer < rhs.pointer
+        }
+        return lhs.target < rhs.target
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMToolManifest.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Runtime/AFMToolManifest.swift
@@ -1,0 +1,210 @@
+import Foundation
+import FoundationModels
+
+struct AFMToolManifest: Sendable, Codable {
+    let name: String
+    let description: String
+    let parameters: AFMSchemaDocument
+    let runner: AFMToolRunnerManifest
+}
+
+struct AFMToolRunnerManifest: Sendable, Codable {
+    enum Kind: String, Sendable, Codable {
+        case shell
+        case `static`
+    }
+
+    enum OutputFormat: String, Sendable, Codable {
+        case text
+        case json
+    }
+
+    let kind: Kind
+    let outputFormat: OutputFormat?
+    let command: String?
+    let args: [String]?
+    let workingDirectory: String?
+    let environment: [String: String]?
+    let text: String?
+    let json: AFMJSONValue?
+}
+
+struct AFMManifestTool: Tool {
+    typealias Arguments = GeneratedContent
+    typealias Output = GeneratedContent
+
+    let manifest: AFMToolManifest
+    let sourcePath: String
+    let parameters: GenerationSchema
+
+    init(manifest: AFMToolManifest, sourcePath: String) throws {
+        self.manifest = manifest
+        self.sourcePath = sourcePath
+        self.parameters = try manifest.parameters.generationSchema(fallbackName: manifest.name.camelizedSchemaName())
+    }
+
+    var name: String { manifest.name }
+    var description: String { manifest.description }
+
+    func call(arguments: GeneratedContent) async throws -> GeneratedContent {
+        switch manifest.runner.kind {
+        case .static:
+            return try staticOutput()
+        case .shell:
+            return try await shellOutput(arguments: arguments)
+        }
+    }
+
+    private func staticOutput() throws -> GeneratedContent {
+        switch manifest.runner.outputFormat ?? .json {
+        case .json:
+            guard let json = manifest.runner.json else {
+                throw AFMRuntimeError.invalidRequest("Static tool '\(name)' is missing runner.json output")
+            }
+            return try GeneratedContent(json: json.jsonString(pretty: false))
+        case .text:
+            guard let text = manifest.runner.text else {
+                throw AFMRuntimeError.invalidRequest("Static tool '\(name)' is missing runner.text output")
+            }
+            return GeneratedContent(text)
+        }
+    }
+
+    private func shellOutput(arguments: GeneratedContent) async throws -> GeneratedContent {
+        guard let command = manifest.runner.command,
+              !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AFMRuntimeError.invalidRequest("Shell tool '\(name)' is missing runner.command")
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: expandedPathString(command))
+        process.arguments = manifest.runner.args ?? []
+        if let workingDirectory = manifest.runner.workingDirectory, !workingDirectory.isEmpty {
+            process.currentDirectoryURL = URL(fileURLWithPath: expandedPathString(workingDirectory))
+        }
+        process.environment = ProcessInfo.processInfo.environment.merging(manifest.runner.environment ?? [:]) { _, new in new }
+
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardInput = inputPipe
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        let outputHandle = outputPipe.fileHandleForReading
+        let errorHandle = errorPipe.fileHandleForReading
+        let outputTask = Task.detached {
+            try outputHandle.readToEnd() ?? Data()
+        }
+        let errorTask = Task.detached {
+            try errorHandle.readToEnd() ?? Data()
+        }
+
+        let inputData = Data(arguments.jsonString.utf8)
+        inputPipe.fileHandleForWriting.write(inputData)
+        try? inputPipe.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        let stdout = String(data: try await outputTask.value, encoding: .utf8) ?? ""
+        let stderr = String(data: try await errorTask.value, encoding: .utf8) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            let trimmedError = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let message = trimmedError.isEmpty
+                ? "Tool '\(name)' exited with status \(process.terminationStatus)"
+                : trimmedError
+            throw AFMRuntimeError.providerFailure(message)
+        }
+
+        switch manifest.runner.outputFormat ?? .json {
+        case .json:
+            let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw AFMRuntimeError.providerFailure("Tool '\(name)' returned empty JSON output")
+            }
+            return try GeneratedContent(json: trimmed)
+        case .text:
+            let trimmed = stdout.trimmingCharacters(in: .newlines)
+            guard !trimmed.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw AFMRuntimeError.providerFailure("Tool '\(name)' returned empty text output")
+            }
+            return GeneratedContent(trimmed)
+        }
+    }
+}
+
+enum AFMJSONValue: Sendable, Codable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: AFMJSONValue])
+    case array([AFMJSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: AFMJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([AFMJSONValue].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    func jsonString(pretty: Bool) throws -> String {
+        let encoder = JSONEncoder()
+        if pretty {
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        } else {
+            encoder.outputFormatting = [.sortedKeys]
+        }
+        let data = try encoder.encode(self)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw AFMRuntimeError.providerFailure("Could not encode JSON value")
+        }
+        return text
+    }
+}
+
+extension String {
+    func camelizedSchemaName() -> String {
+        split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map { segment in
+                segment.prefix(1).uppercased() + segment.dropFirst()
+            }
+            .joined()
+            .nonEmptyOrFallback("Schema")
+    }
+
+    func nonEmptyOrFallback(_ fallback: String) -> String {
+        isEmpty ? fallback : self
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLISchemaTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLISchemaTests.swift
@@ -178,8 +178,8 @@ func pipedSchemaInputOverridesPresetDefaults() throws {
     #expect(json["input"] as? String == pipedInput)
 }
 
-@Test("Schemas emitted by fm fail closed instead of changing shape silently")
-func foundationModelsCLISchemaFixturesFailClosed() throws {
+@Test("Schemas emitted by fm convert into runnable generation schemas")
+func foundationModelsCLISchemaFixturesConvert() throws {
     let fixtures = ["fm-schema-nested", "fm-schema-union"]
 
     for fixture in fixtures {
@@ -192,10 +192,10 @@ func foundationModelsCLISchemaFixturesFailClosed() throws {
         )
         let result = try runCustomSchemaDryRun(schemaURL)
 
-        #expect(result.status == 64)
-        #expect(result.stdout.isEmpty)
-        #expect(result.stderr.contains("Unsupported schema keyword '$defs'"))
-        #expect(result.stderr.contains("JSON pointer '/$defs'"))
+        #expect(result.status == 0)
+        #expect(result.stderr.isEmpty)
+        let payload = try parseJSONObject(result.stdout)
+        #expect(payload["command"] as? String == "schema run custom")
     }
 }
 
@@ -208,34 +208,22 @@ func unsupportedSchemaKeywordsReportExactPointers() throws {
 
     let cases = [
         UnsupportedSchemaCase(
-            name: "definitions",
-            document: #"{"type":"object","$defs":{}}"#,
-            keyword: "$defs",
-            pointer: "/$defs"
+            name: "one-of",
+            document: #"{"oneOf":[{"type":"string"},{"type":"integer"}]}"#,
+            keyword: "oneOf",
+            pointer: "/oneOf"
         ),
         UnsupportedSchemaCase(
-            name: "reference",
-            document: ##"{"type":"object","properties":{"address":{"$ref":"#/$defs/Address"}}}"##,
-            keyword: "$ref",
-            pointer: "/properties/address/$ref"
+            name: "all-of",
+            document: #"{"type":"object","properties":{"profile":{"allOf":[{"type":"object"}]}}}"#,
+            keyword: "allOf",
+            pointer: "/properties/profile/allOf"
         ),
         UnsupportedSchemaCase(
-            name: "escaped-reference-path",
-            document: ##"{"type":"object","properties":{"home/office~primary":{"$ref":"#/$defs/Room"}}}"##,
-            keyword: "$ref",
-            pointer: "/properties/home~1office~0primary/$ref"
-        ),
-        UnsupportedSchemaCase(
-            name: "union",
-            document: #"{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"}]}}"#,
-            keyword: "anyOf",
-            pointer: "/items/anyOf"
-        ),
-        UnsupportedSchemaCase(
-            name: "property-order",
-            document: #"{"type":"object","properties":{"profile":{"type":"object","x-order":[]}}}"#,
-            keyword: "x-order",
-            pointer: "/properties/profile/x-order"
+            name: "escaped-unsupported-path",
+            document: #"{"type":"object","properties":{"home/office~primary":{"format":"email"}}}"#,
+            keyword: "format",
+            pointer: "/properties/home~1office~0primary/format"
         ),
         UnsupportedSchemaCase(
             name: "open-additional-properties",
@@ -273,15 +261,17 @@ func unsupportedYAMLSchemaKeywordReportsExactPointer() throws {
     type: object
     properties:
       address:
-        $ref: '#/$defs/Address'
+        oneOf:
+        - type: string
+        - type: integer
     """
     try schema.write(to: schemaURL, atomically: true, encoding: .utf8)
 
     let result = try runCustomSchemaDryRun(schemaURL)
 
     #expect(result.status == 64)
-    #expect(result.stderr.contains("Unsupported schema keyword '$ref'"))
-    #expect(result.stderr.contains("JSON pointer '/properties/address/$ref'"))
+    #expect(result.stderr.contains("Unsupported schema keyword 'oneOf'"))
+    #expect(result.stderr.contains("JSON pointer '/properties/address/oneOf'"))
 }
 
 @Test("Closed additional properties preserve supported schema conversion")

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLITests.swift
@@ -35,6 +35,7 @@ func leafCommandHelpCoverage() throws {
         ["session", "respond", "--help"],
         ["session", "stream", "--help"],
         ["session", "chat", "--help"],
+        ["schema", "object", "--help"],
         ["schema", "list", "--help"],
         ["schema", "run", "custom", "--help"],
         ["schema", "run", "typed-person", "--help"],

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMSchemaObjectTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMSchemaObjectTests.swift
@@ -1,0 +1,363 @@
+import Foundation
+import Testing
+@testable import AFMCLI
+
+@Test("schema object matches fm nested and union artifacts semantically")
+func schemaObjectMatchesFoundationModelsNestedAndUnionArtifacts() throws {
+    let nested = try runAFM(
+        "schema", "object",
+        "--name", "ContactCard",
+        "--string", "address.street",
+        "--string", "address.zip", "--optional"
+    )
+    #expect(nested.status == 0)
+    try expectSchema(nested.stdout, matchesFixture: "fm-schema-nested")
+
+    let deep = try runAFM(
+        "schema", "object", "--name", "Deep",
+        "--string", "customer.billing.street",
+        "--integer", "customer.billing.zip", "--optional",
+        "--boolean", "customer.active"
+    )
+    #expect(deep.status == 0)
+    try expectSchema(deep.stdout, matchesFixture: "fm-schema-deep")
+
+    let email = try runAFM("schema", "object", "--name", "EmailContact", "--string", "email")
+    let phone = try runAFM("schema", "object", "--name", "PhoneContact", "--string", "phone")
+    let union = try runAFM(
+        "schema", "object",
+        "--name", "ContactMethod",
+        "--anyOf",
+        "--schema", email.stdout,
+        "--schema", phone.stdout
+    )
+
+    #expect(email.status == 0)
+    #expect(phone.status == 0)
+    #expect(union.status == 0)
+    try expectSchema(union.stdout, matchesFixture: "fm-schema-union")
+}
+
+@Test("schema object matches fm primitives, modifiers, and object arrays")
+func schemaObjectMatchesFoundationModelsPropertyArtifacts() throws {
+    let primitives = try runAFM(
+        "schema", "object",
+        "--name=Sample",
+        "--string", "title", "--description", "Display title",
+        "--int", "count", "--optional",
+        "--double", "score",
+        "--boolean", "active",
+        "--string", "tags", "--array"
+    )
+    #expect(primitives.status == 0)
+    try expectSchema(primitives.stdout, matchesFixture: "fm-schema-primitives")
+
+    let item = try runAFM(
+        "schema", "object", "--name", "Item",
+        "--string", "id", "--double", "price"
+    )
+    let basket = try runAFM(
+        "schema", "object", "--name", "Basket",
+        "--object", "items", "--schema", item.stdout,
+        "--array", "--description", "Line items"
+    )
+    #expect(item.status == 0)
+    #expect(basket.status == 0)
+    try expectSchema(basket.stdout, matchesFixture: "fm-schema-object-array")
+}
+
+@Test("schema object YAML composes and runs through schema custom")
+func schemaObjectYAMLRoundTripsThroughCustomRunner() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-schema-object-yaml-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let item = try runAFM(
+        "schema", "object", "--format", "yaml", "--name", "Item",
+        "--string", "id", "--double", "price"
+    )
+    let itemURL = directory.appending(path: "item.yaml")
+    try item.stdout.write(to: itemURL, atomically: true, encoding: .utf8)
+    let basket = try runAFM(
+        "schema", "object", "--name", "Basket",
+        "--object", "items", "--schema", "@\(itemURL.path())",
+        "--array", "--description", "Line items"
+    )
+    #expect(item.status == 0)
+    #expect(basket.status == 0)
+    try expectSchema(basket.stdout, matchesFixture: "fm-schema-object-array")
+
+    let basketURL = directory.appending(path: "basket.json")
+    try basket.stdout.write(to: basketURL, atomically: true, encoding: .utf8)
+    let custom = try runSchemaCustomDryRun(basketURL)
+    #expect(custom.status == 0)
+    #expect((try parseJSONObject(custom.stdout))["command"] as? String == "schema run custom")
+}
+
+@Test("schema object rejects invalid declaration sequences")
+func schemaObjectRejectsInvalidDeclarationSequences() throws {
+    let cases = [
+        InvalidSchemaObjectCase(arguments: ["--string", "name"], message: "Please provide --name"),
+        InvalidSchemaObjectCase(arguments: ["--name", "Bad", "--optional"], message: "Property modifiers"),
+        InvalidSchemaObjectCase(arguments: ["--name", "Bad", "--object", "child"], message: "must be followed"),
+        InvalidSchemaObjectCase(arguments: ["--name", "Bad", "--anyOf"], message: "requires at least one"),
+        InvalidSchemaObjectCase(
+            arguments: ["--name", "Bad", "--string", "value", "--string", "value"],
+            message: "multiple 'value'"
+        ),
+        InvalidSchemaObjectCase(
+            arguments: [
+                "--name", "Bad",
+                "--string", "billing.address.street",
+                "--integer", "shipping.address.zip"
+            ],
+            message: "Conflicting schema definitions named 'Address'"
+        ),
+        InvalidSchemaObjectCase(arguments: ["--name", "Bad", "--unknown"], message: "Unknown schema object option")
+    ]
+
+    for testCase in cases {
+        let result = try runAFM(["schema", "object"] + testCase.arguments)
+        #expect(result.status == 64)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.contains(testCase.message))
+    }
+}
+
+@Test("supported schema keywords still fail closed when malformed")
+func supportedSchemaKeywordsFailClosedWhenMalformed() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-malformed-supported-schema-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let cases = [
+        MalformedSchemaCase(
+            name: "undefined-reference",
+            document: ##"{"type":"object","properties":{"value":{"$ref":"#/$defs/Missing"}}}"##,
+            message: "Undefined schema reference"
+        ),
+        MalformedSchemaCase(
+            name: "external-reference",
+            document: #"{"$ref":"https://example.com/schema.json"}"#,
+            message: "Only local references"
+        ),
+        MalformedSchemaCase(
+            name: "invalid-order",
+            document: #"{"type":"object","properties":{"value":{"type":"string"}},"x-order":[]}"#,
+            message: "x-order must list every object property"
+        ),
+        MalformedSchemaCase(
+            name: "empty-union",
+            document: #"{"title":"EmptyUnion","anyOf":[]}"#,
+            message: "anyOf must contain at least one schema"
+        ),
+        MalformedSchemaCase(
+            name: "nested-definitions",
+            document: #"{"type":"object","properties":{"nested":{"type":"object","$defs":{"Value":{"type":"string"}}}}}"#,
+            message: "Nested $defs are not supported"
+        )
+    ]
+
+    for testCase in cases {
+        let url = directory.appending(path: "\(testCase.name).json")
+        try testCase.document.write(to: url, atomically: true, encoding: .utf8)
+        let result = try runSchemaCustomDryRun(url)
+        #expect(result.status == 64)
+        #expect(result.stderr.contains(testCase.message))
+    }
+}
+
+@Test("schema JSON rejects semantic duplicate keys at exact pointers")
+func schemaJSONRejectsSemanticDuplicateKeys() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-duplicate-schema-keys-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let cases = [
+        InvalidJSONSchemaCase(
+            name: "escaped-root-key",
+            document: ##"{"type":"object","\u0074ype":"string"}"##,
+            pointer: "/type"
+        ),
+        InvalidJSONSchemaCase(
+            name: "escaped-property-key",
+            document: ##"{"type":"object","properties":{"a/b":{"type":"string"},"a\/b":{"type":"integer"}}}"##,
+            pointer: "/properties/a~1b"
+        ),
+        InvalidJSONSchemaCase(
+            name: "escaped-definition-key",
+            document: ##"{"type":"object","$defs":{"Node":{"type":"object"},"\u004eode":{"type":"string"}}}"##,
+            pointer: "/$defs/Node"
+        ),
+        InvalidJSONSchemaCase(
+            name: "duplicate-inside-array",
+            document: ##"{"title":"Choice","anyOf":[{"type":"object","\u0074ype":"string"}]}"##,
+            pointer: "/anyOf/0/type"
+        )
+    ]
+
+    for testCase in cases {
+        let url = directory.appending(path: "\(testCase.name).json")
+        try testCase.document.write(to: url, atomically: true, encoding: .utf8)
+        let result = try runSchemaCustomDryRun(url)
+
+        #expect(result.status == 64)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.contains("Duplicate object key"))
+        #expect(result.stderr.contains("JSON pointer '\(testCase.pointer)'"))
+    }
+
+    let duplicateLeaf = ##"{"type":"object","\u0074ype":"string"}"##
+    let deeplyNested = String(repeating: "[", count: 256)
+        + duplicateLeaf
+        + String(repeating: "]", count: 256)
+    let deeplyNestedURL = directory.appending(path: "deeply-nested-duplicate.json")
+    try deeplyNested.write(to: deeplyNestedURL, atomically: true, encoding: .utf8)
+    let deeplyNestedResult = try runSchemaCustomDryRun(deeplyNestedURL)
+
+    #expect(deeplyNestedResult.status == 64)
+    #expect(deeplyNestedResult.stdout.isEmpty)
+    #expect(deeplyNestedResult.stderr.contains("JSON nesting exceeds the supported depth"))
+}
+
+@Test("schema references reject cycles without a finite value")
+func schemaReferencesRejectUnproductiveCycles() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-schema-productivity-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let rejected = [
+        InvalidJSONSchemaCase(
+            name: "required-self-cycle",
+            document: ##"""
+            {"title":"Root","type":"object","properties":{"node":{"$ref":"#/$defs/Node"}},
+            "required":["node"],"$defs":{"Node":{"type":"object",
+            "properties":{"next":{"$ref":"#/$defs/Node"}},"required":["next"]}}}
+            """##,
+            pointer: "/$defs/Node/properties/next/$ref"
+        ),
+        InvalidJSONSchemaCase(
+            name: "required-mutual-cycle",
+            document: ##"""
+            {"title":"Root","type":"object","properties":{"a":{"$ref":"#/$defs/A"}},
+            "required":["a"],"$defs":{"A":{"type":"object",
+            "properties":{"b":{"$ref":"#/$defs/B"}},"required":["b"]},
+            "B":{"type":"object","properties":{"a":{"$ref":"#/$defs/A"}},"required":["a"]}}}
+            """##,
+            pointer: "/$defs/B/properties/a/$ref"
+        ),
+        InvalidJSONSchemaCase(
+            name: "positive-array-cycle",
+            document: ##"""
+            {"title":"Root","type":"object","properties":{"node":{"$ref":"#/$defs/Node"}},
+            "required":["node"],"$defs":{"Node":{"type":"object",
+            "properties":{"children":{"type":"array","minItems":1,
+            "items":{"$ref":"#/$defs/Node"}}},"required":["children"]}}}
+            """##,
+            pointer: "/$defs/Node/properties/children/items/$ref"
+        )
+    ]
+
+    for testCase in rejected {
+        let url = directory.appending(path: "\(testCase.name).json")
+        try testCase.document.write(to: url, atomically: true, encoding: .utf8)
+        let result = try runSchemaCustomDryRun(url)
+
+        #expect(result.status == 64)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.contains("cannot produce a finite value"))
+        #expect(result.stderr.contains("JSON pointer '\(testCase.pointer)'"))
+    }
+}
+
+@Test("schema references allow recursion with a finite base case")
+func schemaReferencesAllowProductiveRecursion() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "afm-schema-productive-recursion-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let accepted = [
+        ValidJSONSchemaCase(
+            name: "optional-recursion",
+            document: ##"""
+            {"title":"Root","type":"object","properties":{"node":{"$ref":"#/$defs/Node"}},
+            "required":["node"],"$defs":{"Node":{"type":"object",
+            "properties":{"next":{"$ref":"#/$defs/Node"}},"required":[]}}}
+            """##
+        ),
+        ValidJSONSchemaCase(
+            name: "zero-minimum-array-recursion",
+            document: ##"""
+            {"title":"Root","type":"object","properties":{"node":{"$ref":"#/$defs/Node"}},
+            "required":["node"],"$defs":{"Node":{"type":"object",
+            "properties":{"children":{"type":"array","minItems":0,
+            "items":{"$ref":"#/$defs/Node"}}},"required":["children"]}}}
+            """##
+        ),
+        ValidJSONSchemaCase(
+            name: "recursive-union-with-base-case",
+            document: ##"""
+            {"title":"Root","type":"object","properties":{"node":{"$ref":"#/$defs/Node"}},
+            "required":["node"],"$defs":{"Node":{"anyOf":[
+            {"$ref":"#/$defs/Node"},{"type":"string"}]}}}
+            """##
+        )
+    ]
+
+    for testCase in accepted {
+        let url = directory.appending(path: "\(testCase.name).json")
+        try testCase.document.write(to: url, atomically: true, encoding: .utf8)
+        let result = try runSchemaCustomDryRun(url)
+
+        #expect(result.status == 0)
+        #expect(result.stderr.isEmpty)
+    }
+}
+
+private func expectSchema(_ text: String, matchesFixture fixture: String) throws {
+    let fixtureURL = try #require(
+        Bundle.module.url(forResource: fixture, withExtension: "json", subdirectory: "Fixtures")
+    )
+    let expectedData = try Data(contentsOf: fixtureURL)
+    let actualData = try #require(text.data(using: .utf8))
+    let expected = try #require(JSONSerialization.jsonObject(with: expectedData) as? NSDictionary)
+    let actual = try #require(JSONSerialization.jsonObject(with: actualData) as? NSDictionary)
+    #expect(actual.isEqual(expected))
+}
+
+private func runSchemaCustomDryRun(_ schemaURL: URL) throws -> CommandResult {
+    try runAFM(
+        "schema", "run", "custom",
+        "--output", "json",
+        "--dry-run",
+        "--schema", schemaURL.path(),
+        "--input", "Test input"
+    )
+}
+
+private struct InvalidSchemaObjectCase {
+    let arguments: [String]
+    let message: String
+}
+
+private struct MalformedSchemaCase {
+    let name: String
+    let document: String
+    let message: String
+}
+
+private struct InvalidJSONSchemaCase {
+    let name: String
+    let document: String
+    let pointer: String
+}
+
+private struct ValidJSONSchemaCase {
+    let name: String
+    let document: String
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-deep.json
+++ b/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-deep.json
@@ -1,0 +1,59 @@
+{
+  "title" : "Deep",
+  "properties" : {
+    "customer" : {
+      "$ref" : "#\/$defs\/Customer"
+    }
+  },
+  "$defs" : {
+    "Billing" : {
+      "type" : "object",
+      "properties" : {
+        "zip" : {
+          "type" : "integer"
+        },
+        "street" : {
+          "type" : "string"
+        }
+      },
+      "x-order" : [
+        "street",
+        "zip"
+      ],
+      "title" : "Billing",
+      "required" : [
+        "street"
+      ],
+      "additionalProperties" : false
+    },
+    "Customer" : {
+      "required" : [
+        "active",
+        "billing"
+      ],
+      "type" : "object",
+      "properties" : {
+        "active" : {
+          "type" : "boolean"
+        },
+        "billing" : {
+          "$ref" : "#\/$defs\/Billing"
+        }
+      },
+      "title" : "Customer",
+      "additionalProperties" : false,
+      "x-order" : [
+        "active",
+        "billing"
+      ]
+    }
+  },
+  "required" : [
+    "customer"
+  ],
+  "x-order" : [
+    "customer"
+  ],
+  "type" : "object",
+  "additionalProperties" : false
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-object-array.json
+++ b/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-object-array.json
@@ -1,0 +1,43 @@
+{
+  "additionalProperties" : false,
+  "title" : "Basket",
+  "properties" : {
+    "items" : {
+      "description" : "Line items",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#\/$defs\/Item"
+      }
+    }
+  },
+  "type" : "object",
+  "$defs" : {
+    "Item" : {
+      "additionalProperties" : false,
+      "type" : "object",
+      "title" : "Item",
+      "x-order" : [
+        "id",
+        "price"
+      ],
+      "properties" : {
+        "price" : {
+          "type" : "number"
+        },
+        "id" : {
+          "type" : "string"
+        }
+      },
+      "required" : [
+        "id",
+        "price"
+      ]
+    }
+  },
+  "required" : [
+    "items"
+  ],
+  "x-order" : [
+    "items"
+  ]
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-primitives.json
+++ b/Tools/AFMCLI/Tests/AFMCLITests/Fixtures/fm-schema-primitives.json
@@ -1,0 +1,39 @@
+{
+  "type" : "object",
+  "additionalProperties" : false,
+  "properties" : {
+    "tags" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string"
+      }
+    },
+    "title" : {
+      "description" : "Display title",
+      "type" : "string"
+    },
+    "count" : {
+      "type" : "integer"
+    },
+    "score" : {
+      "type" : "number"
+    },
+    "active" : {
+      "type" : "boolean"
+    }
+  },
+  "title" : "Sample",
+  "required" : [
+    "title",
+    "score",
+    "active",
+    "tags"
+  ],
+  "x-order" : [
+    "title",
+    "count",
+    "score",
+    "active",
+    "tags"
+  ]
+}


### PR DESCRIPTION
## Summary

- add `afm schema object` with native-compatible ordered declarations, modifiers, primitive aliases, dot-path objects, explicit object schemas, arrays, and root `anyOf`
- emit composable JSON or YAML artifacts and accept inline or `@path` JSON/YAML input
- convert native `$defs`, local `$ref`, `x-order`, closed objects, and unions into runnable `GenerationSchema` values instead of only parsing their shape
- validate generated/custom schemas during dry runs
- preserve exact JSON-pointer diagnostics, reject duplicate escaped-equivalent JSON keys, external references, conflicting definitions, and recursive schemas that cannot produce a finite value
- accept productive recursion such as optional links, zero-minimum arrays, and unions with a finite base case

This is stacked on #168, whose fail-closed boundary remains in force for unsupported keywords.

## Verification

- all five fixture families match live `/usr/bin/fm` output semantically: primitives/modifiers, nested objects, deep objects, object arrays, and unions
- Xcode 26.6: 12 focused schema-object/conversion/hardening tests passed
- Xcode 27: the same 12 tests passed
- direct native comparison confirmed equivalent artifacts despite key-order formatting differences
- verified an `fm` collision case that silently reuses an incompatible nested definition; `afm` rejects it explicitly
- strict Core/CLI SwiftLint: 0 violations
- `git diff --check`: clean