### PR TITLE
Add signed no-TTY Foundation Lab agent bridge

### DIFF
--- a/Foundation Lab/AgentBridge/AgentBridgeBookmarkStore.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeBookmarkStore.swift
@@ -1,0 +1,100 @@
+#if os(macOS)
+import Foundation
+
+@MainActor
+struct AgentBridgeBookmarkStore {
+    enum Error: LocalizedError {
+        case missingDirectory
+        case inaccessibleDirectory
+        case notDirectory
+
+        var errorDescription: String? {
+            switch self {
+            case .missingDirectory:
+                String(localized: "Choose a bridge folder before enabling the agent bridge.")
+            case .inaccessibleDirectory:
+                String(localized: "Foundation Lab could not keep access to the selected bridge folder.")
+            case .notDirectory:
+                String(localized: "The selected bridge location is not a folder.")
+            }
+        }
+    }
+
+    private static let bookmarkKey = "agentBridge.baseDirectoryBookmark.v1"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var hasBookmark: Bool {
+        defaults.data(forKey: Self.bookmarkKey) != nil
+    }
+
+    func save(_ directoryURL: URL) throws {
+        let didStartAccess = directoryURL.startAccessingSecurityScopedResource()
+        guard didStartAccess else {
+            throw Error.inaccessibleDirectory
+        }
+        defer { directoryURL.stopAccessingSecurityScopedResource() }
+
+        try requireDirectory(directoryURL)
+        defaults.set(try bookmarkData(for: directoryURL), forKey: Self.bookmarkKey)
+    }
+
+    func resolvedURL() throws -> URL? {
+        guard let data = defaults.data(forKey: Self.bookmarkKey) else { return nil }
+        return try resolve(data).url
+    }
+
+    func beginAccess() throws -> URL {
+        guard let data = defaults.data(forKey: Self.bookmarkKey) else {
+            throw Error.missingDirectory
+        }
+
+        let resolution = try resolve(data)
+        let directoryURL = resolution.url
+        guard directoryURL.startAccessingSecurityScopedResource() else {
+            throw Error.inaccessibleDirectory
+        }
+
+        do {
+            try requireDirectory(directoryURL)
+            if resolution.isStale {
+                defaults.set(try bookmarkData(for: directoryURL), forKey: Self.bookmarkKey)
+            }
+            return directoryURL
+        } catch {
+            directoryURL.stopAccessingSecurityScopedResource()
+            throw error
+        }
+    }
+
+    private func bookmarkData(for directoryURL: URL) throws -> Data {
+        try directoryURL.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: [.isDirectoryKey],
+            relativeTo: nil
+        )
+    }
+
+    private func resolve(_ data: Data) throws -> (url: URL, isStale: Bool) {
+        var isStale = false
+        let url = try URL(
+            resolvingBookmarkData: data,
+            options: [.withSecurityScope, .withoutUI],
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+        return (url, isStale)
+    }
+
+    private func requireDirectory(_ url: URL) throws {
+        let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+        guard values.isDirectory == true else {
+            throw Error.notDirectory
+        }
+    }
+}
+#endif

--- a/Foundation Lab/AgentBridge/AgentBridgeController.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeController.swift
@@ -60,6 +60,7 @@ final class AgentBridgeController {
     @ObservationIgnored private var protectsProcessLifetime = false
     @ObservationIgnored private var hasActivated = false
     @ObservationIgnored private var reconciliationTask: Task<Void, Never>?
+    @ObservationIgnored private var cleanupFailureContext: String?
 
     private static let enabledPreferenceKey = "agentBridge.isEnabled.v1"
     private static let bridgeDirectoryName = "bridge"
@@ -167,9 +168,17 @@ private extension AgentBridgeController {
 
     private func reconcileEnabledState() async {
         while true {
+            if status == .failed, hasActiveResources {
+                await retryFailedCleanup()
+                return
+            }
+
             if isEnabled, !hasActiveResources {
                 await start()
-                guard server != nil else {
+                guard status == .running else {
+                    if status == .failed, hasActiveResources {
+                        continue
+                    }
                     if !isEnabled {
                         resetDisabledStatus()
                     }
@@ -177,7 +186,9 @@ private extension AgentBridgeController {
                 }
             } else if !isEnabled, hasActiveResources {
                 await stop()
-                guard !hasActiveResources else { return }
+                if hasActiveResources {
+                    continue
+                }
             } else {
                 if !isEnabled { resetDisabledStatus() }
                 return
@@ -192,6 +203,7 @@ private extension AgentBridgeController {
     private func start() async {
         status = .starting
         errorMessage = nil
+        cleanupFailureContext = nil
 
         guard let bearerToken else {
             failStart(Error.secureTokenUnavailable(tokenErrorDescription ?? String(localized: "Unknown error")))
@@ -292,21 +304,50 @@ private extension AgentBridgeController {
 
     private func cleanFailedStart(server: AFMHTTPServer?, baseDirectory: URL) async -> [String] {
         if let server {
-            do {
-                try await server.stop()
-            } catch {
-                self.server = server
-                activeBaseDirectory = baseDirectory
-                return [error.localizedDescription]
-            }
+            self.server = server
         }
-        baseDirectory.stopAccessingSecurityScopedResource()
-        releaseProcessLifetimeProtection()
-        return []
+        activeBaseDirectory = baseDirectory
+        return await cleanActiveResources()
     }
 
     private func stop() async {
         status = .stopping
+        let failures = await cleanActiveResources()
+
+        if failures.isEmpty {
+            cleanupFailureContext = nil
+            status = bookmarkStore.hasBookmark ? .off : .notConfigured
+            errorMessage = nil
+        } else {
+            let context = String(localized: "The bridge could not stop completely.")
+            cleanupFailureContext = context
+            status = .failed
+            errorMessage = cleanupFailureMessage(context: context, failures: failures)
+        }
+    }
+
+    private func retryFailedCleanup() async {
+        let context = cleanupFailureContext
+            ?? errorMessage
+            ?? String(localized: "The bridge cleanup did not finish.")
+        let failures = await cleanActiveResources()
+
+        if failures.isEmpty {
+            cleanupFailureContext = nil
+            if isEnabled {
+                status = .failed
+                errorMessage = context
+            } else {
+                resetDisabledStatus()
+            }
+        } else {
+            cleanupFailureContext = context
+            status = .failed
+            errorMessage = cleanupFailureMessage(context: context, failures: failures)
+        }
+    }
+
+    private func cleanActiveResources() async -> [String] {
         var failures: [String] = []
 
         if let descriptorLease {
@@ -333,33 +374,31 @@ private extension AgentBridgeController {
             activeBaseDirectory = nil
             releaseProcessLifetimeProtection()
         }
-
-        if failures.isEmpty {
-            status = bookmarkStore.hasBookmark ? .off : .notConfigured
-            errorMessage = nil
-        } else {
-            status = .failed
-            errorMessage = String(
-                localized: "The bridge stopped, but cleanup needs attention: \(failures.joined(separator: " "))"
-            )
-        }
+        return failures
     }
 
     private func failStart(_ error: any Swift.Error, cleanupFailures: [String] = []) {
-        descriptorLease = nil
-        descriptorPath = nil
+        if descriptorLease == nil {
+            descriptorPath = nil
+        }
         status = .failed
+        let context = String(localized: "The bridge could not start: \(error.localizedDescription)")
 
         if cleanupFailures.isEmpty {
-            errorMessage = String(localized: "The bridge could not start: \(error.localizedDescription)")
+            cleanupFailureContext = nil
+            errorMessage = context
         } else {
-            errorMessage = String(
-                localized: "The bridge could not start: \(error.localizedDescription) Cleanup: \(cleanupFailures.joined(separator: " "))"
-            )
+            cleanupFailureContext = context
+            errorMessage = cleanupFailureMessage(context: context, failures: cleanupFailures)
         }
     }
 
+    private func cleanupFailureMessage(context: String, failures: [String]) -> String {
+        String(localized: "\(context) Cleanup: \(failures.joined(separator: " "))")
+    }
+
     private func resetDisabledStatus() {
+        cleanupFailureContext = nil
         status = bookmarkStore.hasBookmark ? .off : .notConfigured
         errorMessage = nil
     }

--- a/Foundation Lab/AgentBridge/AgentBridgeController.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeController.swift
@@ -1,0 +1,381 @@
+#if os(macOS)
+import AFMServer
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AgentBridgeController {
+    enum Status: Sendable, Equatable {
+        case notConfigured
+        case off
+        case starting
+        case running
+        case stopping
+        case failed
+    }
+
+    enum Error: LocalizedError {
+        case noAvailableModels
+        case secureTokenUnavailable(String)
+        case unexpectedEndpoint
+        case emptySelection
+
+        var errorDescription: String? {
+            switch self {
+            case .noAvailableModels:
+                String(localized: "No Foundation Models runtime is ready on this Mac.")
+            case .secureTokenUnavailable(let reason):
+                String(localized: "The bridge could not create its launch token: \(reason)")
+            case .unexpectedEndpoint:
+                String(localized: "The bridge server did not bind its requested loopback endpoint.")
+            case .emptySelection:
+                String(localized: "No bridge folder was selected.")
+            }
+        }
+    }
+
+    var isEnabled: Bool {
+        didSet {
+            guard oldValue != isEnabled else { return }
+            preferenceDefaults.set(isEnabled, forKey: Self.enabledPreferenceKey)
+            guard hasActivated else { return }
+            scheduleReconciliation()
+        }
+    }
+
+    private(set) var status: Status
+    private(set) var baseDirectoryPath: String?
+    private(set) var descriptorPath: String?
+    private(set) var errorMessage: String?
+
+    @ObservationIgnored private let bookmarkStore: AgentBridgeBookmarkStore
+    @ObservationIgnored private let preferenceDefaults: UserDefaults
+    @ObservationIgnored private let bearerToken: String?
+    @ObservationIgnored private let tokenErrorDescription: String?
+    @ObservationIgnored private let launchIdentifier = UUID()
+    @ObservationIgnored private var server: AFMHTTPServer?
+    @ObservationIgnored private var descriptorLease: AFMBridgeDescriptorLease?
+    @ObservationIgnored private var activeBaseDirectory: URL?
+    @ObservationIgnored private var protectsProcessLifetime = false
+    @ObservationIgnored private var hasActivated = false
+    @ObservationIgnored private var reconciliationTask: Task<Void, Never>?
+
+    private static let enabledPreferenceKey = "agentBridge.isEnabled.v1"
+    private static let bridgeDirectoryName = "bridge"
+    private static let loopbackHost = "127.0.0.1"
+    private static let terminationReason = "Foundation Lab agent bridge is serving local requests."
+
+    init(defaults: UserDefaults = .standard) {
+        let bookmarkStore = AgentBridgeBookmarkStore(defaults: defaults)
+        self.bookmarkStore = bookmarkStore
+        preferenceDefaults = defaults
+        isEnabled = defaults.bool(forKey: Self.enabledPreferenceKey)
+
+        do {
+            bearerToken = try AFMBridgeBearerTokenGenerator.generate()
+            tokenErrorDescription = nil
+        } catch {
+            bearerToken = nil
+            tokenErrorDescription = error.localizedDescription
+        }
+
+        do {
+            let resolvedPath = try bookmarkStore.resolvedURL()?.path()
+            baseDirectoryPath = resolvedPath
+            status = resolvedPath == nil ? .notConfigured : .off
+            errorMessage = nil
+        } catch {
+            baseDirectoryPath = nil
+            status = .failed
+            errorMessage = String(
+                localized: "The saved bridge folder could not be restored: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    var isTransitioning: Bool {
+        status == .starting || status == .stopping
+    }
+
+    var canToggleEnabled: Bool {
+        !isTransitioning && (isEnabled || bookmarkStore.hasBookmark)
+    }
+
+    var statusTitle: String {
+        switch status {
+        case .notConfigured:
+            String(localized: "Choose a folder")
+        case .off:
+            String(localized: "Off")
+        case .starting:
+            String(localized: "Starting")
+        case .running:
+            String(localized: "Running")
+        case .stopping:
+            String(localized: "Stopping")
+        case .failed:
+            String(localized: "Needs attention")
+        }
+    }
+
+    func selectBaseDirectory(_ directoryURL: URL) {
+        guard !isEnabled, !isTransitioning else { return }
+
+        do {
+            try bookmarkStore.save(directoryURL)
+            baseDirectoryPath = try bookmarkStore.resolvedURL()?.path()
+            status = .off
+            errorMessage = nil
+        } catch {
+            errorMessage = String(
+                localized: "The bridge folder could not be saved: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func handleDirectorySelectionFailure(_ error: any Swift.Error) {
+        let cocoaError = error as NSError
+        guard !(cocoaError.domain == NSCocoaErrorDomain && cocoaError.code == NSUserCancelledError) else {
+            return
+        }
+        errorMessage = String(localized: "The bridge folder could not be selected: \(error.localizedDescription)")
+    }
+
+    func handleEmptyDirectorySelection() {
+        errorMessage = Error.emptySelection.localizedDescription
+    }
+
+    func activatePersistedPreference() {
+        guard !hasActivated else { return }
+        hasActivated = true
+        if isEnabled {
+            scheduleReconciliation()
+        }
+    }
+}
+
+private extension AgentBridgeController {
+    private func scheduleReconciliation() {
+        guard reconciliationTask == nil else { return }
+        reconciliationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await reconcileEnabledState()
+            reconciliationTask = nil
+        }
+    }
+
+    private func reconcileEnabledState() async {
+        while true {
+            if isEnabled, server == nil {
+                await start()
+                guard server != nil else { return }
+            } else if !isEnabled, hasActiveResources {
+                await stop()
+            } else {
+                if !isEnabled, status != .notConfigured {
+                    status = bookmarkStore.hasBookmark ? .off : .notConfigured
+                    errorMessage = nil
+                }
+                return
+            }
+        }
+    }
+
+    private var hasActiveResources: Bool {
+        server != nil || descriptorLease != nil || activeBaseDirectory != nil || protectsProcessLifetime
+    }
+
+    private func start() async {
+        status = .starting
+        errorMessage = nil
+
+        guard let bearerToken else {
+            failStart(Error.secureTokenUnavailable(tokenErrorDescription ?? String(localized: "Unknown error")))
+            return
+        }
+
+        do {
+            let baseDirectory = try bookmarkStore.beginAccess()
+            await start(bearerToken: bearerToken, baseDirectory: baseDirectory)
+        } catch {
+            failStart(error)
+        }
+    }
+
+    private func start(bearerToken: String, baseDirectory: URL) async {
+        var newServer: AFMHTTPServer?
+
+        do {
+            let startup = try makeStartupConfiguration(
+                bearerToken: bearerToken,
+                baseDirectory: baseDirectory
+            )
+            newServer = startup.server
+            protectProcessLifetime()
+            let address = try await startup.server.start()
+            guard case .tcp(let boundHost, let boundPort) = address,
+                  boundHost == startup.host else {
+                throw Error.unexpectedEndpoint
+            }
+
+            let lease = try publishDescriptor(
+                startup,
+                endpoint: .loopbackTCP(host: boundHost, port: boundPort),
+                bearerToken: bearerToken
+            )
+            server = startup.server
+            descriptorLease = lease
+            activeBaseDirectory = baseDirectory
+            descriptorPath = lease.descriptorPath
+            status = .running
+        } catch {
+            let cleanupFailures = await cleanFailedStart(server: newServer, baseDirectory: baseDirectory)
+            failStart(error, cleanupFailures: cleanupFailures)
+        }
+    }
+
+    private func makeStartupConfiguration(
+        bearerToken: String,
+        baseDirectory: URL
+    ) throws -> StartupConfiguration {
+        let bridgeDirectory = baseDirectory.appending(
+            path: Self.bridgeDirectoryName,
+            directoryHint: .isDirectory
+        )
+        let bridgeDirectoryPath = bridgeDirectory.path()
+        try AFMBridgeDirectory.prepare(at: bridgeDirectoryPath)
+
+        let catalog = AgentBridgeModelCatalog()
+        let modelIdentifiers = catalog.models().map(\.id).sorted()
+        guard !modelIdentifiers.isEmpty else { throw Error.noAvailableModels }
+
+        let configuration = AFMServerConfiguration(
+            endpoint: .tcp(host: Self.loopbackHost, port: 0),
+            security: .init(bearerToken: bearerToken)
+        )
+        let generator = AFMFoundationModelsChatGenerator(
+            sessionBuilder: AgentBridgeSessionBuilder.makeSession
+        )
+        let server = try AFMHTTPServer(
+            configuration: configuration,
+            catalog: catalog,
+            generator: generator
+        )
+        return StartupConfiguration(
+            server: server,
+            directoryPath: bridgeDirectoryPath,
+            host: Self.loopbackHost,
+            modelIdentifiers: modelIdentifiers
+        )
+    }
+
+    private func publishDescriptor(
+        _ startup: StartupConfiguration,
+        endpoint: AFMBridgeEndpoint,
+        bearerToken: String
+    ) throws -> AFMBridgeDescriptorLease {
+        let descriptorStore = try AFMBridgeDescriptorStore(directoryPath: startup.directoryPath)
+        let descriptor = AFMBridgeConnectionDescriptor(
+            endpoint: endpoint,
+            bearerToken: bearerToken,
+            processIdentifier: ProcessInfo.processInfo.processIdentifier,
+            launchIdentifier: launchIdentifier,
+            modelIdentifiers: startup.modelIdentifiers,
+            startedAt: .now
+        )
+        return try descriptorStore.publish(descriptor)
+    }
+
+    private func cleanFailedStart(server: AFMHTTPServer?, baseDirectory: URL) async -> [String] {
+        var failures: [String] = []
+        if let server {
+            do {
+                try await server.stop()
+            } catch {
+                failures.append(error.localizedDescription)
+            }
+        }
+        baseDirectory.stopAccessingSecurityScopedResource()
+        releaseProcessLifetimeProtection()
+        return failures
+    }
+
+    private func stop() async {
+        status = .stopping
+        var failures: [String] = []
+
+        if let descriptorLease {
+            do {
+                try descriptorLease.cleanup()
+            } catch {
+                failures.append(error.localizedDescription)
+            }
+        }
+        descriptorLease = nil
+        descriptorPath = nil
+
+        if let server {
+            do {
+                try await server.stop()
+            } catch {
+                failures.append(error.localizedDescription)
+            }
+        }
+        server = nil
+
+        activeBaseDirectory?.stopAccessingSecurityScopedResource()
+        activeBaseDirectory = nil
+        releaseProcessLifetimeProtection()
+
+        if failures.isEmpty {
+            status = bookmarkStore.hasBookmark ? .off : .notConfigured
+            errorMessage = nil
+        } else {
+            status = .failed
+            errorMessage = String(
+                localized: "The bridge stopped, but cleanup needs attention: \(failures.joined(separator: " "))"
+            )
+        }
+    }
+
+    private func failStart(_ error: any Swift.Error, cleanupFailures: [String] = []) {
+        server = nil
+        descriptorLease = nil
+        activeBaseDirectory = nil
+        descriptorPath = nil
+        status = .failed
+
+        if cleanupFailures.isEmpty {
+            errorMessage = String(localized: "The bridge could not start: \(error.localizedDescription)")
+        } else {
+            errorMessage = String(
+                localized: "The bridge could not start: \(error.localizedDescription) Cleanup: \(cleanupFailures.joined(separator: " "))"
+            )
+        }
+    }
+
+    private func protectProcessLifetime() {
+        guard !protectsProcessLifetime else { return }
+        let processInfo = ProcessInfo.processInfo
+        processInfo.disableSuddenTermination()
+        processInfo.disableAutomaticTermination(Self.terminationReason)
+        protectsProcessLifetime = true
+    }
+
+    private func releaseProcessLifetimeProtection() {
+        guard protectsProcessLifetime else { return }
+        let processInfo = ProcessInfo.processInfo
+        processInfo.enableAutomaticTermination(Self.terminationReason)
+        processInfo.enableSuddenTermination()
+        protectsProcessLifetime = false
+    }
+
+    private struct StartupConfiguration {
+        let server: AFMHTTPServer
+        let directoryPath: String
+        let host: String
+        let modelIdentifiers: [String]
+    }
+}
+#endif

--- a/Foundation Lab/AgentBridge/AgentBridgeController.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeController.swift
@@ -167,16 +167,19 @@ private extension AgentBridgeController {
 
     private func reconcileEnabledState() async {
         while true {
-            if isEnabled, server == nil {
+            if isEnabled, !hasActiveResources {
                 await start()
-                guard server != nil else { return }
+                guard server != nil else {
+                    if !isEnabled {
+                        resetDisabledStatus()
+                    }
+                    return
+                }
             } else if !isEnabled, hasActiveResources {
                 await stop()
+                guard !hasActiveResources else { return }
             } else {
-                if !isEnabled, status != .notConfigured {
-                    status = bookmarkStore.hasBookmark ? .off : .notConfigured
-                    errorMessage = nil
-                }
+                if !isEnabled { resetDisabledStatus() }
                 return
             }
         }
@@ -288,17 +291,18 @@ private extension AgentBridgeController {
     }
 
     private func cleanFailedStart(server: AFMHTTPServer?, baseDirectory: URL) async -> [String] {
-        var failures: [String] = []
         if let server {
             do {
                 try await server.stop()
             } catch {
-                failures.append(error.localizedDescription)
+                self.server = server
+                activeBaseDirectory = baseDirectory
+                return [error.localizedDescription]
             }
         }
         baseDirectory.stopAccessingSecurityScopedResource()
         releaseProcessLifetimeProtection()
-        return failures
+        return []
     }
 
     private func stop() async {
@@ -308,25 +312,27 @@ private extension AgentBridgeController {
         if let descriptorLease {
             do {
                 try descriptorLease.cleanup()
+                self.descriptorLease = nil
+                descriptorPath = nil
             } catch {
                 failures.append(error.localizedDescription)
             }
         }
-        descriptorLease = nil
-        descriptorPath = nil
 
         if let server {
             do {
                 try await server.stop()
+                self.server = nil
             } catch {
                 failures.append(error.localizedDescription)
             }
         }
-        server = nil
 
-        activeBaseDirectory?.stopAccessingSecurityScopedResource()
-        activeBaseDirectory = nil
-        releaseProcessLifetimeProtection()
+        if server == nil, descriptorLease == nil {
+            activeBaseDirectory?.stopAccessingSecurityScopedResource()
+            activeBaseDirectory = nil
+            releaseProcessLifetimeProtection()
+        }
 
         if failures.isEmpty {
             status = bookmarkStore.hasBookmark ? .off : .notConfigured
@@ -340,9 +346,7 @@ private extension AgentBridgeController {
     }
 
     private func failStart(_ error: any Swift.Error, cleanupFailures: [String] = []) {
-        server = nil
         descriptorLease = nil
-        activeBaseDirectory = nil
         descriptorPath = nil
         status = .failed
 
@@ -353,6 +357,11 @@ private extension AgentBridgeController {
                 localized: "The bridge could not start: \(error.localizedDescription) Cleanup: \(cleanupFailures.joined(separator: " "))"
             )
         }
+    }
+
+    private func resetDisabledStatus() {
+        status = bookmarkStore.hasBookmark ? .off : .notConfigured
+        errorMessage = nil
     }
 
     private func protectProcessLifetime() {

--- a/Foundation Lab/AgentBridge/AgentBridgeModelCatalog.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeModelCatalog.swift
@@ -1,0 +1,23 @@
+#if os(macOS)
+import AFMServer
+import FoundationModels
+
+nonisolated struct AgentBridgeModelCatalog: AFMModelCatalog {
+    func models() -> [AFMServerModel] {
+        var models: [AFMServerModel] = []
+        if case .available = SystemLanguageModel.default.availability {
+            models.append(AFMServerModel(id: "system", isAvailable: true))
+        }
+
+        #if compiler(>=6.4)
+        if #available(macOS 27.0, *),
+           AgentBridgePrivateCloudAuthorization.isGranted,
+           PrivateCloudComputeLanguageModel().isAvailable {
+            models.append(AFMServerModel(id: "pcc", isAvailable: true))
+        }
+        #endif
+
+        return models
+    }
+}
+#endif

--- a/Foundation Lab/AgentBridge/AgentBridgePrivateCloudAuthorization.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgePrivateCloudAuthorization.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import Foundation
+import Security
+
+nonisolated enum AgentBridgePrivateCloudAuthorization {
+    private static let entitlement = "com.apple.developer.private-cloud-compute"
+
+    static var isGranted: Bool {
+        guard let task = SecTaskCreateFromSelf(nil) else { return false }
+        let value = SecTaskCopyValueForEntitlement(
+            task,
+            entitlement as CFString,
+            nil
+        )
+        return (value as? Bool) == true
+    }
+}
+#endif

--- a/Foundation Lab/AgentBridge/AgentBridgeSessionBuilder.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeSessionBuilder.swift
@@ -1,0 +1,44 @@
+#if os(macOS)
+import AFMServer
+import FoundationModels
+
+nonisolated enum AgentBridgeSessionBuilder {
+    static func makeSession(
+        requestedModelIdentifier: String,
+        transcript: Transcript
+    ) throws -> LanguageModelSession {
+        switch requestedModelIdentifier {
+        case "system":
+            let model = SystemLanguageModel.default
+            guard case .available = model.availability else {
+                throw AFMChatGenerationError.modelUnavailable
+            }
+            return LanguageModelSession(model: model, transcript: transcript)
+        case "pcc":
+            return try makePrivateCloudSession(transcript: transcript)
+        default:
+            throw AFMChatGenerationError.modelUnavailable
+        }
+    }
+
+    private static func makePrivateCloudSession(transcript: Transcript) throws -> LanguageModelSession {
+        #if compiler(>=6.4)
+        if #available(macOS 27.0, *) {
+            guard AgentBridgePrivateCloudAuthorization.isGranted else {
+                throw AFMChatGenerationError.modelUnavailable
+            }
+            let model = PrivateCloudComputeLanguageModel()
+            guard model.isAvailable else {
+                throw AFMChatGenerationError.modelUnavailable
+            }
+            guard !model.quotaUsage.isLimitReached else {
+                throw AFMChatGenerationError.rateLimited
+            }
+            return LanguageModelSession(model: model, transcript: transcript)
+        }
+        #endif
+
+        throw AFMChatGenerationError.modelUnavailable
+    }
+}
+#endif

--- a/Foundation Lab/AgentBridge/AgentBridgeSettingsView.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeSettingsView.swift
@@ -1,0 +1,108 @@
+#if os(macOS)
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct AgentBridgeSettingsView: View {
+    @Environment(AgentBridgeController.self) private var controller
+    @State private var isSelectingDirectory = false
+
+    var body: some View {
+        @Bindable var controller = controller
+
+        Section("Agent Bridge") {
+            Toggle("Enable local agent bridge", isOn: $controller.isEnabled)
+                .disabled(!controller.canToggleEnabled)
+
+            LabeledContent("Status") {
+                Label(controller.statusTitle, systemImage: statusSymbol)
+                    .foregroundStyle(statusStyle)
+            }
+
+            if let baseDirectoryPath = controller.baseDirectoryPath {
+                LabeledContent("Base Folder") {
+                    Text(baseDirectoryPath)
+                        .font(.callout.monospaced())
+                        .multilineTextAlignment(.trailing)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let descriptorPath = controller.descriptorPath {
+                LabeledContent("Connection File") {
+                    Text(descriptorPath)
+                        .font(.callout.monospaced())
+                        .multilineTextAlignment(.trailing)
+                        .textSelection(.enabled)
+                }
+            }
+
+            Button("Choose Bridge Folder…", systemImage: "folder", action: chooseDirectory)
+                .disabled(controller.isEnabled || controller.isTransitioning)
+
+            Text(
+                "Foundation Lab stores a private connection file and exposes an authenticated loopback server. "
+                    + "It stays off until you enable it; after that, "
+                    + "Foundation Lab can restore the bridge when launched."
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+
+            if let errorMessage = controller.errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+            }
+        }
+        .fileImporter(
+            isPresented: $isSelectingDirectory,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false,
+            onCompletion: handleSelection
+        )
+    }
+
+    private var statusSymbol: String {
+        switch controller.status {
+        case .notConfigured:
+            "folder.badge.questionmark"
+        case .off:
+            "stop.circle"
+        case .starting, .stopping:
+            "hourglass"
+        case .running:
+            "checkmark.circle.fill"
+        case .failed:
+            "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var statusStyle: Color {
+        switch controller.status {
+        case .running:
+            .green
+        case .failed:
+            .red
+        default:
+            .secondary
+        }
+    }
+
+    private func chooseDirectory() {
+        isSelectingDirectory = true
+    }
+
+    private func handleSelection(_ result: Result<[URL], any Error>) {
+        switch result {
+        case .success(let urls):
+            guard let directoryURL = urls.first else {
+                controller.handleEmptyDirectorySelection()
+                return
+            }
+            controller.selectBaseDirectory(directoryURL)
+        case .failure(let error):
+            controller.handleDirectorySelectionFailure(error)
+        }
+    }
+}
+#endif

--- a/Foundation Lab/FoundationLab-macOS.entitlements
+++ b/Foundation Lab/FoundationLab-macOS.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.private-cloud-compute</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/Foundation Lab/FoundationLabApp.swift
+++ b/Foundation Lab/FoundationLabApp.swift
@@ -14,6 +14,9 @@ import SwiftData
 struct FoundationLabApp: App {
     @State private var unavailabilityReason: ModelAvailabilityUnavailableReason?
     @State private var showModelUnavailableWarning = false
+#if os(macOS)
+    @State private var agentBridgeController = AgentBridgeController()
+#endif
 
     var body: some Scene {
         WindowGroup {
@@ -21,6 +24,10 @@ struct FoundationLabApp: App {
                 .modelContainer(for: [HealthMetric.self, HealthSession.self])
 #if os(macOS)
                 .frame(minWidth: 800, minHeight: 600)
+                .environment(agentBridgeController)
+                .task {
+                    agentBridgeController.activatePersistedPreference()
+                }
 #endif
                 .onAppear {
                     FoundationLabAppShortcuts.updateAppShortcutParameters()
@@ -35,6 +42,7 @@ struct FoundationLabApp: App {
         Settings {
             SettingsView()
                 .frame(minWidth: 520, minHeight: 420)
+                .environment(agentBridgeController)
         }
 #endif
     }

--- a/Foundation Lab/Views/SettingsView.swift
+++ b/Foundation Lab/Views/SettingsView.swift
@@ -12,6 +12,10 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+#if os(macOS)
+            AgentBridgeSettingsView()
+#endif
+
             Section("About") {
                 LabeledContent("Version", value: version)
 
@@ -64,4 +68,7 @@ struct SettingsView: View {
     NavigationStack {
         SettingsView()
     }
+#if os(macOS)
+    .environment(AgentBridgeController())
+#endif
 }

--- a/FoundationLab.xcodeproj/project.pbxproj
+++ b/FoundationLab.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A5454AB2E1148A8002C2152 /* Foundation Lab.icon in Resources */ = {isa = PBXBuildFile; fileRef = 0A5454A72E1148A8002C2152 /* Foundation Lab.icon */; };
 		0A979E842E1E5921008CFA37 /* FoundationModelsKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0A979E832E1E5921008CFA37 /* FoundationModelsKit */; };
 		0B0A11132ECB100100000001 /* FoundationLabCore in Frameworks */ = {isa = PBXBuildFile; productRef = 0B0A11122ECB100100000001 /* FoundationLabCore */; };
+		0B0A11332ECB200100000001 /* AFMServer in Frameworks */ = {isa = PBXBuildFile; platformFilter = macos; productRef = 0B0A11322ECB200100000001 /* AFMServer */; };
 		F1B8C56E2E5B5A1C00XYZ123 /* LumoKit in Frameworks */ = {isa = PBXBuildFile; productRef = F1B8C56D2E5B5A1C00XYZ123 /* LumoKit */; };
 		FA43F9412E13A16E00F24BCC /* HighlightSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FA43F9402E13A16E00F24BCC /* HighlightSwift */; };
 /* End PBXBuildFile section */
@@ -54,6 +55,7 @@
 				FA43F9412E13A16E00F24BCC /* HighlightSwift in Frameworks */,
 				0A979E842E1E5921008CFA37 /* FoundationModelsKit in Frameworks */,
 				0B0A11132ECB100100000001 /* FoundationLabCore in Frameworks */,
+				0B0A11332ECB200100000001 /* AFMServer in Frameworks */,
 				F1B8C56E2E5B5A1C00XYZ123 /* LumoKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -111,6 +113,7 @@
 				FA43F9402E13A16E00F24BCC /* HighlightSwift */,
 				0A979E832E1E5921008CFA37 /* FoundationModelsKit */,
 				0B0A11122ECB100100000001 /* FoundationLabCore */,
+				0B0A11322ECB200100000001 /* AFMServer */,
 				F1B8C56D2E5B5A1C00XYZ123 /* LumoKit */,
 			);
 			productName = FoundationLab;
@@ -145,6 +148,7 @@
 				0AC6037E2E1D5288002106F9 /* XCRemoteSwiftPackageReference "HighlightSwift" */,
 				0A979E822E1E5921008CFA37 /* XCLocalSwiftPackageReference "FoundationModelsKit" */,
 				0B0A11112ECB100100000001 /* XCLocalSwiftPackageReference "FoundationLabCore" */,
+				0B0A11312ECB200100000001 /* XCLocalSwiftPackageReference "AFMServer" */,
 				F1B8C56C2E5B5A1C00XYZ123 /* XCRemoteSwiftPackageReference "LumoKit" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -310,6 +314,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Foundation Lab/FoundationLab.entitlements";
+				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Foundation Lab/FoundationLab-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -392,6 +397,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Foundation Lab/FoundationLab.entitlements";
+				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Foundation Lab/FoundationLab-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -498,6 +504,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = FoundationLabCore;
 		};
+		0B0A11312ECB200100000001 /* XCLocalSwiftPackageReference "AFMServer" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/AFMServer;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -529,6 +539,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0B0A11112ECB100100000001 /* XCLocalSwiftPackageReference "FoundationLabCore" */;
 			productName = FoundationLabCore;
+		};
+		0B0A11322ECB200100000001 /* AFMServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0B0A11312ECB200100000001 /* XCLocalSwiftPackageReference "AFMServer" */;
+			productName = AFMServer;
 		};
 		F1B8C56D2E5B5A1C00XYZ123 /* LumoKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/FoundationLab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FoundationLab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcc2212c367abc6ed186641126a9ba0d9a9a94d8c7f2e1c1d31783daffff709f",
+  "originHash" : "1d1c222bafbebe0f2b0dc380fa15127ff88c4e799284f03ca604d2ce37d4e07c",
   "pins" : [
     {
       "identity" : "highlightswift",
@@ -83,6 +83,15 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
+      }
+    },
+    {
       "identity" : "swift-safetensors",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jkrukowski/swift-safetensors.git",
@@ -98,6 +107,15 @@
       "state" : {
         "revision" : "36a8b2b45733f6adb3092100f16e4c7d38a10a7c",
         "version" : "0.0.6"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeBearerTokenGenerator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeBearerTokenGenerator.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Security
+
+public enum AFMBridgeBearerTokenGenerator {
+    static let encodedByteCount = 43
+    private static let randomByteCount = 32
+
+    public static func generate() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: randomByteCount)
+        let status = bytes.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, buffer.count, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw AFMBridgeTokenError.randomGenerationFailed(status)
+        }
+
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeConnectionDescriptor.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeConnectionDescriptor.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public struct AFMBridgeConnectionDescriptor: Sendable, Codable, Equatable {
+    public static let currentVersion = 1
+
+    public let version: Int
+    public let endpoint: AFMBridgeEndpoint
+    public let bearerToken: String
+    public let processIdentifier: Int32
+    public let launchIdentifier: UUID
+    public let modelIdentifiers: [String]
+    public let startedAt: Date
+
+    public init(
+        version: Int = Self.currentVersion,
+        endpoint: AFMBridgeEndpoint,
+        bearerToken: String,
+        processIdentifier: Int32,
+        launchIdentifier: UUID,
+        modelIdentifiers: [String],
+        startedAt: Date
+    ) {
+        self.version = version
+        self.endpoint = endpoint
+        self.bearerToken = bearerToken
+        self.processIdentifier = processIdentifier
+        self.launchIdentifier = launchIdentifier
+        self.modelIdentifiers = modelIdentifiers
+        self.startedAt = startedAt
+    }
+
+    public func validated() throws -> Self {
+        guard version == Self.currentVersion else {
+            throw AFMBridgeDescriptorError.unsupportedVersion(version)
+        }
+        _ = try endpoint.validated()
+        guard Self.isValidBearerToken(bearerToken) else {
+            throw AFMBridgeDescriptorError.invalidField("bearerToken")
+        }
+        guard processIdentifier > 0 else {
+            throw AFMBridgeDescriptorError.invalidField("processIdentifier")
+        }
+        guard !modelIdentifiers.isEmpty,
+              modelIdentifiers.allSatisfy(Self.isValidModelIdentifier),
+              Set(modelIdentifiers).count == modelIdentifiers.count else {
+            throw AFMBridgeDescriptorError.invalidField("modelIdentifiers")
+        }
+        guard startedAt.timeIntervalSinceReferenceDate.isFinite else {
+            throw AFMBridgeDescriptorError.invalidField("startedAt")
+        }
+        return self
+    }
+
+    private static func isValidBearerToken(_ token: String) -> Bool {
+        token.utf8.count == AFMBridgeBearerTokenGenerator.encodedByteCount
+            && token.utf8.allSatisfy { byte in
+                switch byte {
+                case 45, 48...57, 65...90, 95, 97...122:
+                    true
+                default:
+                    false
+                }
+            }
+    }
+
+    private static func isValidModelIdentifier(_ identifier: String) -> Bool {
+        !identifier.isEmpty
+            && identifier == identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+            && !identifier.contains("\0")
+    }
+}
+
+extension AFMBridgeConnectionDescriptor: CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        "AFMBridgeConnectionDescriptor(version: \(version), endpoint: \(endpoint), "
+            + "bearerToken: <redacted>, processIdentifier: \(processIdentifier), "
+            + "launchIdentifier: \(launchIdentifier), modelIdentifiers: \(modelIdentifiers), "
+            + "startedAt: \(startedAt))"
+    }
+
+    public var debugDescription: String { description }
+
+    public var customMirror: Mirror {
+        Mirror(
+            self,
+            children: [
+                "version": version,
+                "endpoint": endpoint,
+                "bearerToken": "<redacted>",
+                "processIdentifier": processIdentifier,
+                "launchIdentifier": launchIdentifier,
+                "modelIdentifiers": modelIdentifiers,
+                "startedAt": startedAt
+            ],
+            displayStyle: .struct
+        )
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeDescriptorError.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeDescriptorError.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum AFMBridgeDescriptorError: Error, Sendable, Equatable, LocalizedError {
+    case invalidPath
+    case invalidFileName
+    case directoryMissing
+    case descriptorMissing
+    case unexpectedObject(expected: String, actual: String)
+    case ownerMismatch
+    case permissionsMismatch(expected: UInt16, actual: UInt16)
+    case pathChanged
+    case tooManyLinks
+    case descriptorTooLarge
+    case invalidField(String)
+    case unsupportedVersion(Int)
+    case encodingFailed
+    case decodingFailed
+    case posix(operation: String, code: Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidPath:
+            "The bridge path must be an absolute path without null bytes."
+        case .invalidFileName:
+            "The bridge descriptor file name must be a single safe path component."
+        case .directoryMissing:
+            "The bridge directory does not exist."
+        case .descriptorMissing:
+            "The bridge connection descriptor does not exist."
+        case .unexpectedObject(let expected, let actual):
+            "Expected \(expected), but found \(actual)."
+        case .ownerMismatch:
+            "The bridge filesystem object is not owned by the current user."
+        case .permissionsMismatch(let expected, let actual):
+            "The bridge filesystem object has mode \(Self.octal(actual)); expected \(Self.octal(expected))."
+        case .pathChanged:
+            "The bridge filesystem path changed during a safety check."
+        case .tooManyLinks:
+            "The bridge descriptor has more than one filesystem link."
+        case .descriptorTooLarge:
+            "The bridge connection descriptor exceeds the safe size limit."
+        case .invalidField(let field):
+            "The bridge connection descriptor has an invalid \(field) field."
+        case .unsupportedVersion(let version):
+            "Bridge connection descriptor version \(version) is not supported."
+        case .encodingFailed:
+            "The bridge connection descriptor could not be encoded."
+        case .decodingFailed:
+            "The bridge connection descriptor could not be decoded."
+        case .posix(let operation, let code):
+            "Could not \(operation): \(String(cString: strerror(code)))."
+        }
+    }
+
+    private static func octal(_ mode: UInt16) -> String {
+        String(mode, radix: 8)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeDescriptorLease.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeDescriptorLease.swift
@@ -1,0 +1,65 @@
+import Darwin
+import Foundation
+
+public struct AFMBridgeDescriptorLease: Sendable {
+    public let descriptorPath: String
+
+    private let directoryPath: String
+    private let fileName: String
+    private let directoryDevice: dev_t
+    private let directoryInode: ino_t
+    private let descriptorDevice: dev_t
+    private let descriptorInode: ino_t
+
+    init(
+        descriptorPath: String,
+        directoryPath: String,
+        fileName: String,
+        directoryStatus: stat,
+        descriptorStatus: stat
+    ) {
+        self.descriptorPath = descriptorPath
+        self.directoryPath = directoryPath
+        self.fileName = fileName
+        directoryDevice = directoryStatus.st_dev
+        directoryInode = directoryStatus.st_ino
+        descriptorDevice = descriptorStatus.st_dev
+        descriptorInode = descriptorStatus.st_ino
+    }
+
+    public func cleanup() throws {
+        let directoryDescriptor: CInt
+        do {
+            directoryDescriptor = try AFMBridgePOSIX.openDirectory(at: directoryPath, repairPermissions: false)
+        } catch AFMBridgeDescriptorError.directoryMissing {
+            return
+        } catch AFMBridgeDescriptorError.pathChanged {
+            return
+        } catch AFMBridgeDescriptorError.unexpectedObject {
+            return
+        }
+        defer { Darwin.close(directoryDescriptor) }
+
+        var directoryStatus = stat()
+        guard Darwin.fstat(directoryDescriptor, &directoryStatus) == 0 else {
+            throw AFMBridgePOSIX.posixError(operation: "inspect the bridge directory during cleanup")
+        }
+        guard directoryStatus.st_dev == directoryDevice,
+              directoryStatus.st_ino == directoryInode else {
+            return
+        }
+        guard let descriptorStatus = try AFMBridgePOSIX.status(at: directoryDescriptor, name: fileName),
+              descriptorStatus.st_dev == descriptorDevice,
+              descriptorStatus.st_ino == descriptorInode else {
+            return
+        }
+        try AFMBridgePOSIX.requireSafeDescriptor(descriptorStatus)
+        guard Darwin.unlinkat(directoryDescriptor, fileName, 0) == 0 else {
+            if errno == ENOENT { return }
+            throw AFMBridgePOSIX.posixError(operation: "remove the bridge descriptor")
+        }
+        guard Darwin.fsync(directoryDescriptor) == 0 else {
+            throw AFMBridgePOSIX.posixError(operation: "synchronize bridge descriptor cleanup")
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeDescriptorStore.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeDescriptorStore.swift
@@ -1,0 +1,275 @@
+import Darwin
+import Foundation
+
+public struct AFMBridgeDescriptorStore: Sendable {
+    public static let defaultFileName = "connection.json"
+    public static let maximumDescriptorByteCount = 65_536
+
+    public let directoryPath: String
+    public let fileName: String
+
+    public var descriptorPath: String {
+        (directoryPath as NSString).appendingPathComponent(fileName)
+    }
+
+    public init(directoryPath: String, fileName: String = Self.defaultFileName) throws {
+        try AFMBridgePOSIX.validateAbsolutePath(directoryPath)
+        try AFMBridgePOSIX.validateFileName(fileName)
+        self.directoryPath = directoryPath
+        self.fileName = fileName
+    }
+
+    @discardableResult
+    public func publish(_ descriptor: AFMBridgeConnectionDescriptor) throws -> AFMBridgeDescriptorLease {
+        let data = try encodedData(for: descriptor)
+        try AFMBridgeDirectory.prepare(at: directoryPath)
+        let directoryDescriptor = try AFMBridgePOSIX.openDirectory(at: directoryPath, repairPermissions: false)
+        defer { Darwin.close(directoryDescriptor) }
+        return try publish(data, in: directoryDescriptor)
+    }
+
+    public func read() throws -> AFMBridgeConnectionDescriptor {
+        let directoryDescriptor = try AFMBridgePOSIX.openDirectory(at: directoryPath, repairPermissions: false)
+        defer { Darwin.close(directoryDescriptor) }
+        let descriptor = Darwin.openat(
+            directoryDescriptor,
+            fileName,
+            O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard descriptor >= 0 else {
+            if errno == ENOENT {
+                throw AFMBridgeDescriptorError.descriptorMissing
+            }
+            if errno == ELOOP {
+                throw AFMBridgeDescriptorError.unexpectedObject(expected: "regular file", actual: "symbolic link")
+            }
+            throw AFMBridgePOSIX.posixError(operation: "open the bridge descriptor")
+        }
+        defer { Darwin.close(descriptor) }
+
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0 else {
+            throw AFMBridgePOSIX.posixError(operation: "inspect the bridge descriptor")
+        }
+        try AFMBridgePOSIX.requireSafeDescriptor(status)
+        guard status.st_size > 0, status.st_size <= Self.maximumDescriptorByteCount else {
+            throw AFMBridgeDescriptorError.descriptorTooLarge
+        }
+        let data = try AFMBridgePOSIX.readAll(from: descriptor, byteCount: Int(status.st_size))
+        let decoded: AFMBridgeConnectionDescriptor
+        do {
+            decoded = try JSONDecoder().decode(AFMBridgeConnectionDescriptor.self, from: data)
+        } catch {
+            throw AFMBridgeDescriptorError.decodingFailed
+        }
+        return try decoded.validated()
+    }
+}
+
+private extension AFMBridgeDescriptorStore {
+    func encodedData(for descriptor: AFMBridgeConnectionDescriptor) throws -> Data {
+        let data: Data
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            data = try encoder.encode(descriptor.validated())
+        } catch let error as AFMBridgeDescriptorError {
+            throw error
+        } catch {
+            throw AFMBridgeDescriptorError.encodingFailed
+        }
+        guard !data.isEmpty, data.count <= Self.maximumDescriptorByteCount else {
+            throw AFMBridgeDescriptorError.descriptorTooLarge
+        }
+        return data
+    }
+
+    func publish(_ data: Data, in directoryDescriptor: CInt) throws -> AFMBridgeDescriptorLease {
+        let temporary = try makeTemporaryDescriptor(data, in: directoryDescriptor)
+        var shouldRemoveTemporary = true
+        defer {
+            Darwin.close(temporary.fileDescriptor)
+            if shouldRemoveTemporary {
+                removeTemporaryIfUnchanged(
+                    directoryDescriptor: directoryDescriptor,
+                    name: temporary.name,
+                    expectedStatus: temporary.status
+                )
+            }
+        }
+
+        try install(temporary, in: directoryDescriptor)
+        shouldRemoveTemporary = false
+        return try makeLease(for: temporary.status, in: directoryDescriptor)
+    }
+
+    func makeTemporaryDescriptor(_ data: Data, in directoryDescriptor: CInt) throws -> AFMBridgeTemporaryDescriptor {
+        let name = ".\(fileName).\(UUID().uuidString).tmp"
+        let fileDescriptor = Darwin.openat(
+            directoryDescriptor,
+            name,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            AFMBridgePOSIX.descriptorMode
+        )
+        guard fileDescriptor >= 0 else {
+            throw AFMBridgePOSIX.posixError(operation: "create the temporary bridge descriptor")
+        }
+
+        var status = stat()
+        do {
+            guard Darwin.fstat(fileDescriptor, &status) == 0 else {
+                throw AFMBridgePOSIX.posixError(operation: "inspect the temporary bridge descriptor")
+            }
+            guard Darwin.fchmod(fileDescriptor, AFMBridgePOSIX.descriptorMode) == 0 else {
+                throw AFMBridgePOSIX.posixError(operation: "set bridge descriptor permissions")
+            }
+            try AFMBridgePOSIX.writeAll(data, to: fileDescriptor)
+            guard Darwin.fsync(fileDescriptor) == 0 else {
+                throw AFMBridgePOSIX.posixError(operation: "synchronize the temporary bridge descriptor")
+            }
+            guard Darwin.fstat(fileDescriptor, &status) == 0 else {
+                throw AFMBridgePOSIX.posixError(operation: "verify the temporary bridge descriptor")
+            }
+            try AFMBridgePOSIX.requireSafeDescriptor(status)
+            return AFMBridgeTemporaryDescriptor(name: name, fileDescriptor: fileDescriptor, status: status)
+        } catch {
+            Darwin.close(fileDescriptor)
+            removeTemporaryIfUnchanged(
+                directoryDescriptor: directoryDescriptor,
+                name: name,
+                expectedStatus: status
+            )
+            throw error
+        }
+    }
+
+    func install(_ temporary: AFMBridgeTemporaryDescriptor, in directoryDescriptor: CInt) throws {
+        if let existingStatus = try AFMBridgePOSIX.status(at: directoryDescriptor, name: fileName) {
+            try AFMBridgePOSIX.requireSafeDescriptor(existingStatus)
+            try replaceExisting(
+                directoryDescriptor: directoryDescriptor,
+                temporaryName: temporary.name,
+                temporaryStatus: temporary.status
+            )
+        } else {
+            try installWhenMissing(
+                directoryDescriptor: directoryDescriptor,
+                temporaryName: temporary.name
+            )
+        }
+    }
+
+    func makeLease(for temporaryStatus: stat, in directoryDescriptor: CInt) throws -> AFMBridgeDescriptorLease {
+        guard Darwin.fsync(directoryDescriptor) == 0 else {
+            throw AFMBridgePOSIX.posixError(operation: "synchronize the bridge descriptor directory")
+        }
+        guard let installedStatus = try AFMBridgePOSIX.status(at: directoryDescriptor, name: fileName),
+              AFMBridgePOSIX.sameFile(installedStatus, temporaryStatus) else {
+            throw AFMBridgeDescriptorError.pathChanged
+        }
+        try AFMBridgePOSIX.requireSafeDescriptor(installedStatus)
+
+        var directoryStatus = stat()
+        guard Darwin.fstat(directoryDescriptor, &directoryStatus) == 0 else {
+            throw AFMBridgePOSIX.posixError(operation: "inspect the bridge descriptor directory")
+        }
+        return AFMBridgeDescriptorLease(
+            descriptorPath: descriptorPath,
+            directoryPath: directoryPath,
+            fileName: fileName,
+            directoryStatus: directoryStatus,
+            descriptorStatus: installedStatus
+        )
+    }
+
+    func installWhenMissing(directoryDescriptor: CInt, temporaryName: String) throws {
+        guard Darwin.renameatx_np(
+            directoryDescriptor,
+            temporaryName,
+            directoryDescriptor,
+            fileName,
+            UInt32(RENAME_EXCL)
+        ) == 0 else {
+            if errno == EEXIST {
+                if let appearedStatus = try AFMBridgePOSIX.status(at: directoryDescriptor, name: fileName) {
+                    try AFMBridgePOSIX.requireSafeDescriptor(appearedStatus)
+                }
+                throw AFMBridgeDescriptorError.pathChanged
+            }
+            throw AFMBridgePOSIX.posixError(operation: "install the bridge descriptor")
+        }
+    }
+
+    func replaceExisting(
+        directoryDescriptor: CInt,
+        temporaryName: String,
+        temporaryStatus: stat
+    ) throws {
+        guard Darwin.renameatx_np(
+            directoryDescriptor,
+            temporaryName,
+            directoryDescriptor,
+            fileName,
+            UInt32(RENAME_SWAP)
+        ) == 0 else {
+            if errno == ENOENT {
+                throw AFMBridgeDescriptorError.pathChanged
+            }
+            throw AFMBridgePOSIX.posixError(operation: "rotate the bridge descriptor")
+        }
+
+        do {
+            guard let installedStatus = try AFMBridgePOSIX.status(at: directoryDescriptor, name: fileName),
+                  AFMBridgePOSIX.sameFile(installedStatus, temporaryStatus) else {
+                throw AFMBridgeDescriptorError.pathChanged
+            }
+            guard let displacedStatus = try AFMBridgePOSIX.status(at: directoryDescriptor, name: temporaryName) else {
+                throw AFMBridgeDescriptorError.pathChanged
+            }
+            try AFMBridgePOSIX.requireSafeDescriptor(displacedStatus)
+            guard Darwin.unlinkat(directoryDescriptor, temporaryName, 0) == 0 else {
+                throw AFMBridgePOSIX.posixError(operation: "remove the previous bridge descriptor")
+            }
+        } catch {
+            rollbackSwapIfPossible(
+                directoryDescriptor: directoryDescriptor,
+                temporaryName: temporaryName,
+                temporaryStatus: temporaryStatus
+            )
+            throw error
+        }
+    }
+
+    func rollbackSwapIfPossible(
+        directoryDescriptor: CInt,
+        temporaryName: String,
+        temporaryStatus: stat
+    ) {
+        guard let installedStatus = try? AFMBridgePOSIX.status(at: directoryDescriptor, name: fileName),
+              AFMBridgePOSIX.sameFile(installedStatus, temporaryStatus),
+              (try? AFMBridgePOSIX.status(at: directoryDescriptor, name: temporaryName)) != nil else {
+            return
+        }
+        _ = Darwin.renameatx_np(
+            directoryDescriptor,
+            temporaryName,
+            directoryDescriptor,
+            fileName,
+            UInt32(RENAME_SWAP)
+        )
+    }
+
+    func removeTemporaryIfUnchanged(
+        directoryDescriptor: CInt,
+        name: String,
+        expectedStatus: stat
+    ) {
+        guard expectedStatus.st_ino != 0,
+              let status = try? AFMBridgePOSIX.status(at: directoryDescriptor, name: name),
+              AFMBridgePOSIX.sameFile(status, expectedStatus),
+              status.st_uid == geteuid() else {
+            return
+        }
+        _ = Darwin.unlinkat(directoryDescriptor, name, 0)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeDirectory.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeDirectory.swift
@@ -1,0 +1,18 @@
+import Darwin
+import Foundation
+
+public enum AFMBridgeDirectory {
+    public static func prepare(at path: String) throws {
+        try AFMBridgePOSIX.validateAbsolutePath(path)
+        if Darwin.mkdir(path, AFMBridgePOSIX.directoryMode) != 0, errno != EEXIST {
+            throw AFMBridgePOSIX.posixError(operation: "create the bridge directory")
+        }
+        let descriptor = try AFMBridgePOSIX.openDirectory(at: path, repairPermissions: true)
+        Darwin.close(descriptor)
+    }
+
+    public static func validate(at path: String) throws {
+        let descriptor = try AFMBridgePOSIX.openDirectory(at: path, repairPermissions: false)
+        Darwin.close(descriptor)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeEndpoint.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeEndpoint.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum AFMBridgeEndpoint: Sendable, Codable, Equatable {
+    case unixSocket(path: String)
+    case loopbackTCP(host: String, port: Int)
+
+    public func validated() throws -> Self {
+        switch self {
+        case .unixSocket(let path):
+            guard path.hasPrefix("/"), !path.contains("\0") else {
+                throw AFMBridgeDescriptorError.invalidField("endpoint.unixSocket.path")
+            }
+        case .loopbackTCP(let host, let port):
+            guard host == "127.0.0.1" || host == "::1" else {
+                throw AFMBridgeDescriptorError.invalidField("endpoint.loopbackTCP.host")
+            }
+            guard (1...65_535).contains(port) else {
+                throw AFMBridgeDescriptorError.invalidField("endpoint.loopbackTCP.port")
+            }
+        }
+        return self
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgePOSIX.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgePOSIX.swift
@@ -1,0 +1,183 @@
+import Darwin
+import Foundation
+
+enum AFMBridgePOSIX {
+    static let directoryMode = mode_t(0o700)
+    static let descriptorMode = mode_t(0o600)
+
+    static func validateAbsolutePath(_ path: String) throws {
+        guard path.hasPrefix("/"), !path.contains("\0") else {
+            throw AFMBridgeDescriptorError.invalidPath
+        }
+    }
+
+    static func validateFileName(_ name: String) throws {
+        guard !name.isEmpty,
+              name != ".",
+              name != "..",
+              !name.contains("/"),
+              !name.contains("\0") else {
+            throw AFMBridgeDescriptorError.invalidFileName
+        }
+    }
+
+    static func openDirectory(at path: String, repairPermissions: Bool) throws -> CInt {
+        try validateAbsolutePath(path)
+        let descriptor = Darwin.open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            if errno == ENOENT {
+                throw AFMBridgeDescriptorError.directoryMissing
+            }
+            if errno == ELOOP || errno == ENOTDIR {
+                throw AFMBridgeDescriptorError.unexpectedObject(expected: "directory", actual: objectKind(at: path))
+            }
+            throw posixError(operation: "open the bridge directory")
+        }
+
+        do {
+            var status = stat()
+            guard Darwin.fstat(descriptor, &status) == 0 else {
+                throw posixError(operation: "inspect the bridge directory")
+            }
+            guard objectType(status) == S_IFDIR else {
+                throw AFMBridgeDescriptorError.unexpectedObject(expected: "directory", actual: objectKind(status))
+            }
+            guard status.st_uid == geteuid() else {
+                throw AFMBridgeDescriptorError.ownerMismatch
+            }
+
+            if repairPermissions, permissions(status) != directoryMode {
+                guard Darwin.fchmod(descriptor, directoryMode) == 0 else {
+                    throw posixError(operation: "set bridge directory permissions")
+                }
+                guard Darwin.fstat(descriptor, &status) == 0 else {
+                    throw posixError(operation: "verify bridge directory permissions")
+                }
+            }
+            try requirePermissions(status, expected: directoryMode)
+            try requirePath(path, matches: status, expectedType: S_IFDIR)
+            return descriptor
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    static func status(at descriptor: CInt, name: String) throws -> stat? {
+        var status = stat()
+        if Darwin.fstatat(descriptor, name, &status, AT_SYMLINK_NOFOLLOW) == 0 {
+            return status
+        }
+        if errno == ENOENT { return nil }
+        throw posixError(operation: "inspect the bridge descriptor path")
+    }
+
+    static func requireSafeDescriptor(_ status: stat) throws {
+        guard objectType(status) == S_IFREG else {
+            throw AFMBridgeDescriptorError.unexpectedObject(expected: "regular file", actual: objectKind(status))
+        }
+        guard status.st_uid == geteuid() else {
+            throw AFMBridgeDescriptorError.ownerMismatch
+        }
+        try requirePermissions(status, expected: descriptorMode)
+        guard status.st_nlink == 1 else {
+            throw AFMBridgeDescriptorError.tooManyLinks
+        }
+    }
+
+    static func writeAll(_ data: Data, to descriptor: CInt) throws {
+        try data.withUnsafeBytes { buffer in
+            guard var baseAddress = buffer.baseAddress else { return }
+            var remaining = buffer.count
+            while remaining > 0 {
+                let count = Darwin.write(descriptor, baseAddress, remaining)
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else {
+                    throw posixError(operation: "write the bridge descriptor")
+                }
+                remaining -= count
+                baseAddress = baseAddress.advanced(by: count)
+            }
+        }
+    }
+
+    static func readAll(from descriptor: CInt, byteCount: Int) throws -> Data {
+        var data = Data(count: byteCount)
+        let bytesRead = try data.withUnsafeMutableBytes { buffer -> Int in
+            guard var baseAddress = buffer.baseAddress else { return 0 }
+            var total = 0
+            while total < buffer.count {
+                let count = Darwin.read(descriptor, baseAddress, buffer.count - total)
+                if count < 0, errno == EINTR { continue }
+                guard count >= 0 else {
+                    throw posixError(operation: "read the bridge descriptor")
+                }
+                if count == 0 { break }
+                total += count
+                baseAddress = baseAddress.advanced(by: count)
+            }
+            return total
+        }
+        guard bytesRead == byteCount else {
+            throw AFMBridgeDescriptorError.pathChanged
+        }
+        return data
+    }
+
+    static func sameFile(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev && lhs.st_ino == rhs.st_ino
+    }
+
+    static func objectKind(_ status: stat) -> String {
+        switch objectType(status) {
+        case S_IFDIR: "directory"
+        case S_IFLNK: "symbolic link"
+        case S_IFREG: "regular file"
+        case S_IFSOCK: "socket"
+        case S_IFIFO: "FIFO"
+        case S_IFCHR: "character device"
+        case S_IFBLK: "block device"
+        default: "unknown object"
+        }
+    }
+
+    static func posixError(operation: String) -> AFMBridgeDescriptorError {
+        .posix(operation: operation, code: errno)
+    }
+
+    private static func requirePermissions(_ status: stat, expected: mode_t) throws {
+        let actual = permissions(status)
+        guard actual == expected else {
+            throw AFMBridgeDescriptorError.permissionsMismatch(
+                expected: UInt16(expected),
+                actual: UInt16(actual)
+            )
+        }
+    }
+
+    private static func requirePath(_ path: String, matches openedStatus: stat, expectedType: mode_t) throws {
+        var pathStatus = stat()
+        guard Darwin.lstat(path, &pathStatus) == 0 else {
+            throw AFMBridgeDescriptorError.pathChanged
+        }
+        guard sameFile(openedStatus, pathStatus),
+              objectType(pathStatus) == expectedType,
+              pathStatus.st_uid == geteuid() else {
+            throw AFMBridgeDescriptorError.pathChanged
+        }
+    }
+
+    private static func permissions(_ status: stat) -> mode_t {
+        status.st_mode & mode_t(0o7777)
+    }
+
+    private static func objectType(_ status: stat) -> mode_t {
+        status.st_mode & S_IFMT
+    }
+
+    private static func objectKind(at path: String) -> String {
+        var status = stat()
+        guard Darwin.lstat(path, &status) == 0 else { return "missing object" }
+        return objectKind(status)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeTemporaryDescriptor.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeTemporaryDescriptor.swift
@@ -1,0 +1,7 @@
+import Darwin
+
+struct AFMBridgeTemporaryDescriptor {
+    let name: String
+    let fileDescriptor: CInt
+    let status: stat
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeTokenError.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeTokenError.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Security
+
+public enum AFMBridgeTokenError: Error, Sendable, Equatable, LocalizedError {
+    case randomGenerationFailed(OSStatus)
+
+    public var errorDescription: String? {
+        switch self {
+        case .randomGenerationFailed(let status):
+            "Could not generate a secure bridge token (Security status \(status))."
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -3,11 +3,24 @@ import FoundationModels
 import FoundationModelsKit
 
 public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
-    public init() {}
+    private let sessionBuilder: AFMFoundationModelsSessionBuilder
+
+    public init() {
+        sessionBuilder = { requestedModelIdentifier, transcript in
+            guard requestedModelIdentifier == "system" else {
+                throw AFMChatGenerationError.modelUnavailable
+            }
+            return LanguageModelSession(model: .default, transcript: transcript)
+        }
+    }
+
+    public init(sessionBuilder: @escaping AFMFoundationModelsSessionBuilder) {
+        self.sessionBuilder = sessionBuilder
+    }
 
     public func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
         let prepared = try AFMChatTranscriptBuilder.prepare(request)
-        let session = LanguageModelSession(model: .default, transcript: prepared.transcript)
+        let session = try sessionBuilder(request.model, prepared.transcript)
 
         do {
             let response = try await session.respond(to: prepared.prompt, options: prepared.options)

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsSessionBuilder.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsSessionBuilder.swift
@@ -1,0 +1,6 @@
+import FoundationModels
+
+public typealias AFMFoundationModelsSessionBuilder = @Sendable (
+    _ requestedModelIdentifier: String,
+    _ transcript: Transcript
+) throws -> LanguageModelSession

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeBearerTokenGeneratorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeBearerTokenGeneratorTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("Bridge bearer tokens are unique 32-byte base64url values")
+func bridgeBearerTokenEntropyAndShape() throws {
+    let tokens = try (0..<128).map { _ in try AFMBridgeBearerTokenGenerator.generate() }
+
+    #expect(Set(tokens).count == tokens.count)
+    for token in tokens {
+        #expect(token.utf8.count == 43)
+        #expect(token.utf8.allSatisfy { byte in
+            switch byte {
+            case 45, 48...57, 65...90, 95, 97...122:
+                true
+            default:
+                false
+            }
+        })
+        let standardBase64 = token
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/") + "="
+        #expect(Data(base64Encoded: standardBase64)?.count == 32)
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeConnectionDescriptorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeConnectionDescriptorTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("Bridge descriptors round-trip without exposing their bearer token in descriptions")
+func bridgeDescriptorCodableRoundTripAndRedaction() throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let descriptor = try makeAFMBridgeTestDescriptor(
+        token: token,
+        launchIdentifier: UUID(uuidString: "7C34288D-32AF-43B3-BB42-8AE094776ACC")!,
+        modelIdentifiers: ["system", "pcc"]
+    )
+
+    let encoded = try JSONEncoder().encode(descriptor)
+    let decoded = try JSONDecoder().decode(AFMBridgeConnectionDescriptor.self, from: encoded)
+
+    #expect(decoded == descriptor)
+    #expect(try decoded.validated() == descriptor)
+    #expect(!descriptor.description.contains(token))
+    #expect(!descriptor.debugDescription.contains(token))
+    #expect(!String(reflecting: descriptor).contains(token))
+    #expect(descriptor.customMirror.children.allSatisfy { String(describing: $0.value) != token })
+    #expect(descriptor.description.contains("<redacted>"))
+}
+
+@Test("Bridge descriptors preserve loopback TCP endpoints")
+func bridgeDescriptorLoopbackTCPRoundTrip() throws {
+    let descriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .loopbackTCP(host: "127.0.0.1", port: 19_760)
+    )
+    let encoded = try JSONEncoder().encode(descriptor)
+    let decoded = try JSONDecoder().decode(AFMBridgeConnectionDescriptor.self, from: encoded)
+
+    #expect(try decoded.validated() == descriptor)
+    #expect(decoded.endpoint == .loopbackTCP(host: "127.0.0.1", port: 19_760))
+}
+
+@Test("Bridge descriptors reject invalid connection fields")
+func bridgeDescriptorValidation() throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+
+    #expect(throws: AFMBridgeDescriptorError.unsupportedVersion(2)) {
+        try AFMBridgeConnectionDescriptor(
+            version: 2,
+            endpoint: .unixSocket(path: "/tmp/bridge.sock"),
+            bearerToken: token,
+            processIdentifier: 1,
+            launchIdentifier: UUID(),
+            modelIdentifiers: ["system"],
+            startedAt: .now
+        ).validated()
+    }
+    #expect(throws: AFMBridgeDescriptorError.invalidField("endpoint.unixSocket.path")) {
+        try makeAFMBridgeTestDescriptor(endpoint: .unixSocket(path: "relative.sock"), token: token).validated()
+    }
+    #expect(throws: AFMBridgeDescriptorError.invalidField("bearerToken")) {
+        try makeAFMBridgeTestDescriptor(token: "not-a-32-byte-token").validated()
+    }
+    #expect(throws: AFMBridgeDescriptorError.invalidField("processIdentifier")) {
+        try makeAFMBridgeTestDescriptor(token: token, processIdentifier: 0).validated()
+    }
+    #expect(throws: AFMBridgeDescriptorError.invalidField("modelIdentifiers")) {
+        try makeAFMBridgeTestDescriptor(token: token, modelIdentifiers: ["system", "system"]).validated()
+    }
+    #expect(throws: AFMBridgeDescriptorError.invalidField("modelIdentifiers")) {
+        try makeAFMBridgeTestDescriptor(token: token, modelIdentifiers: [" pcc"]).validated()
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeDescriptorStoreTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeDescriptorStoreTests.swift
@@ -1,0 +1,182 @@
+import Darwin
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("Descriptor publication is atomic, current-user-only, and readable")
+func bridgeDescriptorPublishAndRead() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let directory = (parent as NSString).appendingPathComponent("bridge")
+        let store = try AFMBridgeDescriptorStore(directoryPath: directory)
+        let descriptor = try makeAFMBridgeTestDescriptor(modelIdentifiers: ["system", "pcc"])
+        let lease = try store.publish(descriptor)
+
+        #expect(lease.descriptorPath == store.descriptorPath)
+        #expect(try store.read() == descriptor)
+        let status = try afmBridgeStatus(at: store.descriptorPath)
+        #expect((status.st_mode & S_IFMT) == S_IFREG)
+        #expect(status.st_uid == geteuid())
+        #expect(status.st_nlink == 1)
+        #expect(afmBridgePermissions(status) == mode_t(0o600))
+    }
+}
+
+@Test("Descriptor rotation makes old leases harmless and supports stale crash replacement")
+func bridgeDescriptorRotationAndCrashReplacement() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let directory = (parent as NSString).appendingPathComponent("bridge")
+        let store = try AFMBridgeDescriptorStore(directoryPath: directory)
+        try AFMBridgeDirectory.prepare(at: directory)
+
+        try Data("interrupted previous launch".utf8).write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o600)) == 0)
+
+        let first = try makeAFMBridgeTestDescriptor(launchIdentifier: UUID(), modelIdentifiers: ["system"])
+        let firstLease = try store.publish(first)
+        #expect(try store.read() == first)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory) == [store.fileName])
+
+        let second = try makeAFMBridgeTestDescriptor(launchIdentifier: UUID(), modelIdentifiers: ["system", "pcc"])
+        let secondLease = try store.publish(second)
+        try firstLease.cleanup()
+        #expect(try store.read() == second)
+
+        try secondLease.cleanup()
+        #expect(throws: AFMBridgeDescriptorError.descriptorMissing) {
+            try store.read()
+        }
+    }
+}
+
+@Test("Descriptor leases never delete a replacement inode")
+func bridgeDescriptorLeaseInodeSafety() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let directory = (parent as NSString).appendingPathComponent("bridge")
+        let store = try AFMBridgeDescriptorStore(directoryPath: directory)
+        let lease = try store.publish(makeAFMBridgeTestDescriptor())
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+
+        let replacement = Data("replacement".utf8)
+        try replacement.write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o600)) == 0)
+
+        try lease.cleanup()
+        #expect(try Data(contentsOf: URL(fileURLWithPath: store.descriptorPath)) == replacement)
+    }
+}
+
+@Test("Descriptor publication refuses unsafe existing targets without changing them")
+func bridgeDescriptorPublishRefusesUnsafeTargets() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let directory = (parent as NSString).appendingPathComponent("bridge")
+        let store = try AFMBridgeDescriptorStore(directoryPath: directory)
+        try AFMBridgeDirectory.prepare(at: directory)
+        let descriptor = try makeAFMBridgeTestDescriptor()
+
+        let target = (parent as NSString).appendingPathComponent("target")
+        let targetData = Data("do not replace".utf8)
+        #expect(FileManager.default.createFile(atPath: target, contents: targetData))
+        #expect(Darwin.symlink(target, store.descriptorPath) == 0)
+        #expect(throws: AFMBridgeDescriptorError.self) {
+            try store.publish(descriptor)
+        }
+        #expect(try Data(contentsOf: URL(fileURLWithPath: target)) == targetData)
+        #expect(try temporaryDescriptorNames(in: directory).isEmpty)
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        let unsafeData = Data("unsafe mode".utf8)
+        try unsafeData.write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o644)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.permissionsMismatch(expected: 0o600, actual: 0o644)) {
+            try store.publish(descriptor)
+        }
+        #expect(try Data(contentsOf: URL(fileURLWithPath: store.descriptorPath)) == unsafeData)
+        #expect(try temporaryDescriptorNames(in: directory).isEmpty)
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        #expect(Darwin.mkdir(store.descriptorPath, mode_t(0o700)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.self) {
+            try store.publish(descriptor)
+        }
+        #expect(try temporaryDescriptorNames(in: directory).isEmpty)
+
+        #expect(Darwin.rmdir(store.descriptorPath) == 0)
+        #expect(Darwin.mkfifo(store.descriptorPath, mode_t(0o600)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.self) {
+            try store.publish(descriptor)
+        }
+    }
+}
+
+@Test("Descriptor reads reject symlinks, wrong modes, hard links, malformed data, and oversized data")
+func bridgeDescriptorReadValidation() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let directory = (parent as NSString).appendingPathComponent("bridge")
+        let store = try AFMBridgeDescriptorStore(directoryPath: directory)
+        try AFMBridgeDirectory.prepare(at: directory)
+
+        let target = (parent as NSString).appendingPathComponent("target")
+        #expect(FileManager.default.createFile(atPath: target, contents: Data("{}".utf8)))
+        #expect(Darwin.symlink(target, store.descriptorPath) == 0)
+        #expect(throws: AFMBridgeDescriptorError.self) { try store.read() }
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        try Data("{}".utf8).write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o644)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.permissionsMismatch(expected: 0o600, actual: 0o644)) {
+            try store.read()
+        }
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        try Data("not json".utf8).write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o600)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.decodingFailed) { try store.read() }
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        let unsupported = try makeAFMBridgeTestDescriptor()
+        let unsupportedVersion = AFMBridgeConnectionDescriptor(
+            version: 2,
+            endpoint: unsupported.endpoint,
+            bearerToken: unsupported.bearerToken,
+            processIdentifier: unsupported.processIdentifier,
+            launchIdentifier: unsupported.launchIdentifier,
+            modelIdentifiers: unsupported.modelIdentifiers,
+            startedAt: unsupported.startedAt
+        )
+        try JSONEncoder().encode(unsupportedVersion).write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o600)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.unsupportedVersion(2)) { try store.read() }
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        try Data(repeating: 65, count: AFMBridgeDescriptorStore.maximumDescriptorByteCount + 1)
+            .write(to: URL(fileURLWithPath: store.descriptorPath))
+        #expect(Darwin.chmod(store.descriptorPath, mode_t(0o600)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.descriptorTooLarge) { try store.read() }
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        let hardLinkSource = (parent as NSString).appendingPathComponent("hard-link-source")
+        try Data("{}".utf8).write(to: URL(fileURLWithPath: hardLinkSource))
+        #expect(Darwin.chmod(hardLinkSource, mode_t(0o600)) == 0)
+        #expect(Darwin.link(hardLinkSource, store.descriptorPath) == 0)
+        #expect(throws: AFMBridgeDescriptorError.tooManyLinks) { try store.read() }
+
+        #expect(Darwin.unlink(store.descriptorPath) == 0)
+        #expect(Darwin.mkfifo(store.descriptorPath, mode_t(0o600)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.self) { try store.read() }
+    }
+}
+
+@Test("Descriptor store rejects unsafe file names")
+func bridgeDescriptorStoreFileNameValidation() {
+    for fileName in ["", ".", "..", "nested/connection.json", "connection\0.json"] {
+        #expect(throws: AFMBridgeDescriptorError.invalidFileName) {
+            try AFMBridgeDescriptorStore(directoryPath: "/tmp/bridge", fileName: fileName)
+        }
+    }
+}
+
+private func temporaryDescriptorNames(in directory: String) throws -> [String] {
+    try FileManager.default.contentsOfDirectory(atPath: directory).filter { name in
+        name.hasPrefix(".connection.json.")
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeDirectoryTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeDirectoryTests.swift
@@ -1,0 +1,54 @@
+import Darwin
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("Bridge directory preparation creates and repairs exact current-user-only permissions")
+func bridgeDirectoryPreparationAndValidation() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let directory = (parent as NSString).appendingPathComponent("bridge")
+        try AFMBridgeDirectory.prepare(at: directory)
+
+        var status = try afmBridgeStatus(at: directory)
+        #expect((status.st_mode & S_IFMT) == S_IFDIR)
+        #expect(status.st_uid == geteuid())
+        #expect(afmBridgePermissions(status) == mode_t(0o700))
+        try AFMBridgeDirectory.validate(at: directory)
+
+        #expect(Darwin.chmod(directory, mode_t(0o755)) == 0)
+        #expect(throws: AFMBridgeDescriptorError.permissionsMismatch(expected: 0o700, actual: 0o755)) {
+            try AFMBridgeDirectory.validate(at: directory)
+        }
+
+        try AFMBridgeDirectory.prepare(at: directory)
+        status = try afmBridgeStatus(at: directory)
+        #expect(afmBridgePermissions(status) == mode_t(0o700))
+    }
+}
+
+@Test("Bridge directory preparation refuses symlinks and non-directory objects")
+func bridgeDirectoryRefusesUnsafeObjects() throws {
+    try withAFMBridgeTemporaryDirectory { parent in
+        let realDirectory = (parent as NSString).appendingPathComponent("real")
+        let symlinkPath = (parent as NSString).appendingPathComponent("link")
+        let filePath = (parent as NSString).appendingPathComponent("file")
+        try AFMBridgeDirectory.prepare(at: realDirectory)
+        #expect(Darwin.symlink(realDirectory, symlinkPath) == 0)
+        #expect(FileManager.default.createFile(atPath: filePath, contents: Data("safe".utf8)))
+
+        #expect(throws: AFMBridgeDescriptorError.self) {
+            try AFMBridgeDirectory.prepare(at: symlinkPath)
+        }
+        #expect(throws: AFMBridgeDescriptorError.self) {
+            try AFMBridgeDirectory.prepare(at: filePath)
+        }
+        #expect(try Data(contentsOf: URL(fileURLWithPath: filePath)) == Data("safe".utf8))
+    }
+}
+
+@Test("Bridge directory paths must be absolute")
+func bridgeDirectoryRejectsRelativePaths() {
+    #expect(throws: AFMBridgeDescriptorError.invalidPath) {
+        try AFMBridgeDirectory.prepare(at: "relative/bridge")
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeEndpointTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeEndpointTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import AFMServer
+
+@Test("Bridge endpoints round-trip and accept only supported local transports")
+func bridgeEndpointCodableRoundTrip() throws {
+    let endpoints: [AFMBridgeEndpoint] = [
+        .unixSocket(path: "/tmp/foundation-lab.sock"),
+        .loopbackTCP(host: "127.0.0.1", port: 19_760),
+        .loopbackTCP(host: "::1", port: 65_535)
+    ]
+
+    for endpoint in endpoints {
+        #expect(try endpoint.validated() == endpoint)
+        let encoded = try JSONEncoder().encode(endpoint)
+        #expect(try JSONDecoder().decode(AFMBridgeEndpoint.self, from: encoded) == endpoint)
+    }
+}
+
+@Test("Unix bridge endpoints require absolute null-free paths")
+func bridgeUnixEndpointValidation() {
+    #expect(throws: AFMBridgeDescriptorError.invalidField("endpoint.unixSocket.path")) {
+        try AFMBridgeEndpoint.unixSocket(path: "relative.sock").validated()
+    }
+    #expect(throws: AFMBridgeDescriptorError.invalidField("endpoint.unixSocket.path")) {
+        try AFMBridgeEndpoint.unixSocket(path: "/tmp/bridge\0shadow.sock").validated()
+    }
+}
+
+@Test("TCP bridge endpoints require exact numeric loopback hosts and valid ports")
+func bridgeLoopbackTCPEndpointValidation() {
+    for host in ["localhost", "0.0.0.0", "127.0.0.2", "[::1]", "::"] {
+        #expect(throws: AFMBridgeDescriptorError.invalidField("endpoint.loopbackTCP.host")) {
+            try AFMBridgeEndpoint.loopbackTCP(host: host, port: 19_760).validated()
+        }
+    }
+    for port in [-1, 0, 65_536] {
+        #expect(throws: AFMBridgeDescriptorError.invalidField("endpoint.loopbackTCP.port")) {
+            try AFMBridgeEndpoint.loopbackTCP(host: "127.0.0.1", port: port).validated()
+        }
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeTestSupport.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeTestSupport.swift
@@ -1,0 +1,45 @@
+import Darwin
+import Foundation
+@testable import AFMServer
+
+func withAFMBridgeTemporaryDirectory<Result>(
+    _ body: (String) throws -> Result
+) throws -> Result {
+    let path = (NSTemporaryDirectory() as NSString)
+        .appendingPathComponent("AFMBridgeTests-\(UUID().uuidString)")
+    guard Darwin.mkdir(path, mode_t(0o700)) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    return try body(path)
+}
+
+func makeAFMBridgeTestDescriptor(
+    endpoint: AFMBridgeEndpoint = .unixSocket(path: "/tmp/foundation-lab.sock"),
+    token: String? = nil,
+    processIdentifier: Int32 = 42,
+    launchIdentifier: UUID = UUID(),
+    modelIdentifiers: [String] = ["system"],
+    startedAt: Date = Date(timeIntervalSinceReferenceDate: 123_456)
+) throws -> AFMBridgeConnectionDescriptor {
+    AFMBridgeConnectionDescriptor(
+        endpoint: endpoint,
+        bearerToken: try token ?? AFMBridgeBearerTokenGenerator.generate(),
+        processIdentifier: processIdentifier,
+        launchIdentifier: launchIdentifier,
+        modelIdentifiers: modelIdentifiers,
+        startedAt: startedAt
+    )
+}
+
+func afmBridgeStatus(at path: String) throws -> stat {
+    var status = stat()
+    guard Darwin.lstat(path, &status) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    return status
+}
+
+func afmBridgePermissions(_ status: stat) -> mode_t {
+    status.st_mode & mode_t(0o7777)
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMFoundationModelsChatGeneratorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMFoundationModelsChatGeneratorTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import FoundationModels
+import Testing
+@testable import AFMServer
+
+@Test("Foundation Models generator forwards the requested model identifier to its session builder")
+func foundationModelsGeneratorForwardsRequestedModel() async throws {
+    let probe = AFMSessionBuilderProbe()
+    let generator = AFMFoundationModelsChatGenerator { modelIdentifier, _ in
+        probe.record(modelIdentifier)
+        throw AFMSessionBuilderTestError.expected
+    }
+    let request = AFMChatGenerationRequest(
+        model: "pcc",
+        messages: [.init(role: .user, contentSegments: ["Hello"])]
+    )
+
+    await #expect(throws: AFMSessionBuilderTestError.expected) {
+        try await generator.generate(request)
+    }
+    #expect(probe.modelIdentifier == "pcc")
+}
+
+private final class AFMSessionBuilderProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedModelIdentifier: String?
+
+    var modelIdentifier: String? {
+        lock.withLock { recordedModelIdentifier }
+    }
+
+    func record(_ modelIdentifier: String) {
+        lock.withLock { recordedModelIdentifier = modelIdentifier }
+    }
+}
+
+private enum AFMSessionBuilderTestError: Error {
+    case expected
+}


### PR DESCRIPTION
## Summary

- add a macOS-only, process-scoped Agent Bridge hosted by the signed Foundation Lab app
- persist one-time user folder consent and the explicit enabled preference so agents can relaunch the app in the background without a TTY or repeated UI work
- expose the existing OpenAI-compatible AFM server on an authenticated `127.0.0.1` ephemeral port
- advertise and execute `system` and `pcc` explicitly, with current-process entitlement, availability, and quota checks and no PCC fallback
- add reusable bridge endpoint/descriptor/token primitives and an injected Foundation Models session builder to `AFMServer`
- add a macOS entitlement file that keeps the public PCC entitlement while adding app-scoped bookmarks and user-selected read/write access

This is stacked on #175, which extracts `AFMServer` as a reusable package.

## Why a signed app bridge

Apple's `/usr/bin/fm` gates PCC behind its own process/signature/TTY checks and private ModelManager capability. An ordinary Homebrew-style CLI cannot inherit those rights. Foundation Lab already has the public PCC entitlement, so the legitimate headless path is:

`agent / afm -> authenticated loopback endpoint -> signed Foundation Lab app -> PCC`

The first runtime prototype used a Unix socket in the selected folder. A real signed sandbox run proved macOS rejects that pathname bind with `EPERM`, even though the folder bookmark authorizes normal file access. The bridge therefore uses loopback TCP plus a protected connection descriptor; this works inside App Sandbox and remains local-only and agent-friendly.

## Security

- 32 random bytes per process launch, encoded as a 43-byte base64url bearer token
- exact `0700` bridge directory and `0600` descriptor permissions
- no-follow opens, owner/type/mode/hard-link checks, nonblocking FIFO rejection, atomic descriptor rotation, and inode-safe cleanup
- redacted string/debug/reflection output for descriptors
- numeric loopback hosts only (`127.0.0.1` or `::1`); no wildcard or `localhost` descriptor endpoints
- constant-time bearer comparison and Origin/Host protections from the server package
- token, launch UUID, PID, models, endpoint, and start time rotate/publish as one descriptor
- requested PCC never falls back to the system model

## Verification

- `swiftlint lint --strict --config .swiftlint.yml` — 0 violations across 226 files
- `swift test` with Xcode 27 — 188 tests passed
- standalone `AFMServer` suite — 52/52 on Xcode 26.6 and 52/52 on Xcode 27
- unsigned app builds passed on both toolchains for:
  - generic macOS
  - generic iOS Simulator
- clean Xcode 27 Apple Development build passed
- `codesign --verify --deep --strict` passed
- signed entitlements and embedded provisioning profile both contain `com.apple.developer.private-cloud-compute = true`
- signed app entitlements also contain App Sandbox, app-scoped bookmarks, user-selected read/write, and network server access

### Live no-TTY proof

From a process where stdin was not a TTY:

- background LaunchServices start restored the opted-in bridge and published `pcc` + `system`
- invalid bearer token returned `401 invalid_api_key`
- system request returned exactly `bridge online` with observed usage `57 input / 5 output / 62 total`
- PCC request returned exactly `clean signed bridge online` with framework-observed response usage
- background relaunch rotated the launch UUID, bearer token, and descriptor inode
- the prior token returned `401`; the new token succeeded

No Terminal ancestry, pseudo-TTY, private entitlement copying, or `/usr/bin/fm` subprocess is involved.
