### PR TITLE
Add headless afm bridge client

### DIFF
--- a/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
@@ -2,7 +2,7 @@ import Foundation
 import NIOCore
 import NIOHTTP1
 
-final class AFMAsyncHTTPResponseWriter: @unchecked Sendable {
+actor AFMAsyncHTTPResponseWriter {
     enum WriterError: Error {
         case invalidEmissionSequence
         case inactiveChannel

--- a/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
@@ -1,0 +1,108 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
+final class AFMAsyncHTTPResponseWriter: @unchecked Sendable {
+    enum WriterError: Error {
+        case invalidEmissionSequence
+        case inactiveChannel
+    }
+
+    private let channel: any Channel
+    private let version: HTTPVersion
+    private let closeAfterResponse: Bool
+    private var responseStarted = false
+    private var isStreaming = false
+    private var responseEnded = false
+
+    var hasStarted: Bool {
+        responseStarted
+    }
+
+    init(channel: any Channel, version: HTTPVersion, closeAfterResponse: Bool) {
+        self.channel = channel
+        self.version = version
+        self.closeAfterResponse = closeAfterResponse || version != .http1_1
+    }
+
+    func write(_ emission: AFMHTTPEmission) async throws {
+        guard channel.isActive else { throw WriterError.inactiveChannel }
+        switch emission {
+        case .fixed(let response):
+            guard !responseStarted, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            responseStarted = true
+            try await writeFixed(response)
+            responseEnded = true
+        case .streamHead(let status, let headers):
+            guard !responseStarted, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            responseStarted = true
+            isStreaming = true
+            try await writeStreamHead(status: status, headers: headers)
+        case .streamBody(let data):
+            guard isStreaming, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            try await writeBody(data)
+        case .streamEnd:
+            guard isStreaming, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            try await writeEnd()
+            responseEnded = true
+        }
+    }
+
+    func abort() async {
+        if channel.isActive {
+            try? await channel.close().get()
+        }
+    }
+
+    private func writeFixed(_ response: AFMHTTPResponse) async throws {
+        var headers = response.headers
+        headers.replaceOrAdd(name: "content-type", value: "application/json")
+        headers.replaceOrAdd(name: "content-length", value: String(response.body.count))
+        addSecurityHeaders(to: &headers, streaming: false)
+        try await writeHead(status: response.status, headers: headers)
+        if !response.body.isEmpty {
+            try await writeBody(response.body)
+        }
+        try await writeEnd()
+    }
+
+    private func writeStreamHead(status: HTTPResponseStatus, headers originalHeaders: HTTPHeaders) async throws {
+        var headers = originalHeaders
+        headers.replaceOrAdd(name: "content-type", value: "text/event-stream")
+        headers.remove(name: "content-length")
+        if version == .http1_1 {
+            headers.replaceOrAdd(name: "transfer-encoding", value: "chunked")
+        }
+        addSecurityHeaders(to: &headers, streaming: true)
+        try await writeHead(status: status, headers: headers)
+    }
+
+    private func addSecurityHeaders(to headers: inout HTTPHeaders, streaming: Bool) {
+        headers.replaceOrAdd(name: "cache-control", value: streaming ? "no-cache" : "no-store")
+        headers.replaceOrAdd(name: "x-content-type-options", value: "nosniff")
+        if closeAfterResponse {
+            headers.replaceOrAdd(name: "connection", value: "close")
+        } else if streaming {
+            headers.replaceOrAdd(name: "connection", value: "keep-alive")
+        }
+    }
+
+    private func writeHead(status: HTTPResponseStatus, headers: HTTPHeaders) async throws {
+        let head = HTTPResponseHead(version: version, status: status, headers: headers)
+        try await channel.writeAndFlush(HTTPServerResponsePart.head(head)).get()
+    }
+
+    private func writeBody(_ data: Data) async throws {
+        guard !data.isEmpty else { return }
+        var buffer = channel.allocator.buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        try await channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buffer))).get()
+    }
+
+    private func writeEnd() async throws {
+        try await channel.writeAndFlush(HTTPServerResponsePart.end(nil)).get()
+        if closeAfterResponse, channel.isActive {
+            try await channel.close().get()
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeClient.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeClient.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+public struct AFMBridgeClient: Sendable {
+    private let endpoint: AFMBridgeEndpoint
+    private let baseURL: URL
+    private let bearerToken: String
+    private let configuration: AFMBridgeClientConfiguration
+
+    public init(
+        descriptor: AFMBridgeConnectionDescriptor,
+        configuration: AFMBridgeClientConfiguration = .init()
+    ) throws {
+        let descriptor = try descriptor.validated()
+        let configuration = try configuration.validated()
+        guard case .loopbackTCP(let host, let port) = descriptor.endpoint else {
+            throw AFMBridgeClientError.unsupportedTransport
+        }
+
+        endpoint = descriptor.endpoint
+        baseURL = try Self.makeBaseURL(host: host, port: port)
+        bearerToken = descriptor.bearerToken
+        self.configuration = configuration
+    }
+
+    public init(
+        descriptorStore: AFMBridgeDescriptorStore,
+        configuration: AFMBridgeClientConfiguration = .init()
+    ) throws {
+        try self.init(descriptor: descriptorStore.read(), configuration: configuration)
+    }
+
+    public func health() async throws -> AFMBridgeClientResponse {
+        try await perform(method: "GET", path: "/health")
+    }
+
+    public func models() async throws -> AFMBridgeClientResponse {
+        try await perform(method: "GET", path: "/v1/models")
+    }
+
+    public func chatCompletions(body: Data) async throws -> AFMBridgeClientResponse {
+        try await perform(method: "POST", path: "/v1/chat/completions", body: body)
+    }
+}
+
+extension AFMBridgeClient: CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
+    public var description: String {
+        "AFMBridgeClient(endpoint: \(endpoint), bearerToken: <redacted>, configuration: \(configuration))"
+    }
+
+    public var debugDescription: String { description }
+
+    public var customMirror: Mirror {
+        Mirror(
+            self,
+            children: [
+                "endpoint": endpoint,
+                "bearerToken": "<redacted>",
+                "configuration": configuration
+            ],
+            displayStyle: .struct
+        )
+    }
+}
+
+private extension AFMBridgeClient {
+    static func makeBaseURL(host: String, port: Int) throws -> URL {
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = host
+        components.port = port
+        guard let url = components.url else {
+            throw AFMBridgeClientError.invalidResponse
+        }
+        return url
+    }
+
+    func perform(
+        method: String,
+        path: String,
+        body: Data? = nil
+    ) async throws -> AFMBridgeClientResponse {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = method
+        request.timeoutInterval = configuration.requestTimeout
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let session = makeURLSession()
+        defer { session.invalidateAndCancel() }
+
+        do {
+            let (bytes, response) = try await session.bytes(for: request)
+            guard let response = response as? HTTPURLResponse else {
+                throw AFMBridgeClientError.invalidResponse
+            }
+            if response.expectedContentLength > Int64(configuration.maximumResponseByteCount) {
+                throw AFMBridgeClientError.responseTooLarge(
+                    maximumByteCount: configuration.maximumResponseByteCount
+                )
+            }
+            let body = try await AFMBridgeResponseAccumulator.data(
+                from: bytes,
+                maximumByteCount: configuration.maximumResponseByteCount
+            )
+            return AFMBridgeClientResponse(statusCode: response.statusCode, body: body)
+        } catch let error as AFMBridgeClientError {
+            throw error
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError {
+            if Task.isCancelled { throw CancellationError() }
+            throw AFMBridgeClientError.transportFailure(code: error.code)
+        } catch {
+            if Task.isCancelled { throw CancellationError() }
+            throw AFMBridgeClientError.transportFailure(code: .unknown)
+        }
+    }
+
+    func makeURLSession() -> URLSession {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.timeoutIntervalForRequest = configuration.requestTimeout
+        sessionConfiguration.timeoutIntervalForResource = configuration.requestTimeout
+        sessionConfiguration.waitsForConnectivity = false
+        sessionConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        sessionConfiguration.urlCache = nil
+        sessionConfiguration.httpCookieStorage = nil
+        sessionConfiguration.httpShouldSetCookies = false
+        sessionConfiguration.urlCredentialStorage = nil
+        sessionConfiguration.connectionProxyDictionary = [:]
+        return URLSession(
+            configuration: sessionConfiguration,
+            delegate: AFMBridgeURLSessionDelegate(),
+            delegateQueue: nil
+        )
+    }
+
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeClientConfiguration.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeClientConfiguration.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct AFMBridgeClientConfiguration: Sendable, Equatable {
+    public static let defaultRequestTimeout: TimeInterval = 130
+    public static let defaultMaximumResponseByteCount = 8 * 1_024 * 1_024
+
+    public let requestTimeout: TimeInterval
+    public let maximumResponseByteCount: Int
+
+    public init(
+        requestTimeout: TimeInterval = Self.defaultRequestTimeout,
+        maximumResponseByteCount: Int = Self.defaultMaximumResponseByteCount
+    ) {
+        self.requestTimeout = requestTimeout
+        self.maximumResponseByteCount = maximumResponseByteCount
+    }
+
+    func validated() throws -> Self {
+        guard requestTimeout.isFinite, requestTimeout > 0 else {
+            throw AFMBridgeClientError.invalidConfiguration(field: "requestTimeout")
+        }
+        guard maximumResponseByteCount > 0 else {
+            throw AFMBridgeClientError.invalidConfiguration(field: "maximumResponseByteCount")
+        }
+        return self
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeClientError.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeClientError.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public enum AFMBridgeClientError: Error, Sendable, Equatable, LocalizedError {
+    case unsupportedTransport
+    case invalidConfiguration(field: String)
+    case invalidResponse
+    case responseTooLarge(maximumByteCount: Int)
+    case transportFailure(code: URLError.Code)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedTransport:
+            "The bridge client supports authenticated loopback TCP endpoints only."
+        case .invalidConfiguration(let field):
+            "The bridge client configuration field '\(field)' is invalid."
+        case .invalidResponse:
+            "The bridge returned a response that was not HTTP."
+        case .responseTooLarge(let maximumByteCount):
+            "The bridge response exceeded the \(maximumByteCount)-byte limit."
+        case .transportFailure(let code):
+            "The bridge request failed with URL error code \(code.rawValue)."
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeClientResponse.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeClientResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct AFMBridgeClientResponse: Sendable, Equatable {
+    public let statusCode: Int
+    public let body: Data
+
+    public init(statusCode: Int, body: Data) {
+        self.statusCode = statusCode
+        self.body = body
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeResponseAccumulator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeResponseAccumulator.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum AFMBridgeResponseAccumulator {
+    static func data<Bytes: AsyncSequence>(
+        from bytes: Bytes,
+        maximumByteCount: Int
+    ) async throws -> Data where Bytes.Element == UInt8 {
+        var data = Data()
+        for try await byte in bytes {
+            guard data.count < maximumByteCount else {
+                throw AFMBridgeClientError.responseTooLarge(maximumByteCount: maximumByteCount)
+            }
+            data.append(byte)
+        }
+        return data
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMBridgeURLSessionDelegate.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMBridgeURLSessionDelegate.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class AFMBridgeURLSessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct AFMChatCompletionChunk: Encodable {
+    struct Choice: Encodable {
+        struct Delta: Encodable {
+            let role: String?
+            let content: String?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(role, forKey: .role)
+                try container.encodeIfPresent(content, forKey: .content)
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case role
+                case content
+            }
+        }
+
+        let index: Int
+        let delta: Delta
+        let finishReason: AFMChatFinishReason?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(index, forKey: .index)
+            try container.encode(delta, forKey: .delta)
+            try container.encodeNil(forKey: .logprobs)
+            if let finishReason {
+                try container.encode(finishReason, forKey: .finishReason)
+            } else {
+                try container.encodeNil(forKey: .finishReason)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case index
+            case delta
+            case logprobs
+            case finishReason = "finish_reason"
+        }
+    }
+
+    let id: String
+    let object = "chat.completion.chunk"
+    let created: Int64
+    let model: String
+    let choices: [Choice]
+    let usage: AFMChatUsagePayload?
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(object, forKey: .object)
+        try container.encode(created, forKey: .created)
+        try container.encode(model, forKey: .model)
+        try container.encode(choices, forKey: .choices)
+        if let usage {
+            try container.encode(usage, forKey: .usage)
+        } else {
+            try container.encodeNil(forKey: .usage)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case created
+        case model
+        case choices
+        case usage
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
@@ -5,16 +5,19 @@ struct AFMChatCompletionChunk: Encodable {
         struct Delta: Encodable {
             let role: String?
             let content: String?
+            let refusal: String?
 
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(role, forKey: .role)
                 try container.encodeIfPresent(content, forKey: .content)
+                try container.encodeIfPresent(refusal, forKey: .refusal)
             }
 
             private enum CodingKeys: String, CodingKey {
                 case role
                 case content
+                case refusal
             }
         }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
@@ -45,6 +45,8 @@ public struct AFMChatMessage: Sendable, Equatable {
 public struct AFMChatGenerationRequest: Sendable, Equatable {
     public let model: String
     public let messages: [AFMChatMessage]
+    public let stream: Bool
+    public let streamOptions: AFMChatStreamOptions?
     public let temperature: Double?
     public let topP: Double?
     public let maximumCompletionTokens: Int?
@@ -52,12 +54,16 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
     public init(
         model: String = "system",
         messages: [AFMChatMessage],
+        stream: Bool = false,
+        streamOptions: AFMChatStreamOptions? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
         maximumCompletionTokens: Int? = nil
     ) {
         self.model = model
         self.messages = messages
+        self.stream = stream
+        self.streamOptions = streamOptions
         self.temperature = temperature
         self.topP = topP
         self.maximumCompletionTokens = maximumCompletionTokens
@@ -74,21 +80,18 @@ extension AFMChatGenerationRequest: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AFMJSONKey.self)
         try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
-        try rejectUnsupportedFields(
-            ["tools", "tool_choice", "response_format", "stream_options"],
-            in: container,
-            decoder: decoder
-        )
-
-        if try container.decodeIfPresent(Bool.self, forKey: .init("stream")) == true {
-            throw AFMChatRequestValidationError.unsupportedField("stream")
-        }
+        try rejectUnsupportedFields(["response_format"], in: container, decoder: decoder)
 
         let model = try container.decodeIfPresent(String.self, forKey: .init("model")) ?? "system"
         guard container.contains(.init("messages")) else {
             throw AFMChatRequestValidationError.missingField("messages")
         }
         let messages = try container.decode([AFMChatMessage].self, forKey: .init("messages"))
+        let stream = try container.decodeIfPresent(Bool.self, forKey: .init("stream")) ?? false
+        let streamOptions = try container.decodeIfPresent(
+            AFMChatStreamOptions.self,
+            forKey: .init("stream_options")
+        )
         let temperature = try container.decodeIfPresent(Double.self, forKey: .init("temperature"))
         let topP = try container.decodeIfPresent(Double.self, forKey: .init("top_p"))
         let maximumCompletionTokens = try container.decodeIfPresent(
@@ -98,6 +101,8 @@ extension AFMChatGenerationRequest: Decodable {
         let legacyMaximumTokens = try container.decodeIfPresent(Int.self, forKey: .init("max_tokens"))
 
         try Self.validateModel(model)
+        try Self.validateStreaming(stream: stream, streamOptions: streamOptions)
+        try Self.validateEmptyToolSentinel(in: container)
         try Self.validateOptions(
             temperature: temperature,
             topP: topP,
@@ -109,6 +114,8 @@ extension AFMChatGenerationRequest: Decodable {
         self.init(
             model: model,
             messages: messages,
+            stream: stream,
+            streamOptions: streamOptions,
             temperature: temperature,
             topP: topP,
             maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens
@@ -130,6 +137,36 @@ extension AFMChatGenerationRequest: Decodable {
     private static func validateModel(_ model: String) throws {
         guard !model.isEmpty, model == model.trimmingCharacters(in: .whitespacesAndNewlines) else {
             throw AFMChatRequestValidationError.invalidField("model", message: "Model must be a non-empty identifier.")
+        }
+    }
+
+    private static func validateStreaming(
+        stream: Bool,
+        streamOptions: AFMChatStreamOptions?
+    ) throws {
+        guard stream || streamOptions == nil else {
+            throw AFMChatRequestValidationError.invalidField(
+                "stream_options",
+                message: "stream_options may only be used when stream is true."
+            )
+        }
+    }
+
+    private static func validateEmptyToolSentinel(
+        in container: KeyedDecodingContainer<AFMJSONKey>
+    ) throws {
+        let toolsKey = AFMJSONKey("tools")
+        if container.contains(toolsKey), try !container.decodeNil(forKey: toolsKey) {
+            let tools = try container.nestedUnkeyedContainer(forKey: toolsKey)
+            guard tools.isAtEnd else {
+                throw AFMChatRequestValidationError.unsupportedField("tools")
+            }
+        }
+
+        let toolChoiceKey = AFMJSONKey("tool_choice")
+        if let toolChoice = try container.decodeIfPresent(String.self, forKey: toolChoiceKey),
+           toolChoice != "auto" {
+            throw AFMChatRequestValidationError.unsupportedField("tool_choice")
         }
     }
 
@@ -182,7 +219,7 @@ struct AFMChatRequestValidationError: Error, Equatable, Sendable {
 
     static func unsupportedField(_ parameter: String) -> Self {
         .init(
-            message: "Field '\(parameter)' is not supported by non-streaming chat completions yet.",
+            message: "Field '\(parameter)' is not supported by this chat completions endpoint.",
             parameter: parameter,
             code: "unsupported_field"
         )

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionResponse.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionResponse.swift
@@ -3,6 +3,7 @@ import FoundationModelsKit
 
 public enum AFMChatFinishReason: String, Sendable, Equatable, Encodable {
     case stop
+    case length
     case contentFilter = "content_filter"
 }
 
@@ -27,6 +28,24 @@ public struct AFMChatGenerationResult: Sendable, Equatable {
 
 public protocol AFMChatCompletionGenerating: Sendable {
     func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult
+
+    func stream(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult
+}
+
+public extension AFMChatCompletionGenerating {
+    func stream(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        let result = try await generate(request)
+        if let content = result.content, !content.isEmpty {
+            try await event(.contentDelta(content))
+        }
+        return result
+    }
 }
 
 public enum AFMChatGenerationError: Error, Sendable, Equatable {

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationModelsKit
 import NIOHTTP1
 
 actor AFMGenerationGate {
@@ -72,7 +73,104 @@ struct AFMChatCompletionService: Sendable {
         }
     }
 
-    private func validateModel(_ identifier: String) -> AFMHTTPResponse? {
+    func writeResponse(
+        for body: Data,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        let request: AFMChatGenerationRequest
+        do {
+            request = try AFMChatGenerationRequest.decode(body)
+        } catch let error as AFMChatRequestValidationError {
+            try await emission(.fixed(validationErrorResponse(error)))
+            return
+        }
+
+        guard request.stream else {
+            try await emission(.fixed(try await response(for: body)))
+            return
+        }
+        if let modelError = validateModel(request.model) {
+            try await emission(.fixed(modelError))
+            return
+        }
+        guard await gate.tryAcquire() else {
+            try await emission(.fixed(serverBusyResponse()))
+            return
+        }
+
+        try await writeStreamingResponse(request, emitting: emission)
+    }
+}
+
+private extension AFMChatCompletionService {
+    func writeStreamingResponse(
+        _ request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        var sentStreamHead = false
+        do {
+            let identifier = "chatcmpl-\(UUID().uuidString)"
+            let created = clock.unixTime()
+            try await emission(.streamHead(status: .ok, headers: .init()))
+            sentStreamHead = true
+            try await writeChunk(
+                identifier: identifier,
+                created: created,
+                role: "assistant",
+                request: request,
+                emitting: emission
+            )
+
+            let result = try await streamWithTimeout(request) { event in
+                switch event {
+                case .contentDelta(let content):
+                    try await writeChunk(
+                        identifier: identifier,
+                        created: created,
+                        content: content,
+                        request: request,
+                        emitting: emission
+                    )
+                }
+            }
+            try await writeChunk(
+                identifier: identifier,
+                created: created,
+                finishReason: result.finishReason,
+                request: request,
+                emitting: emission
+            )
+            if request.streamOptions?.includeUsage == true {
+                try await writeUsageChunk(
+                    result.usage,
+                    identifier: identifier,
+                    created: created,
+                    request: request,
+                    emitting: emission
+                )
+            }
+            try await emission(.streamBody(AFMServerSentEventEncoder().done))
+            try await emission(.streamEnd)
+            await gate.release()
+        } catch is CancellationError {
+            await gate.release()
+            throw CancellationError()
+        } catch let error as AFMAsyncHTTPResponseWriter.WriterError {
+            await gate.release()
+            throw error
+        } catch {
+            await gate.release()
+            if sentStreamHead {
+                let response = generationErrorResponse(error)
+                try await emission(.streamBody(AFMServerSentEventEncoder().event(json: response.body)))
+                try await emission(.streamEnd)
+            } else {
+                try await emission(.fixed(generationErrorResponse(error)))
+            }
+        }
+    }
+
+    func validateModel(_ identifier: String) -> AFMHTTPResponse? {
         guard let model = catalog.models().first(where: { $0.id == identifier }) else {
             return .apiError(
                 status: .notFound,
@@ -93,7 +191,16 @@ struct AFMChatCompletionService: Sendable {
         return nil
     }
 
-    private func generateWithTimeout(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+    func serverBusyResponse() -> AFMHTTPResponse {
+        .apiError(
+            status: .tooManyRequests,
+            message: "The local model is already handling the configured number of requests.",
+            code: "server_busy",
+            type: "rate_limit_error"
+        )
+    }
+
+    func generateWithTimeout(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
         try await withThrowingTaskGroup(of: AFMChatGenerationResult.self) { group in
             group.addTask {
                 try await generator.generate(request)
@@ -110,7 +217,27 @@ struct AFMChatCompletionService: Sendable {
         }
     }
 
-    private func completionResponse(
+    func streamWithTimeout(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        try await withThrowingTaskGroup(of: AFMChatGenerationResult.self) { group in
+            group.addTask {
+                try await generator.stream(request, emitting: event)
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: .seconds(timeoutSeconds))
+                throw AFMChatServiceError.timedOut
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw AFMChatServiceError.missingResult
+            }
+            return result
+        }
+    }
+
+    func completionResponse(
         _ result: AFMChatGenerationResult,
         request: AFMChatGenerationRequest
     ) -> AFMHTTPResponse {
@@ -131,7 +258,49 @@ struct AFMChatCompletionService: Sendable {
         )
     }
 
-    private func validationErrorResponse(_ error: AFMChatRequestValidationError) -> AFMHTTPResponse {
+    func writeChunk(
+        identifier: String,
+        created: Int64,
+        role: String? = nil,
+        content: String? = nil,
+        finishReason: AFMChatFinishReason? = nil,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        let chunk = AFMChatCompletionChunk(
+            id: identifier,
+            created: created,
+            model: request.model,
+            choices: [
+                .init(
+                    index: 0,
+                    delta: .init(role: role, content: content),
+                    finishReason: finishReason
+                )
+            ],
+            usage: nil
+        )
+        try await emission(.streamBody(try AFMServerSentEventEncoder().event(chunk)))
+    }
+
+    func writeUsageChunk(
+        _ usage: ModelTokenUsage,
+        identifier: String,
+        created: Int64,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        let chunk = AFMChatCompletionChunk(
+            id: identifier,
+            created: created,
+            model: request.model,
+            choices: [],
+            usage: .init(usage)
+        )
+        try await emission(.streamBody(try AFMServerSentEventEncoder().event(chunk)))
+    }
+
+    func validationErrorResponse(_ error: AFMChatRequestValidationError) -> AFMHTTPResponse {
         .apiError(
             status: .badRequest,
             message: error.message,
@@ -140,7 +309,7 @@ struct AFMChatCompletionService: Sendable {
         )
     }
 
-    private func generationErrorResponse(_ error: Error) -> AFMHTTPResponse {
+    func generationErrorResponse(_ error: Error) -> AFMHTTPResponse {
         switch error {
         case AFMChatServiceError.timedOut:
             .apiError(
@@ -193,7 +362,7 @@ struct AFMChatCompletionService: Sendable {
         }
     }
 
-    private func generationFailure(
+    func generationFailure(
         _ status: HTTPResponseStatus,
         _ message: String,
         _ code: String,

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
@@ -133,22 +133,13 @@ private extension AFMChatCompletionService {
                     )
                 }
             }
-            try await writeChunk(
+            try await writeTerminalChunks(
+                result,
                 identifier: identifier,
                 created: created,
-                finishReason: result.finishReason,
                 request: request,
                 emitting: emission
             )
-            if request.streamOptions?.includeUsage == true {
-                try await writeUsageChunk(
-                    result.usage,
-                    identifier: identifier,
-                    created: created,
-                    request: request,
-                    emitting: emission
-                )
-            }
             try await emission(.streamBody(AFMServerSentEventEncoder().done))
             try await emission(.streamEnd)
             await gate.release()
@@ -263,6 +254,7 @@ private extension AFMChatCompletionService {
         created: Int64,
         role: String? = nil,
         content: String? = nil,
+        refusal: String? = nil,
         finishReason: AFMChatFinishReason? = nil,
         request: AFMChatGenerationRequest,
         emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
@@ -274,13 +266,62 @@ private extension AFMChatCompletionService {
             choices: [
                 .init(
                     index: 0,
-                    delta: .init(role: role, content: content),
+                    delta: .init(role: role, content: content, refusal: refusal),
                     finishReason: finishReason
                 )
             ],
             usage: nil
         )
         try await emission(.streamBody(try AFMServerSentEventEncoder().event(chunk)))
+    }
+
+    func writeRefusalChunk(
+        _ refusal: String?,
+        identifier: String,
+        created: Int64,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        guard let refusal else { return }
+        try await writeChunk(
+            identifier: identifier,
+            created: created,
+            refusal: refusal,
+            request: request,
+            emitting: emission
+        )
+    }
+
+    func writeTerminalChunks(
+        _ result: AFMChatGenerationResult,
+        identifier: String,
+        created: Int64,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        try await writeRefusalChunk(
+            result.refusal,
+            identifier: identifier,
+            created: created,
+            request: request,
+            emitting: emission
+        )
+        try await writeChunk(
+            identifier: identifier,
+            created: created,
+            finishReason: result.finishReason,
+            request: request,
+            emitting: emission
+        )
+        if request.streamOptions?.includeUsage == true {
+            try await writeUsageChunk(
+                result.usage,
+                identifier: identifier,
+                created: created,
+                request: request,
+                emitting: emission
+            )
+        }
     }
 
     func writeUsageChunk(

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatGenerationEvent.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatGenerationEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum AFMChatGenerationEvent: Sendable, Equatable {
+    case contentDelta(String)
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatStreamOptions.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatStreamOptions.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct AFMChatStreamOptions: Sendable, Equatable {
+    public let includeUsage: Bool
+
+    public init(includeUsage: Bool = false) {
+        self.includeUsage = includeUsage
+    }
+}
+
+extension AFMChatStreamOptions: Decodable {
+    private static let allowedFields: Set<String> = ["include_usage"]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        includeUsage = try container.decodeIfPresent(Bool.self, forKey: .init("include_usage")) ?? false
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -25,7 +25,51 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         do {
             let response = try await session.respond(to: prepared.prompt, options: prepared.options)
             let usage = await responseUsage(response, prepared: prepared)
-            return AFMChatGenerationResult(content: response.content, usage: usage)
+            return AFMChatGenerationResult(
+                content: response.content,
+                finishReason: finishReason(for: request, usage: usage),
+                usage: usage
+            )
+        } catch {
+            if Self.isRefusal(error) {
+                return await refusalResult(prepared: prepared)
+            }
+            throw Self.mappedError(error)
+        }
+    }
+
+    public func stream(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        let prepared = try AFMChatTranscriptBuilder.prepare(request)
+        let session = try sessionBuilder(request.model, prepared.transcript)
+        let responseStream = session.streamResponse(to: prepared.prompt, options: prepared.options)
+        var accumulator = AFMSnapshotDeltaAccumulator()
+
+        do {
+            for try await snapshot in responseStream {
+                try Task.checkCancellation()
+                let delta = try accumulator.append(snapshot: snapshot.content)
+                if !delta.isEmpty {
+                    try await event(.contentDelta(delta))
+                }
+            }
+
+            try Task.checkCancellation()
+            let response = try await responseStream.collect()
+            let finalDelta = try accumulator.append(snapshot: response.content)
+            if !finalDelta.isEmpty {
+                try await event(.contentDelta(finalDelta))
+            }
+            try Task.checkCancellation()
+            let usage = await responseUsage(response, prepared: prepared)
+            let result = AFMChatGenerationResult(
+                content: response.content,
+                finishReason: finishReason(for: request, usage: usage),
+                usage: usage
+            )
+            return result
         } catch {
             if Self.isRefusal(error) {
                 return await refusalResult(prepared: prepared)
@@ -61,6 +105,19 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
             finishReason: .contentFilter,
             usage: usage
         )
+    }
+
+    private func finishReason(
+        for request: AFMChatGenerationRequest,
+        usage: ModelTokenUsage
+    ) -> AFMChatFinishReason {
+        guard let limit = request.maximumCompletionTokens,
+              let output = usage.output,
+              output.totalTokenCount >= limit,
+              output.totalTokenCount > 0 else {
+            return .stop
+        }
+        return .length
     }
 
     private func fallbackUsage(input: Transcript, output: String) async -> ModelTokenUsage {

--- a/Packages/AFMServer/Sources/AFMServer/AFMHTTPEmission.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMHTTPEmission.swift
@@ -1,0 +1,9 @@
+import Foundation
+import NIOHTTP1
+
+enum AFMHTTPEmission: Sendable {
+    case fixed(AFMHTTPResponse)
+    case streamHead(status: HTTPResponseStatus, headers: HTTPHeaders)
+    case streamBody(Data)
+    case streamEnd
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
@@ -177,7 +177,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             } catch is CancellationError {
                 return
             } catch {
-                if !writer.hasStarted {
+                if !(await writer.hasStarted) {
                     try? await writer.write(
                         .fixed(
                             .apiError(

--- a/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
@@ -82,17 +82,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
                 return
             }
             cancelGeneration()
-            responseWasSent = true
-            send(
-                .apiError(
-                    status: .badRequest,
-                    message: "Only one request may be active on a connection.",
-                    code: "invalid_http_request"
-                ),
-                version: head.version,
-                close: true,
-                context: context
-            )
+            context.close(promise: nil)
             return
         }
 
@@ -171,43 +161,61 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         context: ChannelHandlerContext
     ) {
         let router = router
+        responseWasSent = true
+        let writer = AFMAsyncHTTPResponseWriter(
+            channel: context.channel,
+            version: head.version,
+            closeAfterResponse: !head.isKeepAlive
+        )
         let contextReference = AFMChannelContextReference(context)
         let eventLoop = context.eventLoop
         generationTask = Task { [weak self] in
-            let response: AFMHTTPResponse
             do {
-                response = try await router.chatCompletionResponse(body: body, origin: origin)
+                try await router.writeChatCompletionResponse(body: body, origin: origin) { emission in
+                    try await writer.write(emission)
+                }
             } catch is CancellationError {
                 return
             } catch {
-                response = .apiError(
-                    status: .internalServerError,
-                    message: "The chat completion request failed.",
-                    code: "internal_error",
-                    type: "server_error"
-                )
+                if !writer.hasStarted {
+                    try? await writer.write(
+                        .fixed(
+                            .apiError(
+                                status: .internalServerError,
+                                message: "The chat completion request failed.",
+                                code: "internal_error",
+                                type: "server_error"
+                            )
+                        )
+                    )
+                } else {
+                    await writer.abort()
+                }
             }
             guard !Task.isCancelled else { return }
             eventLoop.execute { [weak self] in
-                self?.completeChatCompletion(
-                    response,
-                    head: head,
-                    context: contextReference.context
-                )
+                self?.completeChatCompletion(context: contextReference.context)
             }
         }
     }
 
-    private func completeChatCompletion(
-        _ response: AFMHTTPResponse,
-        head: HTTPRequestHead,
-        context: ChannelHandlerContext
-    ) {
+    private func completeChatCompletion(context: ChannelHandlerContext) {
         generationTask = nil
-        guard requestHead != nil, !responseWasSent, context.channel.isActive else { return }
-        let shouldClose = !head.isKeepAlive || shouldCloseForPipelinedRequest
+        guard requestHead != nil, context.channel.isActive else { return }
+        let shouldClose = shouldCloseForPipelinedRequest
         resetRequestState()
-        send(response, version: head.version, close: shouldClose, context: context)
+        if shouldClose {
+            isClosingResponse = true
+            context.close(promise: nil)
+        }
+    }
+}
+
+private final class AFMChannelContextReference: @unchecked Sendable {
+    let context: ChannelHandlerContext
+
+    init(_ context: ChannelHandlerContext) {
+        self.context = context
     }
 }
 
@@ -303,13 +311,5 @@ private extension AFMHTTPHandler {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return mediaType == "application/json"
-    }
-}
-
-private final class AFMChannelContextReference: @unchecked Sendable {
-    let context: ChannelHandlerContext
-
-    init(_ context: ChannelHandlerContext) {
-        self.context = context
     }
 }

--- a/Packages/AFMServer/Sources/AFMServer/AFMRequestRouter.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMRequestRouter.swift
@@ -89,16 +89,27 @@ struct AFMRequestRouter: Sendable {
         return route.addingOrigin(originResult.origin)
     }
 
-    func chatCompletionResponse(body: Data, origin: String?) async throws -> AFMHTTPResponse {
+    func writeChatCompletionResponse(
+        body: Data,
+        origin: String?,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
         guard let chatCompletions else {
-            return AFMHTTPResponse.apiError(
-                status: .notImplemented,
-                message: "Chat completions are not configured for this server.",
-                code: "not_implemented",
-                type: "server_error"
-            ).addingOrigin(origin)
+            try await emission(
+                .fixed(
+                    AFMHTTPResponse.apiError(
+                        status: .notImplemented,
+                        message: "Chat completions are not configured for this server.",
+                        code: "not_implemented",
+                        type: "server_error"
+                    ).addingOrigin(origin)
+                )
+            )
+            return
         }
-        return try await chatCompletions.response(for: body).addingOrigin(origin)
+        try await chatCompletions.writeResponse(for: body) { response in
+            try await emission(response.addingOrigin(origin))
+        }
     }
 
     func requiresJSONBody(_ request: HTTPRequestHead) -> Bool {
@@ -211,6 +222,22 @@ private extension AFMHTTPResponse {
         updatedHeaders.add(name: "access-control-allow-origin", value: origin)
         updatedHeaders.add(name: "vary", value: "Origin")
         return .init(status: status, headers: updatedHeaders, body: body)
+    }
+}
+
+private extension AFMHTTPEmission {
+    func addingOrigin(_ origin: String?) -> Self {
+        guard let origin else { return self }
+        switch self {
+        case .fixed(let response):
+            return .fixed(response.addingOrigin(origin))
+        case .streamHead(let status, var headers):
+            headers.add(name: "access-control-allow-origin", value: origin)
+            headers.add(name: "vary", value: "Origin")
+            return .streamHead(status: status, headers: headers)
+        case .streamBody, .streamEnd:
+            return self
+        }
     }
 }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMServerSentEventEncoder.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMServerSentEventEncoder.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct AFMServerSentEventEncoder: Sendable {
+    private let encoder: JSONEncoder
+
+    init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    func event<T: Encodable>(_ value: T) throws -> Data {
+        event(json: try encoder.encode(value))
+    }
+
+    func event(json: Data) -> Data {
+        var data = Data("data: ".utf8)
+        data.append(json)
+        data.append(Data("\n\n".utf8))
+        return data
+    }
+
+    var done: Data {
+        Data("data: [DONE]\n\n".utf8)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMSnapshotDeltaAccumulator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMSnapshotDeltaAccumulator.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct AFMSnapshotDeltaAccumulator: Sendable {
+    enum AccumulationError: Error, Equatable {
+        case nonMonotonicSnapshot
+    }
+
+    private(set) var content = ""
+
+    mutating func append(snapshot: String) throws -> String {
+        guard snapshot.hasPrefix(content) else {
+            throw AccumulationError.nonMonotonicSnapshot
+        }
+        let delta = String(snapshot.dropFirst(content.count))
+        content = snapshot
+        return delta
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
@@ -30,7 +30,8 @@ struct AFMAsyncHTTPResponseWriterTests {
             Issue.record("Unexpected writer error: \(error)")
         }
 
-        #expect(writer.hasStarted)
+        let hasStarted = await writer.hasStarted
+        #expect(hasStarted)
         let outbound = try #require(
             try channel.readOutbound(as: HTTPServerResponsePart.self)
         )

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import Testing
+@testable import AFMServer
+
+@Suite("Async HTTP response writer")
+struct AFMAsyncHTTPResponseWriterTests {
+    @Test("A partial fixed response remains marked as started")
+    func partialFixedResponseTracksStartedState() async throws {
+        let channel = EmbeddedChannel(handler: FailingBodyHandler())
+        try await channel.connect(
+            to: SocketAddress(unixDomainSocketPath: "/afm-writer-test")
+        ).get()
+        let writer = AFMAsyncHTTPResponseWriter(
+            channel: channel,
+            version: .http1_1,
+            closeAfterResponse: false
+        )
+
+        do {
+            try await writer.write(
+                .fixed(.init(status: .ok, body: Data("body".utf8)))
+            )
+            Issue.record("Expected the response body write to fail")
+        } catch let error as WriteFailure {
+            #expect(error == .body)
+        } catch {
+            Issue.record("Unexpected writer error: \(error)")
+        }
+
+        #expect(writer.hasStarted)
+        let outbound = try #require(
+            try channel.readOutbound(as: HTTPServerResponsePart.self)
+        )
+        guard case .head(let head) = outbound else {
+            Issue.record("Expected the response head to be written before the body failed")
+            return
+        }
+        #expect(head.status == .ok)
+        #expect(try channel.readOutbound(as: HTTPServerResponsePart.self) == nil)
+        _ = try? channel.finish()
+    }
+}
+
+private extension AFMAsyncHTTPResponseWriterTests {
+    enum WriteFailure: Error, Equatable {
+        case body
+    }
+
+    final class FailingBodyHandler: ChannelOutboundHandler, @unchecked Sendable {
+        typealias OutboundIn = HTTPServerResponsePart
+        typealias OutboundOut = HTTPServerResponsePart
+
+        func write(
+            context: ChannelHandlerContext,
+            data: NIOAny,
+            promise: EventLoopPromise<Void>?
+        ) {
+            let part = unwrapOutboundIn(data)
+            if case .body = part {
+                promise?.fail(WriteFailure.body)
+            } else {
+                context.write(wrapOutboundOut(part), promise: promise)
+            }
+        }
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeClientTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMBridgeClientTests.swift
@@ -1,0 +1,501 @@
+import Darwin
+import Foundation
+import FoundationModelsKit
+import Testing
+@testable import AFMServer
+
+@Test("Bridge client authenticates health, models, and chat requests")
+func bridgeClientAuthenticatedRoundTrip() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let server = try makeBridgeClientTestServer(token: token)
+
+    do {
+        let port = try await startTCPServer(server)
+        let descriptor = try makeAFMBridgeTestDescriptor(
+            endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+            token: token
+        )
+        let client = try AFMBridgeClient(descriptor: descriptor)
+
+        let health = try await client.health()
+        #expect(health.statusCode == 200)
+        #expect(try JSONSerialization.jsonObject(with: health.body) is [String: Any])
+
+        let models = try await client.models()
+        #expect(models.statusCode == 200)
+        let modelsBody = try #require(String(data: models.body, encoding: .utf8))
+        #expect(modelsBody.contains(#""id":"system""#))
+
+        let request = Data(#"{"model":"system","messages":[{"role":"user","content":"Hi"}]}"#.utf8)
+        let completion = try await client.chatCompletions(body: request)
+        #expect(completion.statusCode == 200)
+        let completionBody = try #require(String(data: completion.body, encoding: .utf8))
+        #expect(completionBody.contains(#""content":"From bridge client""#))
+
+        try? await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Descriptor-store initialization reads the secure published descriptor")
+func bridgeClientDescriptorStoreInitialization() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let server = try makeBridgeClientTestServer(token: token)
+    let directory = try makeBridgeClientTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+
+    do {
+        let port = try await startTCPServer(server)
+        let descriptor = try makeAFMBridgeTestDescriptor(
+            endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+            token: token
+        )
+        let store = try AFMBridgeDescriptorStore(directoryPath: directory)
+        let lease = try store.publish(descriptor)
+        defer { try? lease.cleanup() }
+
+        let response = try await AFMBridgeClient(descriptorStore: store).health()
+        #expect(response.statusCode == 200)
+        try? await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Bridge client preserves non-success status and API error bodies")
+func bridgeClientPreservesAPIError() async throws {
+    let serverToken = try AFMBridgeBearerTokenGenerator.generate()
+    let clientToken = try AFMBridgeBearerTokenGenerator.generate()
+    let server = try makeBridgeClientTestServer(token: serverToken)
+
+    do {
+        let port = try await startTCPServer(server)
+        let descriptor = try makeAFMBridgeTestDescriptor(
+            endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+            token: clientToken
+        )
+        let response = try await AFMBridgeClient(descriptor: descriptor).health()
+
+        #expect(response.statusCode == 401)
+        let errorBody = try #require(String(data: response.body, encoding: .utf8))
+        #expect(errorBody.contains(#""code":"invalid_api_key""#))
+        try? await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Bridge client reports a stopped descriptor endpoint as a transport failure")
+func bridgeClientRejectsStaleEndpoint() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let server = try makeBridgeClientTestServer(token: token)
+    let port = try await startTCPServer(server)
+    try await server.stop()
+
+    let descriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+        token: token
+    )
+    let configuration = AFMBridgeClientConfiguration(requestTimeout: 0.25)
+    let client = try AFMBridgeClient(descriptor: descriptor, configuration: configuration)
+
+    do {
+        _ = try await client.health()
+        Issue.record("Expected the stale endpoint to fail")
+    } catch let error as AFMBridgeClientError {
+        guard case .transportFailure = error else {
+            Issue.record("Expected a transport failure, got \(error)")
+            return
+        }
+    }
+}
+
+@Test("Bridge client rejects unsupported and non-loopback endpoints")
+func bridgeClientEndpointValidation() throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let unixDescriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .unixSocket(path: "/tmp/foundation-lab.sock"),
+        token: token
+    )
+    #expect(throws: AFMBridgeClientError.unsupportedTransport) {
+        try AFMBridgeClient(descriptor: unixDescriptor)
+    }
+
+    let networkDescriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .loopbackTCP(host: "192.0.2.1", port: 19_760),
+        token: token
+    )
+    #expect(throws: AFMBridgeDescriptorError.invalidField("endpoint.loopbackTCP.host")) {
+        try AFMBridgeClient(descriptor: networkDescriptor)
+    }
+}
+
+@Test("Bridge client validates timeout and response limits")
+func bridgeClientConfigurationValidation() throws {
+    let descriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .loopbackTCP(host: "127.0.0.1", port: 19_760)
+    )
+    #expect(throws: AFMBridgeClientError.invalidConfiguration(field: "requestTimeout")) {
+        try AFMBridgeClient(
+            descriptor: descriptor,
+            configuration: .init(requestTimeout: .nan)
+        )
+    }
+    #expect(throws: AFMBridgeClientError.invalidConfiguration(field: "maximumResponseByteCount")) {
+        try AFMBridgeClient(
+            descriptor: descriptor,
+            configuration: .init(maximumResponseByteCount: 0)
+        )
+    }
+}
+
+@Test("Bridge client enforces its response limit")
+func bridgeClientResponseLimit() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let server = try makeBridgeClientTestServer(token: token)
+
+    do {
+        let port = try await startTCPServer(server)
+        let descriptor = try makeAFMBridgeTestDescriptor(
+            endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+            token: token
+        )
+        let client = try AFMBridgeClient(
+            descriptor: descriptor,
+            configuration: .init(maximumResponseByteCount: 16)
+        )
+
+        await #expect(throws: AFMBridgeClientError.responseTooLarge(maximumByteCount: 16)) {
+            try await client.health()
+        }
+        try? await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Stream accumulation enforces its hard cap without Content-Length")
+func bridgeClientStreamResponseLimit() async {
+    let bytes = AsyncStream<UInt8> { continuation in
+        for byte in 0..<32 {
+            continuation.yield(UInt8(byte))
+        }
+        continuation.finish()
+    }
+
+    await #expect(throws: AFMBridgeClientError.responseTooLarge(maximumByteCount: 16)) {
+        try await AFMBridgeResponseAccumulator.data(from: bytes, maximumByteCount: 16)
+    }
+}
+
+@Test("Bridge client maps URLSession timeout without exposing its request")
+func bridgeClientTimeout() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let server = try makeBridgeClientTestServer(
+        token: token,
+        generator: BridgeClientPausingGenerator()
+    )
+
+    do {
+        let port = try await startTCPServer(server)
+        let descriptor = try makeAFMBridgeTestDescriptor(
+            endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+            token: token
+        )
+        let client = try AFMBridgeClient(
+            descriptor: descriptor,
+            configuration: .init(requestTimeout: 0.1)
+        )
+        let body = Data(#"{"messages":[{"role":"user","content":"Wait"}]}"#.utf8)
+
+        await #expect(throws: AFMBridgeClientError.transportFailure(code: .timedOut)) {
+            try await client.chatCompletions(body: body)
+        }
+        try? await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Cancelling a bridge request surfaces CancellationError")
+func bridgeClientCancellation() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let probe = BridgeClientGenerationProbe()
+    let server = try makeBridgeClientTestServer(
+        token: token,
+        generator: BridgeClientPausingGenerator(probe: probe)
+    )
+
+    do {
+        let port = try await startTCPServer(server)
+        let descriptor = try makeAFMBridgeTestDescriptor(
+            endpoint: .loopbackTCP(host: "127.0.0.1", port: port),
+            token: token
+        )
+        let client = try AFMBridgeClient(descriptor: descriptor)
+        let body = Data(#"{"messages":[{"role":"user","content":"Wait"}]}"#.utf8)
+        let request = Task { try await client.chatCompletions(body: body) }
+
+        await probe.waitUntilStarted()
+        request.cancel()
+        do {
+            _ = try await request.value
+            Issue.record("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+        try? await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+@Test("Bridge client descriptions and reflection redact the bearer token")
+func bridgeClientRedactsBearerToken() throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let descriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .loopbackTCP(host: "127.0.0.1", port: 19_760),
+        token: token
+    )
+    let client = try AFMBridgeClient(descriptor: descriptor)
+    var dumpOutput = ""
+    dump(client, to: &dumpOutput)
+
+    #expect(!String(describing: client).contains(token))
+    #expect(!String(reflecting: client).contains(token))
+    #expect(!dumpOutput.contains(token))
+    #expect(String(describing: client).contains("<redacted>"))
+}
+
+@Test("Bridge client refuses redirects before forwarding authorization")
+func bridgeClientRefusesRedirects() async throws {
+    let token = try AFMBridgeBearerTokenGenerator.generate()
+    let redirectServer = try BridgeClientRedirectServer.start()
+    let descriptor = try makeAFMBridgeTestDescriptor(
+        endpoint: .loopbackTCP(host: "127.0.0.1", port: redirectServer.port),
+        token: token
+    )
+
+    let response = try await AFMBridgeClient(descriptor: descriptor).health()
+    let requests = try await redirectServer.requests.value
+
+    #expect(response.statusCode == 302)
+    #expect(requests.count == 1)
+    #expect(requests[0].contains("Authorization: Bearer \(token)"))
+}
+
+private func makeBridgeClientTestServer(
+    token: String,
+    generator: any AFMChatCompletionGenerating = BridgeClientTestGenerator()
+) throws -> AFMHTTPServer {
+    try AFMHTTPServer(
+        configuration: .init(
+            endpoint: .tcp(host: "127.0.0.1", port: 0),
+            security: .init(bearerToken: token)
+        ),
+        catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+        clock: BridgeClientTestClock(),
+        generator: generator
+    )
+}
+
+private func startTCPServer(_ server: AFMHTTPServer) async throws -> Int {
+    let address = try await server.start()
+    guard case .tcp(_, let port) = address else {
+        throw BridgeClientTestError.unexpectedAddress
+    }
+    return port
+}
+
+private func makeBridgeClientTemporaryDirectory() throws -> String {
+    let path = (NSTemporaryDirectory() as NSString)
+        .appendingPathComponent("AFMBridgeClientTests-\(UUID().uuidString)")
+    guard Darwin.mkdir(path, mode_t(0o700)) == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    return path
+}
+
+private struct BridgeClientTestClock: AFMServerClock {
+    func unixTime() -> Int64 { 123 }
+}
+
+private struct BridgeClientTestGenerator: AFMChatCompletionGenerating {
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        .init(
+            content: "From bridge client",
+            usage: .init(inputTokenCount: 2, measurement: .estimated, scope: .response)
+        )
+    }
+}
+
+private struct BridgeClientPausingGenerator: AFMChatCompletionGenerating {
+    let probe: BridgeClientGenerationProbe?
+
+    init(probe: BridgeClientGenerationProbe? = nil) {
+        self.probe = probe
+    }
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        await probe?.markStarted()
+        try await ContinuousClock().sleep(for: .seconds(30))
+        return .init(
+            content: "Unexpected",
+            usage: .init(inputTokenCount: 1, measurement: .estimated, scope: .response)
+        )
+    }
+}
+
+private actor BridgeClientGenerationProbe {
+    private var started = false
+
+    func markStarted() {
+        started = true
+    }
+
+    func waitUntilStarted() async {
+        while !started {
+            await Task.yield()
+        }
+    }
+}
+
+private enum BridgeClientTestError: Error {
+    case unexpectedAddress
+}
+
+private struct BridgeClientRedirectServer: Sendable {
+    let port: Int
+    let requests: Task<[String], Error>
+
+    static func start() throws -> Self {
+        let (listener, port) = try makeListener()
+        let requests = Task.detached { () throws -> [String] in
+            defer { Darwin.close(listener) }
+            var received = [try acceptRequest(from: listener)]
+            let redirect = "HTTP/1.1 302 Found\r\n"
+                + "Location: http://127.0.0.1:\(port)/redirected\r\n"
+                + "Content-Length: 0\r\nConnection: close\r\n\r\n"
+            try respond(redirect, to: received[0].descriptor)
+            Darwin.close(received[0].descriptor)
+
+            var pollDescriptor = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
+            let pollResult = Darwin.poll(&pollDescriptor, 1, 500)
+            guard pollResult >= 0 else {
+                throw BridgeClientSocketError(operation: "poll redirect listener", code: errno)
+            }
+            if pollResult > 0 {
+                let request = try acceptRequest(from: listener)
+                received.append(request)
+                try respond(
+                    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+                    to: request.descriptor
+                )
+                Darwin.close(request.descriptor)
+            }
+            return received.map(\.text)
+        }
+        return Self(port: port, requests: requests)
+    }
+
+    private static func makeListener() throws -> (descriptor: CInt, port: Int) {
+        let listener = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard listener >= 0 else {
+            throw BridgeClientSocketError(operation: "create redirect listener", code: errno)
+        }
+        var shouldCloseListener = true
+        defer {
+            if shouldCloseListener {
+                Darwin.close(listener)
+            }
+        }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(listener, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw BridgeClientSocketError(operation: "bind redirect listener", code: errno)
+        }
+        guard Darwin.listen(listener, 2) == 0 else {
+            throw BridgeClientSocketError(operation: "listen for redirects", code: errno)
+        }
+
+        var addressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.getsockname(listener, $0, &addressLength)
+            }
+        }
+        guard nameResult == 0 else {
+            throw BridgeClientSocketError(operation: "read redirect listener address", code: errno)
+        }
+        let port = Int(UInt16(bigEndian: address.sin_port))
+        shouldCloseListener = false
+        return (listener, port)
+    }
+
+    private static func acceptRequest(from listener: CInt) throws -> (descriptor: CInt, text: String) {
+        let descriptor = Darwin.accept(listener, nil, nil)
+        guard descriptor >= 0 else {
+            throw BridgeClientSocketError(operation: "accept redirect request", code: errno)
+        }
+        do {
+            var data = Data()
+            var buffer = [UInt8](repeating: 0, count: 2_048)
+            let separator = Data("\r\n\r\n".utf8)
+            while data.range(of: separator) == nil, data.count < 65_536 {
+                let count = Darwin.read(descriptor, &buffer, buffer.count)
+                guard count > 0 else {
+                    throw BridgeClientSocketError(operation: "read redirect request", code: errno)
+                }
+                data.append(contentsOf: buffer.prefix(count))
+            }
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw BridgeClientSocketError(operation: "decode redirect request", code: EILSEQ)
+            }
+            return (descriptor, text)
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    private static func respond(_ response: String, to descriptor: CInt) throws {
+        let data = Data(response.utf8)
+        try data.withUnsafeBytes { bytes in
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.write(
+                    descriptor,
+                    bytes.baseAddress?.advanced(by: offset),
+                    bytes.count - offset
+                )
+                guard count > 0 else {
+                    throw BridgeClientSocketError(operation: "write redirect response", code: errno)
+                }
+                offset += count
+            }
+        }
+    }
+}
+
+private struct BridgeClientSocketError: Error {
+    let operation: String
+    let code: Int32
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
@@ -28,6 +28,40 @@ func chatRequestContentAndAlias() throws {
     #expect(request.maximumCompletionTokens == 42)
     #expect(request.temperature == 0.5)
     #expect(request.topP == 0.9)
+    #expect(!request.stream)
+    #expect(request.streamOptions == nil)
+}
+
+@Test("Chat requests accept Apple's streaming tool sentinel and usage option")
+func chatRequestAppleStreamingShape() throws {
+    let request = try decodeChatRequest(
+        """
+        {
+          "model": "system",
+          "messages": [{"role": "user", "content": "Hi"}],
+          "stream": true,
+          "stream_options": {"include_usage": true},
+          "tools": [],
+          "tool_choice": "auto"
+        }
+        """
+    )
+
+    #expect(request.stream)
+    #expect(request.streamOptions == .init(includeUsage: true))
+}
+
+@Test("Chat requests accept omitted and null tool sentinels")
+func chatRequestNullToolSentinels() throws {
+    let omitted = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"stream":true}"#
+    )
+    let null = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"stream":true,"tools":null,"tool_choice":null}"#
+    )
+
+    #expect(omitted.stream)
+    #expect(null.stream)
 }
 
 @Test("Chat requests reconstruct assistant tool calls and matching tool outputs")
@@ -44,8 +78,26 @@ func chatRequestToolHistory() throws {
 @Test(
     "Unsupported and unknown chat fields return precise validation errors",
     arguments: [
-        (#"{"messages":[{"role":"user","content":"Hi"}],"stream":true}"#, "stream", "unsupported_field"),
-        (#"{"messages":[{"role":"user","content":"Hi"}],"tools":[]}"#, "tools", "unsupported_field"),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function"}]}"#,
+            "tools",
+            "unsupported_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"tool_choice":"required"}"#,
+            "tool_choice",
+            "unsupported_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"stream_options":{"include_usage":true}}"#,
+            "stream_options",
+            "invalid_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"stream":true,"stream_options":{"extra":true}}"#,
+            "stream_options.extra",
+            "unknown_field"
+        ),
         (#"{"messages":[{"role":"user","content":"Hi"}],"response_format":{}}"#, "response_format", "unsupported_field"),
         (#"{"messages":[{"role":"user","content":"Hi"}],"surprise":1}"#, "surprise", "unknown_field"),
         (

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingIntegrationTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingIntegrationTests.swift
@@ -1,0 +1,310 @@
+import Darwin
+import Foundation
+import FoundationModelsKit
+import Testing
+@testable import AFMServer
+
+@Suite("Streaming chat transport")
+struct AFMChatStreamingIntegrationTests {
+    @Test("TCP streams the first SSE delta before generation completes")
+    func tcpStreamingFlushesIncrementally() async throws {
+        let probe = StagedProbe()
+        let server = try Self.server(generator: StagedGenerator(probe: probe))
+
+        do {
+            let address = try await server.start()
+            guard case .tcp(_, let port) = address else {
+                Issue.record("Expected a TCP address")
+                try await server.stop()
+                return
+            }
+            let descriptor = try Self.connect(port: port)
+            defer { Darwin.close(descriptor) }
+            try Self.write(Self.request(port: port), to: descriptor)
+
+            await probe.waitUntilFirstDeltaWasWritten()
+            let prefix = try Self.readUntil(#""content":"first""#, from: descriptor)
+            #expect(!(await probe.didComplete()))
+            #expect(prefix.lowercased().contains("content-type: text/event-stream"))
+            #expect(prefix.lowercased().contains("transfer-encoding: chunked"))
+            let header = prefix.split(separator: "\r\n\r\n", maxSplits: 1).first.map(String.init) ?? ""
+            #expect(!header.lowercased().contains("content-length:"))
+            #expect(prefix.contains(#""role":"assistant""#))
+
+            await probe.release()
+            let response = prefix + (try Self.readToEnd(from: descriptor))
+            #expect(response.hasPrefix("HTTP/1.1 200 OK"))
+            #expect(response.contains(#""content":"second""#))
+            #expect(response.contains(#""finish_reason":"stop""#))
+            #expect(response.contains(#""choices":[],"created":123"#))
+            #expect(response.contains(#""prompt_tokens":2"#))
+            #expect(response.contains("data: [DONE]\n\n"))
+            #expect(try Self.offset(of: #""content":"first""#, in: response) < Self.offset(of: #""content":"second""#, in: response))
+            #expect(try Self.offset(of: #""finish_reason":"stop""#, in: response) < Self.offset(of: "data: [DONE]", in: response))
+            #expect(await probe.didComplete())
+            try await server.stop()
+        } catch {
+            await probe.release()
+            try? await server.stop()
+            throw error
+        }
+    }
+
+    @Test("A TCP disconnect cancels streaming generation")
+    func tcpStreamingDisconnectCancellation() async throws {
+        let probe = CancellationProbe()
+        let server = try Self.server(generator: PausingGenerator(probe: probe))
+
+        do {
+            let address = try await server.start()
+            guard case .tcp(_, let port) = address else {
+                Issue.record("Expected a TCP address")
+                try await server.stop()
+                return
+            }
+            let descriptor = try Self.connect(port: port)
+            try Self.write(Self.request(port: port, close: false), to: descriptor)
+            await probe.waitUntilStarted()
+
+            var reset = linger(l_onoff: 1, l_linger: 0)
+            #expect(
+                setsockopt(
+                    descriptor,
+                    SOL_SOCKET,
+                    SO_LINGER,
+                    &reset,
+                    socklen_t(MemoryLayout<linger>.size)
+                ) == 0
+            )
+            #expect(Darwin.close(descriptor) == 0)
+            await probe.waitUntilCancelled()
+            try await server.stop()
+        } catch {
+            try? await server.stop()
+            throw error
+        }
+    }
+}
+
+private extension AFMChatStreamingIntegrationTests {
+    struct StagedGenerator: AFMChatCompletionGenerating {
+        let probe: StagedProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            Self.result
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            try await event(.contentDelta("first"))
+            await probe.markFirstDeltaWasWritten()
+            await probe.waitUntilReleased()
+            try await event(.contentDelta("second"))
+            await probe.markCompleted()
+            return Self.result
+        }
+
+        static let result = AFMChatGenerationResult(
+            content: "firstsecond",
+            usage: .init(
+                input: .init(totalTokenCount: 2),
+                output: .init(totalTokenCount: 2),
+                measurement: .estimated,
+                scope: .response
+            )
+        )
+    }
+
+    struct PausingGenerator: AFMChatCompletionGenerating {
+        let probe: CancellationProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            throw CancellationError()
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            try await withTaskCancellationHandler {
+                try await event(.contentDelta("first"))
+                await probe.markStarted()
+                try await ContinuousClock().sleep(for: .seconds(30))
+                return StagedGenerator.result
+            } onCancel: {
+                Task { await probe.markCancelled() }
+            }
+        }
+    }
+
+    actor StagedProbe {
+        private var firstDeltaWasWritten = false
+        private var completed = false
+        private var released = false
+        private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+        func markFirstDeltaWasWritten() { firstDeltaWasWritten = true }
+        func markCompleted() { completed = true }
+        func didComplete() -> Bool { completed }
+
+        func waitUntilFirstDeltaWasWritten() async {
+            while !firstDeltaWasWritten {
+                await Task.yield()
+            }
+        }
+
+        func waitUntilReleased() async {
+            guard !released else { return }
+            await withCheckedContinuation { releaseContinuation = $0 }
+        }
+
+        func release() {
+            released = true
+            releaseContinuation?.resume()
+            releaseContinuation = nil
+        }
+    }
+
+    actor CancellationProbe {
+        private var started = false
+        private var cancelled = false
+
+        func markStarted() { started = true }
+        func markCancelled() { cancelled = true }
+
+        func waitUntilStarted() async {
+            while !started {
+                await Task.yield()
+            }
+        }
+
+        func waitUntilCancelled() async {
+            while !cancelled {
+                await Task.yield()
+            }
+        }
+    }
+
+    struct TestClock: AFMServerClock {
+        func unixTime() -> Int64 { 123 }
+    }
+
+    struct SocketError: Error {
+        let operation: String
+        let code: Int32
+    }
+
+    static func server(generator: any AFMChatCompletionGenerating) throws -> AFMHTTPServer {
+        try AFMHTTPServer(
+            configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)),
+            catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+            clock: TestClock(),
+            generator: generator
+        )
+    }
+
+    static func request(port: Int, close: Bool = true) -> String {
+        let body = #"""
+        {"model":"system","messages":[{"role":"user","content":"Hi"}],"stream":true,
+        "stream_options":{"include_usage":true},"tools":[],"tool_choice":"auto"}
+        """#
+        var request = "POST /v1/chat/completions HTTP/1.1\r\n"
+        request += "Host: 127.0.0.1:\(port)\r\n"
+        request += "Content-Type: application/json\r\n"
+        request += "Content-Length: \(body.utf8.count)\r\n"
+        if close {
+            request += "Connection: close\r\n"
+        }
+        return request + "\r\n" + body
+    }
+
+    static func connect(port: Int) throws -> CInt {
+        let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw SocketError(operation: "socket", code: errno) }
+        var shouldClose = true
+        defer {
+            if shouldClose {
+                Darwin.close(descriptor)
+            }
+        }
+
+        var timeout = timeval(tv_sec: 2, tv_usec: 0)
+        guard setsockopt(
+            descriptor,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            &timeout,
+            socklen_t(MemoryLayout<timeval>.size)
+        ) == 0 else {
+            throw SocketError(operation: "setsockopt", code: errno)
+        }
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(port).bigEndian
+        guard "127.0.0.1".withCString({ inet_pton(AF_INET, $0, &address.sin_addr) }) == 1 else {
+            throw SocketError(operation: "inet_pton", code: errno)
+        }
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else { throw SocketError(operation: "connect", code: errno) }
+        shouldClose = false
+        return descriptor
+    }
+
+    static func write(_ request: String, to descriptor: CInt) throws {
+        try Array(request.utf8).withUnsafeBytes { buffer in
+            var sent = 0
+            while sent < buffer.count {
+                let count = Darwin.write(
+                    descriptor,
+                    buffer.baseAddress?.advanced(by: sent),
+                    buffer.count - sent
+                )
+                guard count > 0 else { throw SocketError(operation: "write", code: errno) }
+                sent += count
+            }
+        }
+    }
+
+    static func readUntil(_ needle: String, from descriptor: CInt) throws -> String {
+        var response = ""
+        while !response.contains(needle) {
+            let chunk = try readChunk(from: descriptor)
+            guard !chunk.isEmpty else { break }
+            response += chunk
+        }
+        return response
+    }
+
+    static func readToEnd(from descriptor: CInt) throws -> String {
+        var response = ""
+        while true {
+            let chunk = try readChunk(from: descriptor)
+            guard !chunk.isEmpty else { return response }
+            response += chunk
+        }
+    }
+
+    static func readChunk(from descriptor: CInt) throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 4_096)
+        let count = Darwin.read(descriptor, &bytes, bytes.count)
+        if count > 0 {
+            return String(bytes: bytes.prefix(count), encoding: .utf8) ?? ""
+        }
+        if count == 0 {
+            return ""
+        }
+        throw SocketError(operation: "read", code: errno)
+    }
+
+    static func offset(of needle: String, in value: String) throws -> Int {
+        let range = try #require(value.range(of: needle))
+        return value.distance(from: value.startIndex, to: range.lowerBound)
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
@@ -1,0 +1,386 @@
+import Foundation
+import FoundationModelsKit
+import NIOHTTP1
+import Testing
+@testable import AFMServer
+
+@Suite("Streaming chat completions")
+struct AFMChatStreamingServiceTests {
+    @Test("Streaming emits role, content deltas, finish, usage, and DONE")
+    func completeStreamShape() async throws {
+        let usage = ModelTokenUsage(
+            input: .init(totalTokenCount: 11, cachedTokenCount: 2),
+            output: .init(totalTokenCount: 7, reasoningTokenCount: 3),
+            measurement: .observed,
+            scope: .response
+        )
+        let generator = StreamingGenerator(
+            deltas: ["Hel", "lo"],
+            result: .init(content: "Hello", usage: usage)
+        )
+        let emissions = try await Self.collect(
+            Self.service(generator: generator),
+            body: Self.streamBody(includeUsage: true)
+        )
+
+        let firstEmission = try #require(emissions.first)
+        guard case .streamHead(let status, _) = firstEmission else {
+            Issue.record("Expected a streaming response head")
+            return
+        }
+        #expect(status == .ok)
+        let lastEmission = try #require(emissions.last)
+        guard case .streamEnd = lastEmission else {
+            Issue.record("Expected the stream to end")
+            return
+        }
+
+        let bodies = Self.streamBodies(emissions)
+        #expect(bodies.last == "data: [DONE]\n\n")
+        let chunks = try bodies.dropLast().map(Self.eventObject)
+        #expect(chunks.count == 5)
+
+        let firstChoice = try Self.choice(in: chunks[0])
+        let firstDelta = try #require(firstChoice["delta"] as? [String: Any])
+        #expect(firstDelta["role"] as? String == "assistant")
+        #expect(firstDelta["content"] == nil)
+        #expect(firstChoice["finish_reason"] is NSNull)
+
+        #expect(try Self.content(in: chunks[1]) == "Hel")
+        #expect(try Self.content(in: chunks[2]) == "lo")
+
+        let finishChoice = try Self.choice(in: chunks[3])
+        #expect(finishChoice["finish_reason"] as? String == "stop")
+        #expect((finishChoice["delta"] as? [String: Any])?.isEmpty == true)
+
+        #expect((chunks[4]["choices"] as? [Any])?.isEmpty == true)
+        let usageJSON = try #require(chunks[4]["usage"] as? [String: Any])
+        #expect(usageJSON["prompt_tokens"] as? Int == 11)
+        #expect(usageJSON["completion_tokens"] as? Int == 7)
+        #expect(usageJSON["total_tokens"] as? Int == 18)
+        #expect(usageJSON["afm_measurement"] as? String == "observed")
+        let promptDetails = try #require(usageJSON["prompt_tokens_details"] as? [String: Any])
+        let completionDetails = try #require(usageJSON["completion_tokens_details"] as? [String: Any])
+        #expect(promptDetails["cached_tokens"] as? Int == 2)
+        #expect(completionDetails["reasoning_tokens"] as? Int == 3)
+
+        let identifiers = chunks.compactMap { $0["id"] as? String }
+        #expect(Set(identifiers).count == 1)
+        #expect(identifiers.first?.hasPrefix("chatcmpl-") == true)
+        #expect(chunks.allSatisfy { $0["object"] as? String == "chat.completion.chunk" })
+        #expect(chunks.allSatisfy { $0["created"] as? Int == 123 })
+        #expect(chunks.allSatisfy { $0["model"] as? String == "system" })
+    }
+
+    @Test("Streaming omits usage unless requested and preserves length finish reason")
+    func streamWithoutUsage() async throws {
+        let generator = StreamingGenerator(
+            deltas: ["Done"],
+            result: .init(content: "Done", finishReason: .length, usage: Self.standardUsage())
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: Self.streamBody())
+        let bodies = Self.streamBodies(emissions)
+        let chunks = try bodies.dropLast().map(Self.eventObject)
+
+        #expect(chunks.count == 3)
+        #expect(try Self.choice(in: chunks[2])["finish_reason"] as? String == "length")
+        #expect(chunks.allSatisfy { !((($0["choices"] as? [Any])?.isEmpty) ?? false) })
+        #expect(bodies.last == "data: [DONE]\n\n")
+    }
+
+    @Test("Streaming refusals finish with content_filter")
+    func streamRefusal() async throws {
+        let generator = StreamingGenerator(
+            deltas: [],
+            result: .init(
+                content: nil,
+                refusal: "Declined",
+                finishReason: .contentFilter,
+                usage: Self.standardUsage()
+            )
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: Self.streamBody())
+        let chunks = try Self.streamBodies(emissions).dropLast().map(Self.eventObject)
+
+        #expect(chunks.count == 2)
+        #expect(try Self.choice(in: chunks[1])["finish_reason"] as? String == "content_filter")
+    }
+
+    @Test("Streaming awaits each emitted body before requesting the next delta")
+    func streamBackpressure() async throws {
+        let probe = BackpressureProbe()
+        let blocker = StreamBlocker()
+        let recorder = EmissionRecorder()
+        let chatService = Self.service(generator: BackpressureGenerator(probe: probe))
+        let task = Task {
+            try await chatService.writeResponse(for: Self.streamBody()) { emission in
+                await recorder.record(emission)
+                if case .streamBody(let data) = emission,
+                   String(bytes: data, encoding: .utf8)?.contains(#""content":"first""#) == true {
+                    await blocker.block()
+                }
+            }
+        }
+
+        await probe.waitUntilFirstAttempt()
+        await blocker.waitUntilBlocked()
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+        #expect(!(await probe.didAttemptSecond()))
+
+        await blocker.release()
+        try await task.value
+        #expect(await probe.didAttemptSecond())
+        #expect(Self.streamBodies(await recorder.snapshot()).contains { $0.contains(#""content":"second""#) })
+    }
+
+    @Test("A streaming timeout cancels generation and stays inside SSE framing")
+    func streamTimeout() async throws {
+        let probe = CancellationProbe()
+        let chatService = Self.service(
+            generator: PausingGenerator(probe: probe),
+            policy: .init(maximumConcurrentGenerations: 1, timeoutSeconds: 0.01)
+        )
+        let emissions = try await Self.collect(chatService, body: Self.streamBody())
+        await probe.waitUntilCancelled()
+
+        let firstEmission = try #require(emissions.first)
+        guard case .streamHead = firstEmission else {
+            Issue.record("Expected timeout after the SSE response started")
+            return
+        }
+        let lastEmission = try #require(emissions.last)
+        guard case .streamEnd = lastEmission else {
+            Issue.record("Expected the timed-out SSE response to end")
+            return
+        }
+        let errorEvent = try #require(Self.streamBodies(emissions).last)
+        let error = try Self.eventObject(errorEvent)
+        let errorBody = try #require(error["error"] as? [String: Any])
+        #expect(errorBody["code"] as? String == "model_timeout")
+
+        let retry = try await Self.collect(chatService, body: Self.streamBody())
+        let retryFirstEmission = try #require(retry.first)
+        guard case .streamHead = retryFirstEmission else {
+            Issue.record("Expected the generation permit to be released after timeout")
+            return
+        }
+    }
+
+    @Test("Streaming validation errors stay as JSON before the SSE response starts")
+    func streamValidationError() async throws {
+        let generator = StreamingGenerator(deltas: [], result: Self.standardResult())
+        let body = Data(
+            #"{"messages":[{"role":"user","content":"Hi"}],"stream":true,"tools":[{}]}"#.utf8
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: body)
+
+        #expect(emissions.count == 1)
+        guard case .fixed(let response) = try #require(emissions.first) else {
+            Issue.record("Expected a fixed JSON validation response")
+            return
+        }
+        #expect(response.status == .badRequest)
+        let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        #expect(error["code"] as? String == "unsupported_field")
+        #expect(error["param"] as? String == "tools")
+    }
+}
+
+private extension AFMChatStreamingServiceTests {
+    actor StreamingGenerator: AFMChatCompletionGenerating {
+        let deltas: [String]
+        let result: AFMChatGenerationResult
+
+        init(deltas: [String], result: AFMChatGenerationResult) {
+            self.deltas = deltas
+            self.result = result
+        }
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            result
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            for delta in deltas {
+                try await event(.contentDelta(delta))
+            }
+            return result
+        }
+    }
+
+    struct BackpressureGenerator: AFMChatCompletionGenerating {
+        let probe: BackpressureProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            AFMChatStreamingServiceTests.standardResult()
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            await probe.markFirstAttempt()
+            try await event(.contentDelta("first"))
+            await probe.markSecondAttempt()
+            try await event(.contentDelta("second"))
+            return AFMChatStreamingServiceTests.standardResult()
+        }
+    }
+
+    struct PausingGenerator: AFMChatCompletionGenerating {
+        let probe: CancellationProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            await probe.markStarted()
+            return try await withTaskCancellationHandler {
+                try await ContinuousClock().sleep(for: .seconds(30))
+                return AFMChatStreamingServiceTests.standardResult()
+            } onCancel: {
+                Task { await probe.markCancelled() }
+            }
+        }
+    }
+
+    actor EmissionRecorder {
+        private var emissions: [AFMHTTPEmission] = []
+
+        func record(_ emission: AFMHTTPEmission) {
+            emissions.append(emission)
+        }
+
+        func snapshot() -> [AFMHTTPEmission] {
+            emissions
+        }
+    }
+
+    actor BackpressureProbe {
+        private var firstAttempted = false
+        private var secondAttempted = false
+
+        func markFirstAttempt() { firstAttempted = true }
+        func markSecondAttempt() { secondAttempted = true }
+        func didAttemptSecond() -> Bool { secondAttempted }
+
+        func waitUntilFirstAttempt() async {
+            while !firstAttempted {
+                await Task.yield()
+            }
+        }
+    }
+
+    actor StreamBlocker {
+        private var isBlocked = false
+        private var isReleased = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func block() async {
+            isBlocked = true
+            guard !isReleased else { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func waitUntilBlocked() async {
+            while !isBlocked {
+                await Task.yield()
+            }
+        }
+
+        func release() {
+            isReleased = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    actor CancellationProbe {
+        private var cancelled = false
+
+        func markStarted() {}
+        func markCancelled() { cancelled = true }
+
+        func waitUntilCancelled() async {
+            while !cancelled {
+                await Task.yield()
+            }
+        }
+    }
+
+    struct TestClock: AFMServerClock {
+        func unixTime() -> Int64 { 123 }
+    }
+
+    static func service(
+        generator: any AFMChatCompletionGenerating,
+        policy: AFMServerGenerationPolicy = .init()
+    ) -> AFMChatCompletionService {
+        AFMChatCompletionService(
+            catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+            generator: generator,
+            clock: TestClock(),
+            policy: policy
+        )
+    }
+
+    static func collect(
+        _ service: AFMChatCompletionService,
+        body: Data
+    ) async throws -> [AFMHTTPEmission] {
+        let recorder = EmissionRecorder()
+        try await service.writeResponse(for: body) { emission in
+            await recorder.record(emission)
+        }
+        return await recorder.snapshot()
+    }
+
+    static func streamBody(includeUsage: Bool = false) -> Data {
+        let options = includeUsage ? #", "stream_options":{"include_usage":true}"# : ""
+        return Data(
+            #"{"model":"system","messages":[{"role":"user","content":"Hi"}],"stream":true\#(options)}"#.utf8
+        )
+    }
+
+    static func streamBodies(_ emissions: [AFMHTTPEmission]) -> [String] {
+        emissions.compactMap { emission in
+            guard case .streamBody(let data) = emission else { return nil }
+            return String(bytes: data, encoding: .utf8)
+        }
+    }
+
+    static func eventObject(_ event: String) throws -> [String: Any] {
+        let prefix = "data: "
+        #expect(event.hasPrefix(prefix))
+        let json = event.dropFirst(prefix.count).dropLast(2)
+        return try #require(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+    }
+
+    static func choice(in chunk: [String: Any]) throws -> [String: Any] {
+        let choices = try #require(chunk["choices"] as? [[String: Any]])
+        return try #require(choices.first)
+    }
+
+    static func content(in chunk: [String: Any]) throws -> String? {
+        let delta = try #require(try choice(in: chunk)["delta"] as? [String: Any])
+        return delta["content"] as? String
+    }
+
+    static func standardUsage() -> ModelTokenUsage {
+        .init(
+            input: .init(totalTokenCount: 1),
+            output: .init(totalTokenCount: 1),
+            measurement: .estimated,
+            scope: .response
+        )
+    }
+
+    static func standardResult() -> AFMChatGenerationResult {
+        .init(content: "firstsecond", usage: standardUsage())
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
@@ -102,8 +102,12 @@ struct AFMChatStreamingServiceTests {
         let emissions = try await Self.collect(Self.service(generator: generator), body: Self.streamBody())
         let chunks = try Self.streamBodies(emissions).dropLast().map(Self.eventObject)
 
-        #expect(chunks.count == 2)
-        #expect(try Self.choice(in: chunks[1])["finish_reason"] as? String == "content_filter")
+        #expect(chunks.count == 3)
+        let refusalChoice = try Self.choice(in: chunks[1])
+        let refusalDelta = try #require(refusalChoice["delta"] as? [String: Any])
+        #expect(refusalDelta["refusal"] as? String == "Declined")
+        #expect(refusalChoice["finish_reason"] is NSNull)
+        #expect(try Self.choice(in: chunks[2])["finish_reason"] as? String == "content_filter")
     }
 
     @Test("Streaming awaits each emitted body before requesting the next delta")

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -106,7 +106,6 @@ func tcpPipelinedChatCompletion() async throws {
         let response = try await responseTask.value
         #expect(response.components(separatedBy: "HTTP/1.1 200 OK").count == 2)
         #expect(response.contains(#""object":"chat.completion""#))
-        #expect(response.contains("connection: close"))
         #expect(!response.contains(#""status":"afm serve is running""#))
         #expect(!response.contains("HTTP/1.1 400 Bad Request"))
         try await server.stop()

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMSnapshotDeltaAccumulatorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMSnapshotDeltaAccumulatorTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import AFMServer
+
+@Test("Snapshot accumulation emits only new cumulative content")
+func snapshotAccumulatorDeltas() throws {
+    var accumulator = AFMSnapshotDeltaAccumulator()
+
+    #expect(try accumulator.append(snapshot: "Hel") == "Hel")
+    #expect(try accumulator.append(snapshot: "Hello") == "lo")
+    #expect(try accumulator.append(snapshot: "Hello") == "")
+    #expect(accumulator.content == "Hello")
+}
+
+@Test("Snapshot accumulation preserves extended grapheme clusters")
+func snapshotAccumulatorUnicode() throws {
+    var accumulator = AFMSnapshotDeltaAccumulator()
+
+    #expect(try accumulator.append(snapshot: "Hello 👨‍👩‍👧‍👦") == "Hello 👨‍👩‍👧‍👦")
+    #expect(try accumulator.append(snapshot: "Hello 👨‍👩‍👧‍👦!") == "!")
+}
+
+@Test("Snapshot accumulation rejects rewritten content")
+func snapshotAccumulatorRejectsNonMonotonicContent() throws {
+    var accumulator = AFMSnapshotDeltaAccumulator()
+    _ = try accumulator.append(snapshot: "Hello")
+
+    #expect(throws: AFMSnapshotDeltaAccumulator.AccumulationError.nonMonotonicSnapshot) {
+        try accumulator.append(snapshot: "Hallo")
+    }
+}

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -178,7 +178,8 @@ afm feedback export --prompt "What is the capital of France?" --sentiment positi
 ### Start the local server
 
 `afm serve` starts a transport for local integrations. It provides `GET /health`,
-`GET /v1/models`, and non-streaming `POST /v1/chat/completions`.
+`GET /v1/models`, and OpenAI-compatible `POST /v1/chat/completions`, including
+incremental server-sent event streaming.
 
 ```bash
 afm serve
@@ -187,14 +188,20 @@ curl http://127.0.0.1:1976/v1/models
 curl http://127.0.0.1:1976/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"system","messages":[{"role":"user","content":"Hello"}]}'
+curl -N http://127.0.0.1:1976/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"system","messages":[{"role":"user","content":"Hello"}],"stream":true,"stream_options":{"include_usage":true},"tools":[],"tool_choice":"auto"}'
 ```
 
 Chat requests are stateless: send the complete system, developer, user,
 assistant, and tool history each time. String content and typed text parts are
 supported, along with `temperature`, `top_p`, `max_completion_tokens`, and the
-legacy `max_tokens` alias. Streaming, image parts, response formats, and
-client-defined tools return a precise `400` until their dedicated endpoints are
-implemented. Responses include input/output usage plus an `afm_measurement`
+legacy `max_tokens` alias. Streaming emits assistant role and content deltas,
+a terminal finish reason, and `[DONE]`. Set `stream_options.include_usage` to
+receive a final empty-choices usage chunk. The empty `tools: []` and
+`tool_choice: "auto"` sentinels used by Apple's client are accepted; client-defined
+tools, image parts, and response formats return a precise `400` until their
+dedicated endpoints are implemented. Responses include input/output usage plus an `afm_measurement`
 value of `observed`, `tokenized`, or `estimated` so fallback counts are never
 presented as runtime observation.
 

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -53,6 +53,10 @@ afm tag run --prompt "A joyful dog playing in a sunny park."
 afm schema run typed-person --input "Alex Rivera is a designer in Berlin."
 afm schema run custom --schema person-card --schema-dir .afm/schemas --input @person.txt
 afm serve
+afm bridge prepare
+afm bridge ensure
+afm bridge status
+afm bridge chat --model pcc --prompt "Explain this change."
 ```
 
 ## Sample Workflows
@@ -210,6 +214,47 @@ afm serve --socket /tmp/afm.sock
 A non-loopback binding requires both `--allow-network` and a bearer token. Unix
 sockets are created with mode `0600`, and `afm` refuses to replace regular files,
 symlinks, or active sockets at the requested path.
+
+### Use the signed Agent Bridge
+
+`afm bridge` lets terminals, scripts, and coding agents use Foundation Lab as a
+signed local host. The client itself needs no TTY and does not need to inherit
+the app's entitlements. Foundation Lab performs the model request and exposes
+only an authenticated local endpoint.
+
+Prepare the shared directory once, choose `~/.afm` in Foundation Lab's Agent
+Bridge settings, and start the bridge:
+
+```bash
+afm bridge prepare
+afm bridge ensure
+afm bridge models
+afm bridge chat --prompt "Summarize this repository."
+afm bridge chat --model pcc --max-tokens 512 --temperature 0.2 --prompt @prompt.md
+```
+
+The default descriptor is `~/.afm/bridge/connection.json`. Use `--base` to
+prepare or inspect another shared base directory, or `--descriptor` to read a
+specific descriptor file:
+
+```bash
+afm bridge status --descriptor /absolute/path/to/connection.json
+```
+
+`afm bridge ensure` (also available as `afm bridge launch`) first checks the
+authenticated health endpoint. If the host is not reachable, it launches
+Foundation Lab in the background with `/usr/bin/open -gj` and waits up to 20
+seconds for the bridge. Use `--app /path/to/Foundation Lab.app` for a specific
+build and `--timeout` to adjust the bounded wait.
+
+The descriptor is validated as a current-user-only regular file. Its bearer
+credential is used internally and is never included in text, JSON, verbose, or
+dry-run output. Missing, stale, and unreachable hosts fail with instructions to
+restart Agent Bridge instead of waiting for terminal interaction.
+
+Preparation never changes permissions on an existing base directory. Existing
+directories must already be owned by the current user with mode `0700`; unsafe
+or overly broad modes are rejected without modification.
 
 ## Files, Pipes, And Automation
 

--- a/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/AppMain.swift
@@ -20,7 +20,7 @@ struct AFMEntryPoint {
 
         let rootCommands = [
             "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve",
-            "help", "version"
+            "bridge", "help", "version"
         ]
         if !rootCommands.contains(firstArgument) {
             if let suggestion = suggestRootCommand(for: firstArgument) {
@@ -40,7 +40,8 @@ struct AFMEntryPoint {
             "schema": ["list", "run"],
             "tool": ["inspect", "validate", "call"],
             "transcript": ["export"],
-            "feedback": ["export"]
+            "feedback": ["export"],
+            "bridge": ["prepare", "ensure", "launch", "status", "models", "chat"]
         ]
 
         guard let knownSubcommands = subcommands[firstArgument],

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeChatResponse.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeChatResponse.swift
@@ -1,0 +1,76 @@
+import FoundationModelsKit
+
+struct AFMBridgeChatResponse: Decodable, Sendable {
+    struct Choice: Decodable, Sendable {
+        struct Message: Decodable, Sendable {
+            let role: String
+            let content: String?
+            let refusal: String?
+        }
+
+        let index: Int
+        let message: Message
+        let finishReason: String
+
+        private enum CodingKeys: String, CodingKey {
+            case index
+            case message
+            case finishReason = "finish_reason"
+        }
+    }
+
+    struct Usage: Decodable, Sendable {
+        struct PromptDetails: Decodable, Sendable {
+            let cachedTokens: Int?
+
+            private enum CodingKeys: String, CodingKey {
+                case cachedTokens = "cached_tokens"
+            }
+        }
+
+        struct CompletionDetails: Decodable, Sendable {
+            let reasoningTokens: Int?
+
+            private enum CodingKeys: String, CodingKey {
+                case reasoningTokens = "reasoning_tokens"
+            }
+        }
+
+        let promptTokens: Int
+        let completionTokens: Int
+        let totalTokens: Int
+        let promptDetails: PromptDetails
+        let completionDetails: CompletionDetails
+        let measurement: ModelTokenUsage.Measurement
+        let scope: ModelTokenUsage.Scope
+
+        var tokenUsage: ModelTokenUsage {
+            ModelTokenUsage(
+                input: .init(totalTokenCount: promptTokens, cachedTokenCount: promptDetails.cachedTokens),
+                output: .init(
+                    totalTokenCount: completionTokens,
+                    reasoningTokenCount: completionDetails.reasoningTokens
+                ),
+                measurement: measurement,
+                scope: scope
+            )
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case completionTokens = "completion_tokens"
+            case totalTokens = "total_tokens"
+            case promptDetails = "prompt_tokens_details"
+            case completionDetails = "completion_tokens_details"
+            case measurement = "afm_measurement"
+            case scope = "afm_scope"
+        }
+    }
+
+    let id: String
+    let object: String
+    let created: Int64
+    let model: String
+    let choices: [Choice]
+    let usage: Usage
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandConnection.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandConnection.swift
@@ -55,6 +55,8 @@ struct AFMBridgeCommandConnection: Sendable {
         let response: AFMBridgeClientResponse
         do {
             response = try await operation()
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             if !bridgeProcessIsRunning(descriptor.processIdentifier) {
                 throw AFMBridgeCommandError.hostStopped(descriptorPath: paths.descriptorPath)

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandConnection.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandConnection.swift
@@ -1,0 +1,99 @@
+import AFMServer
+import Darwin
+import Foundation
+
+struct AFMBridgeCommandConnection: Sendable {
+    let paths: ResolvedBridgePaths
+    let descriptor: AFMBridgeConnectionDescriptor
+    let client: AFMBridgeClient
+
+    static func connect(paths: ResolvedBridgePaths) throws -> Self {
+        let descriptor = try paths.readDescriptor()
+        do {
+            return try Self(
+                paths: paths,
+                descriptor: descriptor,
+                client: AFMBridgeClient(descriptor: descriptor)
+            )
+        } catch {
+            throw AFMBridgeCommandError.invalidDescriptor(
+                descriptorPath: paths.descriptorPath,
+                reason: error.localizedDescription
+            )
+        }
+    }
+
+    var endpointDescription: String {
+        switch descriptor.endpoint {
+        case .unixSocket(let path):
+            return "unix://\(path)"
+        case .loopbackTCP(let host, let port):
+            let renderedHost = host.contains(":") ? "[\(host)]" : host
+            return "http://\(renderedHost):\(port)"
+        }
+    }
+
+    func health() async throws -> AFMBridgeHealthResponse {
+        try await decodeResponse({ try await client.health() }, as: AFMBridgeHealthResponse.self)
+    }
+
+    func models() async throws -> AFMBridgeModelsResponse {
+        try await decodeResponse({ try await client.models() }, as: AFMBridgeModelsResponse.self)
+    }
+
+    func chat(body: Data) async throws -> AFMBridgeChatResponse {
+        try await decodeResponse(
+            { try await client.chatCompletions(body: body) },
+            as: AFMBridgeChatResponse.self
+        )
+    }
+
+    private func decodeResponse<Response: Decodable>(
+        _ operation: () async throws -> AFMBridgeClientResponse,
+        as type: Response.Type
+    ) async throws -> Response {
+        let response: AFMBridgeClientResponse
+        do {
+            response = try await operation()
+        } catch {
+            if !bridgeProcessIsRunning(descriptor.processIdentifier) {
+                throw AFMBridgeCommandError.hostStopped(descriptorPath: paths.descriptorPath)
+            }
+            throw AFMBridgeCommandError.hostUnreachable(
+                endpoint: endpointDescription,
+                reason: error.localizedDescription
+            )
+        }
+
+        guard (200..<300).contains(response.statusCode) else {
+            let envelope = try? JSONDecoder().decode(AFMBridgeAPIErrorEnvelope.self, from: response.body)
+            throw AFMBridgeCommandError.apiFailure(
+                statusCode: response.statusCode,
+                message: envelope?.error.message ?? "The host rejected the request.",
+                code: envelope?.error.code
+            )
+        }
+
+        do {
+            return try JSONDecoder().decode(type, from: response.body)
+        } catch {
+            throw AFMBridgeCommandError.invalidResponse(endpoint: endpointDescription)
+        }
+    }
+}
+
+private struct AFMBridgeAPIErrorEnvelope: Decodable {
+    struct Detail: Decodable {
+        let message: String
+        let code: String?
+    }
+
+    let error: Detail
+}
+
+private func bridgeProcessIsRunning(_ processIdentifier: Int32) -> Bool {
+    if Darwin.kill(processIdentifier, 0) == 0 {
+        return true
+    }
+    return errno == EPERM
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandConnection.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandConnection.swift
@@ -9,6 +9,13 @@ struct AFMBridgeCommandConnection: Sendable {
 
     static func connect(paths: ResolvedBridgePaths) throws -> Self {
         let descriptor = try paths.readDescriptor()
+        return try connect(paths: paths, descriptor: descriptor)
+    }
+
+    static func connect(
+        paths: ResolvedBridgePaths,
+        descriptor: AFMBridgeConnectionDescriptor
+    ) throws -> Self {
         do {
             return try Self(
                 paths: paths,

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandError.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeCommandError.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum AFMBridgeCommandError: LocalizedError, Sendable {
+    case hostMissing(descriptorPath: String)
+    case hostStopped(descriptorPath: String)
+    case hostUnreachable(endpoint: String, reason: String)
+    case invalidDescriptor(descriptorPath: String, reason: String)
+    case invalidResponse(endpoint: String)
+    case apiFailure(statusCode: Int, message: String, code: String?)
+    case launchFailed(app: String, reason: String)
+    case launchTimedOut(app: String, timeoutSeconds: Double, descriptorPath: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .hostMissing(let descriptorPath):
+            "No Foundation Lab bridge host is registered at \(descriptorPath). "
+                + "Run 'afm bridge prepare', then launch Foundation Lab and start Agent Bridge in Settings."
+        case .hostStopped(let descriptorPath):
+            "The Foundation Lab bridge descriptor at \(descriptorPath) is stale. "
+                + "Launch or restart Foundation Lab; its persisted Agent Bridge setting will start the host."
+        case .hostUnreachable(let endpoint, let reason):
+            "Could not reach the Foundation Lab bridge at \(endpoint): \(reason) "
+                + "Launch or restart Foundation Lab; its persisted Agent Bridge setting will start the host."
+        case .invalidDescriptor(let descriptorPath, let reason):
+            "The Foundation Lab bridge descriptor at \(descriptorPath) is invalid: \(reason) Restart Agent Bridge to replace it safely."
+        case .invalidResponse(let endpoint):
+            "Foundation Lab returned an invalid bridge response from \(endpoint). Update Foundation Lab and afm to compatible versions."
+        case .apiFailure(let statusCode, let message, let code):
+            "Foundation Lab bridge request failed with HTTP \(statusCode): \(message)\(code.map { " [\($0)]" } ?? "")"
+        case .launchFailed(let app, let reason):
+            "Could not launch Foundation Lab using '\(app)': \(reason)"
+        case .launchTimedOut(let app, let timeoutSeconds, let descriptorPath):
+            "Launched '\(app)', but no reachable Foundation Lab bridge appeared at \(descriptorPath) "
+                + "within \(timeoutSeconds) seconds. Open Foundation Lab Settings and verify Agent Bridge is enabled."
+        }
+    }
+
+    var permitsHostLaunchRecovery: Bool {
+        switch self {
+        case .hostMissing, .hostStopped, .hostUnreachable:
+            true
+        case .apiFailure(let statusCode, _, _):
+            statusCode == 401
+        case .invalidDescriptor, .invalidResponse, .launchFailed, .launchTimedOut:
+            false
+        }
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeHealthResponse.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeHealthResponse.swift
@@ -1,0 +1,9 @@
+struct AFMBridgeHealthResponse: Decodable, Sendable {
+    struct Model: Codable, Sendable {
+        let name: String
+        let available: Bool
+    }
+
+    let status: String
+    let models: [Model]
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeModelsResponse.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMBridgeModelsResponse.swift
@@ -1,0 +1,18 @@
+struct AFMBridgeModelsResponse: Decodable, Sendable {
+    struct Model: Codable, Sendable {
+        let id: String
+        let object: String
+        let created: Int64
+        let owner: String
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case object
+            case created
+            case owner = "owned_by"
+        }
+    }
+
+    let object: String
+    let data: [Model]
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/AFMRootCommand.swift
@@ -22,7 +22,8 @@ struct AFMRootCommand: AsyncParsableCommand {
             ToolCommand.self,
             TranscriptCommand.self,
             FeedbackCommand.self,
-            ServeCommand.self
+            ServeCommand.self,
+            BridgeCommand.self
         ]
     )
 
@@ -43,7 +44,8 @@ struct AFMRootCommand: AsyncParsableCommand {
             name: Self.configuration.commandName ?? "afm",
             summary: "Workflow-first CLI for Foundation Models sessions, schemas, tools, exports, and local services.",
             commands: [
-                "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve"
+                "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve",
+                "bridge"
             ]
         )
         let human: String

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeChatCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeChatCommand.swift
@@ -1,0 +1,157 @@
+import ArgumentParser
+import Foundation
+import FoundationModelsKit
+
+struct BridgeChatCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "chat",
+        abstract: "Send one prompt through the signed Foundation Lab bridge host."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var connection: BridgeConnectionOptions
+    @OptionGroup var promptInput: PromptInputOptions
+
+    @Option(name: .long, help: "Bridge model identifier. Defaults to system.")
+    var model = "system"
+
+    @Option(name: .long, help: "Sampling temperature between 0 and 1.")
+    var temperature: Double?
+
+    @Option(name: .customLong("max-tokens"), help: "Maximum number of response tokens.")
+    var maximumTokens: Int?
+
+    @Option(name: .customLong("top-p"), help: "Nucleus sampling threshold greater than 0 and at most 1.")
+    var topP: Double?
+
+    mutating func run() async throws {
+        let output = try options.resolvedOutput()
+        try await executeBridgeCommand(output: output) {
+            let paths = try connection.resolve()
+            let prompt = try requiredResolvedInput(promptInput.resolve())
+            let request = try resolvedRequest(prompt: prompt.value)
+
+            if options.dryRun {
+                try CLIOutput.emit(
+                    payload: BridgeChatDryRunPayload(request: request, prompt: prompt, paths: paths),
+                    human: "[dry-run] afm bridge chat\nModel: \(request.model)\nPrompt: \(prompt.value)",
+                    options: output
+                )
+                return
+            }
+
+            let body = try JSONEncoder().encode(request)
+            let result = try await performBridgeRequest(paths: paths) { try await $0.chat(body: body) }
+            guard let choice = result.response.choices.sorted(by: { $0.index < $1.index }).first,
+                  let renderedResponse = nonemptyBridgeResponse(choice.message) else {
+                throw AFMBridgeCommandError.invalidResponse(endpoint: result.host.endpointDescription)
+            }
+            var lines = [renderedResponse]
+            if options.verbose {
+                lines.append("")
+                lines.append("Model: \(result.response.model)")
+                lines.append("Finish reason: \(choice.finishReason)")
+                lines.append(
+                    "Tokens: \(result.response.usage.totalTokens) (\(result.response.usage.measurement.rawValue))"
+                )
+            }
+            try CLIOutput.emit(
+                payload: BridgeChatPayload(response: result.response, choice: choice),
+                human: lines.joined(separator: "\n"),
+                options: output
+            )
+        }
+    }
+
+    private func resolvedRequest(prompt: String) throws -> BridgeChatRequest {
+        let resolvedModel = try validatedNonEmpty(model, optionName: "--model")
+        if let temperature, !temperature.isFinite || !(0...1).contains(temperature) {
+            throw ValidationError("--temperature must be between 0 and 1")
+        }
+        if let maximumTokens, maximumTokens <= 0 {
+            throw ValidationError("--max-tokens must be greater than 0")
+        }
+        if let topP, !topP.isFinite || topP <= 0 || topP > 1 {
+            throw ValidationError("--top-p must be greater than 0 and at most 1")
+        }
+        return BridgeChatRequest(
+            model: resolvedModel,
+            messages: [.init(role: "user", content: prompt)],
+            temperature: temperature,
+            topP: topP,
+            maximumCompletionTokens: maximumTokens
+        )
+    }
+}
+
+private struct BridgeChatRequest: Encodable {
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+
+    let model: String
+    let messages: [Message]
+    let temperature: Double?
+    let topP: Double?
+    let maximumCompletionTokens: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case temperature
+        case topP = "top_p"
+        case maximumCompletionTokens = "max_completion_tokens"
+    }
+}
+
+private struct BridgeChatDryRunPayload: Encodable {
+    let status = "dry_run"
+    let command = "bridge chat"
+    let descriptor: String
+    let model: String
+    let prompt: String
+    let promptFile: String?
+    let temperature: Double?
+    let topP: Double?
+    let maximumCompletionTokens: Int?
+
+    init(request: BridgeChatRequest, prompt: ResolvedTextInput, paths: ResolvedBridgePaths) {
+        descriptor = paths.descriptorPath
+        model = request.model
+        self.prompt = prompt.value
+        promptFile = prompt.file
+        temperature = request.temperature
+        topP = request.topP
+        maximumCompletionTokens = request.maximumCompletionTokens
+    }
+}
+
+private struct BridgeChatPayload: Encodable {
+    let command = "bridge chat"
+    let id: String
+    let model: String
+    let response: String?
+    let refusal: String?
+    let finishReason: String
+    let tokenUsage: ModelTokenUsage
+
+    init(response: AFMBridgeChatResponse, choice: AFMBridgeChatResponse.Choice) {
+        id = response.id
+        model = response.model
+        self.response = choice.message.content
+        refusal = choice.message.refusal
+        finishReason = choice.finishReason
+        tokenUsage = response.usage.tokenUsage
+    }
+}
+
+private func nonemptyBridgeResponse(_ message: AFMBridgeChatResponse.Choice.Message) -> String? {
+    for candidate in [message.content, message.refusal] {
+        if let candidate {
+            let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+    }
+    return nil
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeChatCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeChatCommand.swift
@@ -41,7 +41,12 @@ struct BridgeChatCommand: AsyncParsableCommand {
             }
 
             let body = try JSONEncoder().encode(request)
-            let result = try await performBridgeRequest(paths: paths) { try await $0.chat(body: body) }
+            let result = try await performBridgeRequest(
+                paths: paths,
+                retryAfterDescriptorRotation: false
+            ) {
+                try await $0.chat(body: body)
+            }
             guard let choice = result.response.choices.sorted(by: { $0.index < $1.index }).first,
                   let renderedResponse = nonemptyBridgeResponse(choice.message) else {
                 throw AFMBridgeCommandError.invalidResponse(endpoint: result.host.endpointDescription)

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommand.swift
@@ -1,0 +1,19 @@
+import ArgumentParser
+
+struct BridgeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "bridge",
+        abstract: "Use a signed Foundation Lab host from agents and automation.",
+        discussion: """
+        Agent Bridge does not require a TTY. Foundation Lab remains the signed host
+        for system and PCC requests while afm connects through an authenticated local endpoint.
+        """,
+        subcommands: [
+            BridgePrepareCommand.self,
+            BridgeEnsureCommand.self,
+            BridgeStatusCommand.self,
+            BridgeModelsCommand.self,
+            BridgeChatCommand.self
+        ]
+    )
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
@@ -17,13 +17,15 @@ func executeBridgeCommand(
 
 func performBridgeRequest<Response: Sendable>(
     paths: ResolvedBridgePaths,
+    retryAfterDescriptorRotation: Bool = true,
     operation: (AFMBridgeCommandConnection) async throws -> Response
 ) async throws -> (host: AFMBridgeCommandConnection, response: Response) {
     let firstHost = try AFMBridgeCommandConnection.connect(paths: paths)
     do {
         return (firstHost, try await operation(firstHost))
     } catch {
-        guard let replacementDescriptor = try? paths.readDescriptor(),
+        guard retryAfterDescriptorRotation,
+              let replacementDescriptor = try? paths.readDescriptor(),
               replacementDescriptor.launchIdentifier != firstHost.descriptor.launchIdentifier,
               let replacementHost = try? AFMBridgeCommandConnection.connect(paths: paths) else {
             throw error

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
@@ -1,0 +1,33 @@
+import ArgumentParser
+
+func executeBridgeCommand(
+    output: CLIOutputOptions,
+    operation: () async throws -> Void
+) async throws {
+    do {
+        try await operation()
+    } catch {
+        CLIOutput.emitError(error, format: output.format)
+        if error is ValidationError {
+            throw ExitCode.validationFailure
+        }
+        throw ExitCode.failure
+    }
+}
+
+func performBridgeRequest<Response: Sendable>(
+    paths: ResolvedBridgePaths,
+    operation: (AFMBridgeCommandConnection) async throws -> Response
+) async throws -> (host: AFMBridgeCommandConnection, response: Response) {
+    let firstHost = try AFMBridgeCommandConnection.connect(paths: paths)
+    do {
+        return (firstHost, try await operation(firstHost))
+    } catch {
+        guard let replacementDescriptor = try? paths.readDescriptor(),
+              replacementDescriptor.launchIdentifier != firstHost.descriptor.launchIdentifier,
+              let replacementHost = try? AFMBridgeCommandConnection.connect(paths: paths) else {
+            throw error
+        }
+        return (replacementHost, try await operation(replacementHost))
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
@@ -23,7 +23,10 @@ func performBridgeRequest<Response: Sendable>(
     let firstHost = try AFMBridgeCommandConnection.connect(paths: paths)
     do {
         return (firstHost, try await operation(firstHost))
+    } catch is CancellationError {
+        throw CancellationError()
     } catch {
+        try Task.checkCancellation()
         guard retryAfterDescriptorRotation,
               let replacementDescriptor = try? paths.readDescriptor(),
               replacementDescriptor.launchIdentifier != firstHost.descriptor.launchIdentifier,

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeCommandExecution.swift
@@ -1,3 +1,4 @@
+import AFMServer
 import ArgumentParser
 
 func executeBridgeCommand(
@@ -29,10 +30,24 @@ func performBridgeRequest<Response: Sendable>(
         try Task.checkCancellation()
         guard retryAfterDescriptorRotation,
               let replacementDescriptor = try? paths.readDescriptor(),
-              replacementDescriptor.launchIdentifier != firstHost.descriptor.launchIdentifier,
-              let replacementHost = try? AFMBridgeCommandConnection.connect(paths: paths) else {
+              bridgeConnectionChanged(from: firstHost.descriptor, to: replacementDescriptor),
+              let replacementHost = try? AFMBridgeCommandConnection.connect(
+                  paths: paths,
+                  descriptor: replacementDescriptor
+              ) else {
             throw error
         }
         return (replacementHost, try await operation(replacementHost))
     }
+}
+
+private func bridgeConnectionChanged(
+    from previous: AFMBridgeConnectionDescriptor,
+    to replacement: AFMBridgeConnectionDescriptor
+) -> Bool {
+    previous.endpoint != replacement.endpoint
+        || previous.bearerToken != replacement.bearerToken
+        || previous.processIdentifier != replacement.processIdentifier
+        || previous.launchIdentifier != replacement.launchIdentifier
+        || previous.startedAt != replacement.startedAt
 }

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeConnectionDryRunPayload.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeConnectionDryRunPayload.swift
@@ -1,0 +1,10 @@
+struct BridgeConnectionDryRunPayload: Encodable {
+    let status = "dry_run"
+    let command: String
+    let descriptor: String
+
+    init(command: String, paths: ResolvedBridgePaths) {
+        self.command = command
+        descriptor = paths.descriptorPath
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeConnectionOptions.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeConnectionOptions.swift
@@ -1,0 +1,70 @@
+import AFMServer
+import ArgumentParser
+import Foundation
+
+struct BridgeConnectionOptions: ParsableArguments {
+    @Option(
+        name: .customLong("base"),
+        help: "Base directory shared with Foundation Lab. Defaults to ~/.afm."
+    )
+    var baseDirectory: String?
+
+    @Option(
+        name: .customLong("descriptor"),
+        help: "Read a connection descriptor from this absolute path instead of <base>/bridge/connection.json."
+    )
+    var descriptorPath: String?
+
+    func resolveForPrepare() throws -> ResolvedBridgePaths {
+        guard descriptorPath == nil else {
+            throw ValidationError(
+                "--descriptor is read-only and cannot be used with bridge prepare. Use --base to create a private bridge directory."
+            )
+        }
+        return try resolve()
+    }
+
+    func resolve() throws -> ResolvedBridgePaths {
+        if baseDirectory != nil, descriptorPath != nil {
+            throw ValidationError("Use either --base or --descriptor, not both.")
+        }
+
+        if let descriptorPath {
+            let resolvedDescriptor = try resolveAbsoluteBridgePath(descriptorPath, optionName: "--descriptor")
+            let descriptorURL = URL(fileURLWithPath: resolvedDescriptor)
+            let fileName = descriptorURL.lastPathComponent
+            guard !fileName.isEmpty, fileName != ".", fileName != ".." else {
+                throw ValidationError("--descriptor must include a file name.")
+            }
+            return ResolvedBridgePaths(
+                baseDirectory: nil,
+                bridgeDirectory: descriptorURL.deletingLastPathComponent().path(),
+                descriptorPath: resolvedDescriptor,
+                descriptorFileName: fileName
+            )
+        }
+
+        let resolvedBase = try resolveAbsoluteBridgePath(baseDirectory ?? "~/.afm", optionName: "--base")
+        let bridgeDirectory = URL(fileURLWithPath: resolvedBase)
+            .appending(path: "bridge")
+            .standardizedFileURL
+            .path()
+        return ResolvedBridgePaths(
+            baseDirectory: resolvedBase,
+            bridgeDirectory: bridgeDirectory,
+            descriptorPath: URL(fileURLWithPath: bridgeDirectory)
+                .appending(path: AFMBridgeDescriptorStore.defaultFileName)
+                .path(),
+            descriptorFileName: AFMBridgeDescriptorStore.defaultFileName
+        )
+    }
+}
+
+private func resolveAbsoluteBridgePath(_ path: String, optionName: String) throws -> String {
+    let trimmed = try validatedResolvedText(path, optionName: optionName)
+    let expanded = expandedPathString(trimmed)
+    guard NSString(string: expanded).isAbsolutePath else {
+        throw ValidationError("\(optionName) must be an absolute path.")
+    }
+    return URL(fileURLWithPath: expanded).standardizedFileURL.path()
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeEnsureCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeEnsureCommand.swift
@@ -91,17 +91,19 @@ private func waitForBridge(
 ) async throws {
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: .seconds(timeoutSeconds))
-    while clock.now < deadline {
-        if let launched = try await reachableBridge(paths: paths) {
-            try emitBridgeEnsureResult(
-                status: "launched",
-                host: launched.host,
-                health: launched.response,
-                output: output
-            )
-            return
-        }
-        try await clock.sleep(for: .milliseconds(200))
+    if let launched = try await pollForBridge(
+        clock: clock,
+        deadline: deadline,
+        interval: .milliseconds(200),
+        operation: { try await reachableBridge(paths: paths) }
+    ) {
+        try emitBridgeEnsureResult(
+            status: "launched",
+            host: launched.host,
+            health: launched.response,
+            output: output
+        )
+        return
     }
 
     throw AFMBridgeCommandError.launchTimedOut(
@@ -109,6 +111,23 @@ private func waitForBridge(
         timeoutSeconds: timeoutSeconds,
         descriptorPath: paths.descriptorPath
     )
+}
+
+func pollForBridge<ClockType: Clock, Response>(
+    clock: ClockType,
+    deadline: ClockType.Instant,
+    interval: ClockType.Duration,
+    operation: () async throws -> Response?
+) async throws -> Response? {
+    while true {
+        if let response = try await operation() {
+            return response
+        }
+        let now = clock.now
+        guard now < deadline else { return nil }
+        let nextPoll = min(now.advanced(by: interval), deadline)
+        try await clock.sleep(until: nextPoll, tolerance: nil)
+    }
 }
 
 private func emitBridgeEnsureDryRun(

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeEnsureCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeEnsureCommand.swift
@@ -1,0 +1,200 @@
+import ArgumentParser
+import Foundation
+
+struct BridgeEnsureCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "ensure",
+        abstract: "Launch Foundation Lab when needed and wait for a reachable bridge.",
+        aliases: ["launch"]
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var connection: BridgeConnectionOptions
+
+    @Option(
+        name: .long,
+        help: "Foundation Lab application name or .app path. Defaults to Foundation Lab."
+    )
+    var app: String?
+
+    @Option(name: .customLong("timeout"), help: "Maximum seconds to wait for the bridge. Defaults to 20.")
+    var timeoutSeconds: Double = 20
+
+    mutating func run() async throws {
+        let output = try options.resolvedOutput()
+        try await executeBridgeCommand(output: output) {
+            try await execute(output: output)
+        }
+    }
+
+    private func execute(output: CLIOutputOptions) async throws {
+        let paths = try connection.resolve()
+        let application = try resolvedApplication()
+        guard timeoutSeconds.isFinite, timeoutSeconds > 0, timeoutSeconds <= 300 else {
+            throw ValidationError("--timeout must be greater than 0 and at most 300 seconds.")
+        }
+
+        if options.dryRun {
+            try emitBridgeEnsureDryRun(
+                application: application,
+                timeoutSeconds: timeoutSeconds,
+                paths: paths,
+                output: output
+            )
+            return
+        }
+
+        if let existing = try await reachableBridge(paths: paths) {
+            try emitBridgeEnsureResult(
+                status: "already_running",
+                host: existing.host,
+                health: existing.response,
+                output: output
+            )
+            return
+        }
+
+        try launchFoundationLab(application)
+        try await waitForBridge(
+            paths: paths,
+            application: application,
+            timeoutSeconds: timeoutSeconds,
+            output: output
+        )
+    }
+
+    private func resolvedApplication() throws -> String {
+        guard let app else { return "Foundation Lab" }
+        return try validatedNonEmpty(app, optionName: "--app")
+    }
+}
+
+private func reachableBridge(
+    paths: ResolvedBridgePaths
+) async throws -> (host: AFMBridgeCommandConnection, response: AFMBridgeHealthResponse)? {
+    do {
+        return try await performBridgeRequest(
+            paths: paths,
+            operation: { try await $0.health() }
+        )
+    } catch let error as AFMBridgeCommandError {
+        guard error.permitsHostLaunchRecovery else { throw error }
+        return nil
+    }
+}
+
+private func waitForBridge(
+    paths: ResolvedBridgePaths,
+    application: String,
+    timeoutSeconds: Double,
+    output: CLIOutputOptions
+) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(timeoutSeconds))
+    while clock.now < deadline {
+        if let launched = try await reachableBridge(paths: paths) {
+            try emitBridgeEnsureResult(
+                status: "launched",
+                host: launched.host,
+                health: launched.response,
+                output: output
+            )
+            return
+        }
+        try await clock.sleep(for: .milliseconds(200))
+    }
+
+    throw AFMBridgeCommandError.launchTimedOut(
+        app: application,
+        timeoutSeconds: timeoutSeconds,
+        descriptorPath: paths.descriptorPath
+    )
+}
+
+private func emitBridgeEnsureDryRun(
+    application: String,
+    timeoutSeconds: Double,
+    paths: ResolvedBridgePaths,
+    output: CLIOutputOptions
+) throws {
+    let payload = BridgeEnsureDryRunPayload(
+        application: application,
+        timeoutSeconds: timeoutSeconds,
+        descriptor: paths.descriptorPath
+    )
+    try CLIOutput.emit(
+        payload: payload,
+        human: "[dry-run] afm bridge ensure \(application)",
+        options: output
+    )
+}
+
+private struct BridgeEnsureDryRunPayload: Encodable {
+    let status = "dry_run"
+    let command = "bridge ensure"
+    let application: String
+    let timeoutSeconds: Double
+    let descriptor: String
+}
+
+private struct BridgeEnsurePayload: Encodable {
+    let status: String
+    let command = "bridge ensure"
+    let endpoint: String
+    let processIdentifier: Int32
+    let launchIdentifier: UUID
+    let models: [AFMBridgeHealthResponse.Model]
+}
+
+private func launchFoundationLab(_ application: String) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    let expandedApplication = expandedPathString(application)
+    if expandedApplication.contains("/") || expandedApplication.hasSuffix(".app") {
+        process.arguments = ["-gj", expandedApplication]
+    } else {
+        process.arguments = ["-gj", "-a", application]
+    }
+    process.standardInput = FileHandle.nullDevice
+    let stderr = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = stderr
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        throw AFMBridgeCommandError.launchFailed(app: application, reason: error.localizedDescription)
+    }
+
+    guard process.terminationStatus == 0 else {
+        let data = stderr.fileHandleForReading.readDataToEndOfFile()
+        let message = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        throw AFMBridgeCommandError.launchFailed(
+            app: application,
+            reason: message.flatMap { $0.isEmpty ? nil : $0 } ?? "open exited with status \(process.terminationStatus)."
+        )
+    }
+}
+
+private func emitBridgeEnsureResult(
+    status: String,
+    host: AFMBridgeCommandConnection,
+    health: AFMBridgeHealthResponse,
+    output: CLIOutputOptions
+) throws {
+    let payload = BridgeEnsurePayload(
+        status: status,
+        endpoint: host.endpointDescription,
+        processIdentifier: host.descriptor.processIdentifier,
+        launchIdentifier: host.descriptor.launchIdentifier,
+        models: health.models
+    )
+    let action = status == "launched" ? "launched and is reachable" : "is already reachable"
+    try CLIOutput.emit(
+        payload: payload,
+        human: "Foundation Lab \(action).\nEndpoint: \(host.endpointDescription)",
+        options: output
+    )
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeModelsCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeModelsCommand.swift
@@ -1,0 +1,49 @@
+import ArgumentParser
+
+struct BridgeModelsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "models",
+        abstract: "List models exposed by the signed Foundation Lab bridge host."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var connection: BridgeConnectionOptions
+
+    mutating func run() async throws {
+        let output = try options.resolvedOutput()
+        try await executeBridgeCommand(output: output) {
+            let paths = try connection.resolve()
+            if options.dryRun {
+                try CLIOutput.emit(
+                    payload: BridgeConnectionDryRunPayload(command: "bridge models", paths: paths),
+                    human: "[dry-run] afm bridge models \(paths.descriptorPath)",
+                    options: output
+                )
+                return
+            }
+
+            let result = try await performBridgeRequest(paths: paths) { try await $0.models() }
+            let lines = result.response.data.map { model in
+                options.verbose ? "\(model.id)\n  Owner: \(model.owner)" : model.id
+            }
+            try CLIOutput.emit(
+                payload: BridgeModelsPayload(host: result.host, response: result.response),
+                human: lines.joined(separator: "\n"),
+                options: output
+            )
+        }
+    }
+}
+
+private struct BridgeModelsPayload: Encodable {
+    let command = "bridge models"
+    let endpoint: String
+    let object: String
+    let models: [AFMBridgeModelsResponse.Model]
+
+    init(host: AFMBridgeCommandConnection, response: AFMBridgeModelsResponse) {
+        endpoint = host.endpointDescription
+        object = response.object
+        models = response.data
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgePrepareCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgePrepareCommand.swift
@@ -1,0 +1,54 @@
+import ArgumentParser
+
+struct BridgePrepareCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "prepare",
+        abstract: "Create the private directory used to discover Foundation Lab."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var connection: BridgeConnectionOptions
+
+    mutating func run() async throws {
+        let output = try options.resolvedOutput()
+        try await executeBridgeCommand(output: output) {
+            let paths = try connection.resolveForPrepare()
+            let payload = BridgePreparePayload(
+                status: options.dryRun ? "dry_run" : "prepared",
+                paths: paths
+            )
+
+            if options.dryRun {
+                try CLIOutput.emit(
+                    payload: payload,
+                    human: "[dry-run] afm bridge prepare \(paths.bridgeDirectory)",
+                    options: output
+                )
+                return
+            }
+
+            try paths.prepare()
+            let lines = [
+                "Prepared the private Agent Bridge directory at \(paths.bridgeDirectory).",
+                "In Foundation Lab Settings, choose \(paths.baseDirectory ?? paths.bridgeDirectory) and start Agent Bridge.",
+                "Descriptor: \(paths.descriptorPath)"
+            ]
+            try CLIOutput.emit(payload: payload, human: lines.joined(separator: "\n"), options: output)
+        }
+    }
+}
+
+private struct BridgePreparePayload: Encodable {
+    let status: String
+    let command = "bridge prepare"
+    let baseDirectory: String?
+    let bridgeDirectory: String
+    let descriptor: String
+
+    init(status: String, paths: ResolvedBridgePaths) {
+        self.status = status
+        baseDirectory = paths.baseDirectory
+        bridgeDirectory = paths.bridgeDirectory
+        descriptor = paths.descriptorPath
+    }
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeStatusCommand.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/BridgeStatusCommand.swift
@@ -1,0 +1,73 @@
+import ArgumentParser
+import Foundation
+
+struct BridgeStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Verify that the signed Foundation Lab bridge host is reachable."
+    )
+
+    @OptionGroup var options: GlobalCommandOptions
+    @OptionGroup var connection: BridgeConnectionOptions
+
+    mutating func run() async throws {
+        let output = try options.resolvedOutput()
+        try await executeBridgeCommand(output: output) {
+            let paths = try connection.resolve()
+            if options.dryRun {
+                try CLIOutput.emit(
+                    payload: BridgeConnectionDryRunPayload(command: "bridge status", paths: paths),
+                    human: "[dry-run] afm bridge status \(paths.descriptorPath)",
+                    options: output
+                )
+                return
+            }
+
+            let result = try await performBridgeRequest(paths: paths) { try await $0.health() }
+            var lines = [
+                "Foundation Lab Agent Bridge",
+                "Status: Running",
+                "Endpoint: \(result.host.endpointDescription)",
+                "Process: \(result.host.descriptor.processIdentifier)",
+                "Models: \(result.response.models.map { modelLabel($0) }.joined(separator: ", "))"
+            ]
+            if options.verbose {
+                lines.append("Launch: \(result.host.descriptor.launchIdentifier.uuidString)")
+                lines.append("Started: \(bridgeISO8601String(result.host.descriptor.startedAt))")
+            }
+            try CLIOutput.emit(
+                payload: BridgeStatusPayload(host: result.host, health: result.response),
+                human: lines.joined(separator: "\n"),
+                options: output
+            )
+        }
+    }
+}
+
+private struct BridgeStatusPayload: Encodable {
+    let status = "running"
+    let command = "bridge status"
+    let endpoint: String
+    let processIdentifier: Int32
+    let launchIdentifier: UUID
+    let startedAt: String
+    let models: [AFMBridgeHealthResponse.Model]
+
+    init(host: AFMBridgeCommandConnection, health: AFMBridgeHealthResponse) {
+        endpoint = host.endpointDescription
+        processIdentifier = host.descriptor.processIdentifier
+        launchIdentifier = host.descriptor.launchIdentifier
+        startedAt = bridgeISO8601String(host.descriptor.startedAt)
+        models = health.models
+    }
+}
+
+private func modelLabel(_ model: AFMBridgeHealthResponse.Model) -> String {
+    model.available ? model.name : "\(model.name) (unavailable)"
+}
+
+private func bridgeISO8601String(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/CommandSupport.swift
@@ -400,6 +400,9 @@ enum HelpText {
     SERVER COMMANDS
       serve        Serve local HTTP endpoints over TCP or a Unix-domain socket.
 
+    AGENT BRIDGE COMMANDS
+      bridge       Use a signed Foundation Lab host from agents and automation.
+
     QUICK START
       afm model status
       afm model use-cases
@@ -419,6 +422,10 @@ enum HelpText {
       afm transcript export --message "Hello" --message "Summarize this conversation." --file transcript.json
       afm feedback export --prompt "What is the capital of France?" --sentiment positive --file feedback.json
       afm serve
+      afm bridge prepare
+      afm bridge ensure
+      afm bridge status
+      afm bridge chat --model pcc --prompt "Summarize this repository."
     """
 
     static let session = """
@@ -439,8 +446,8 @@ enum HelpText {
 
 func suggestRootCommand(for input: String) -> String? {
     let commands = [
-        "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve", "help",
-        "version"
+        "model", "token-count", "tag", "session", "schema", "tool", "transcript", "feedback", "serve", "bridge",
+        "help", "version"
     ]
     return suggestCommand(input, in: commands)
 }

--- a/Tools/AFMCLI/Sources/AFMCLI/Commands/ResolvedBridgePaths.swift
+++ b/Tools/AFMCLI/Sources/AFMCLI/Commands/ResolvedBridgePaths.swift
@@ -1,0 +1,49 @@
+import AFMServer
+import Darwin
+import Foundation
+
+struct ResolvedBridgePaths: Sendable, Equatable {
+    let baseDirectory: String?
+    let bridgeDirectory: String
+    let descriptorPath: String
+    let descriptorFileName: String
+
+    func descriptorStore() throws -> AFMBridgeDescriptorStore {
+        try AFMBridgeDescriptorStore(directoryPath: bridgeDirectory, fileName: descriptorFileName)
+    }
+
+    func prepare() throws {
+        if let baseDirectory {
+            try preparePrivateDirectoryWithoutRepair(at: baseDirectory)
+        }
+        try preparePrivateDirectoryWithoutRepair(at: bridgeDirectory)
+    }
+
+    func readDescriptor() throws -> AFMBridgeConnectionDescriptor {
+        do {
+            return try descriptorStore().read()
+        } catch AFMBridgeDescriptorError.descriptorMissing,
+                AFMBridgeDescriptorError.directoryMissing {
+            throw AFMBridgeCommandError.hostMissing(descriptorPath: descriptorPath)
+        } catch {
+            throw AFMBridgeCommandError.invalidDescriptor(
+                descriptorPath: descriptorPath,
+                reason: error.localizedDescription
+            )
+        }
+    }
+}
+
+private func preparePrivateDirectoryWithoutRepair(at path: String) throws {
+    do {
+        try AFMBridgeDirectory.validate(at: path)
+        return
+    } catch AFMBridgeDescriptorError.directoryMissing {
+        // Only a directory created by this invocation may receive new permissions.
+    }
+
+    if Darwin.mkdir(path, 0o700) != 0, errno != EEXIST {
+        throw AFMBridgeDescriptorError.posix(operation: "create the bridge directory", code: errno)
+    }
+    try AFMBridgeDirectory.validate(at: path)
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
@@ -254,11 +254,14 @@ func bridgeDescriptorRotationRetryPolicy() async throws {
         descriptorPath: descriptor.path(),
         descriptorFileName: descriptor.lastPathComponent
     )
+    let launchIdentifier = UUID()
+    let token = String(repeating: "r", count: 43)
     try writeBridgeDescriptor(
         at: descriptor,
         port: 19_760,
-        token: String(repeating: "r", count: 43),
-        processIdentifier: getpid()
+        token: token,
+        processIdentifier: getpid(),
+        launchIdentifier: launchIdentifier
     )
 
     var retriedAttempts = 0
@@ -270,8 +273,9 @@ func bridgeDescriptorRotationRetryPolicy() async throws {
             try writeBridgeDescriptor(
                 at: descriptor,
                 port: 19_761,
-                token: String(repeating: "s", count: 43),
-                processIdentifier: getpid()
+                token: token,
+                processIdentifier: getpid(),
+                launchIdentifier: launchIdentifier
             )
             throw BridgeOperationTestError.expectedFailure
         }
@@ -279,6 +283,8 @@ func bridgeDescriptorRotationRetryPolicy() async throws {
     }
     #expect(retried.response == 42)
     #expect(retriedAttempts == 2)
+    #expect(retried.host.descriptor.endpoint == .loopbackTCP(host: "127.0.0.1", port: 19_761))
+    #expect(retried.host.descriptor.launchIdentifier == launchIdentifier)
 
     var nonRetryingAttempts = 0
     await #expect(throws: BridgeOperationTestError.expectedFailure) {
@@ -297,6 +303,28 @@ func bridgeDescriptorRotationRetryPolicy() async throws {
         }
     }
     #expect(nonRetryingAttempts == 1)
+}
+
+@Test("Bridge polling clamps its last sleep and checks the deadline")
+func bridgePollingFinalDeadlineCheck() async throws {
+    let clock = BridgePollingTestClock()
+    let deadline = clock.now.advanced(by: .milliseconds(250))
+    var attempts = 0
+
+    let result: Int? = try await pollForBridge(
+        clock: clock,
+        deadline: deadline,
+        interval: .milliseconds(100)
+    ) {
+        attempts += 1
+        return attempts == 4 ? 42 : nil
+    }
+
+    #expect(result == 42)
+    #expect(attempts == 4)
+    #expect(clock.now == deadline)
+    #expect(clock.recordedSleepDeadlines().last == deadline)
+    #expect(clock.recordedSleepDeadlines().allSatisfy { $0 <= deadline })
 }
 
 @Test("Bridge descriptor rotation never retries a cancelled operation")
@@ -454,6 +482,52 @@ private enum BridgeTestError: Error {
     case posix(String, CInt)
 }
 
+private final class BridgePollingTestClock: Clock, @unchecked Sendable {
+    struct Instant: InstantProtocol {
+        typealias Duration = Swift.Duration
+
+        let offset: Duration
+
+        func advanced(by duration: Duration) -> Self {
+            Self(offset: offset + duration)
+        }
+
+        func duration(to other: Self) -> Duration {
+            other.offset - offset
+        }
+
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    typealias Duration = Swift.Duration
+
+    private let lock = NSLock()
+    private var current = Instant(offset: .zero)
+    private var sleepDeadlines: [Instant] = []
+
+    var now: Instant {
+        lock.withLock { current }
+    }
+
+    var minimumResolution: Duration { .nanoseconds(1) }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        try Task.checkCancellation()
+        lock.withLock {
+            sleepDeadlines.append(deadline)
+            if current < deadline {
+                current = deadline
+            }
+        }
+    }
+
+    func recordedSleepDeadlines() -> [Instant] {
+        lock.withLock { sleepDeadlines }
+    }
+}
+
 private func withBridgeTemporaryDirectory<Result>(
     _ operation: (URL) throws -> Result
 ) throws -> Result {
@@ -483,14 +557,15 @@ private func writeBridgeDescriptor(
     at url: URL,
     port: Int,
     token: String,
-    processIdentifier: Int32
+    processIdentifier: Int32,
+    launchIdentifier: UUID = UUID()
 ) throws {
     let object: [String: Any] = [
         "version": 1,
         "endpoint": ["loopbackTCP": ["host": "127.0.0.1", "port": port]],
         "bearerToken": token,
         "processIdentifier": processIdentifier,
-        "launchIdentifier": UUID().uuidString,
+        "launchIdentifier": launchIdentifier.uuidString,
         "modelIdentifiers": ["system", "pcc"],
         "startedAt": 0
     ]

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
@@ -1,0 +1,323 @@
+import AFMServer
+import Darwin
+import Foundation
+import Testing
+
+@Test("Bridge commands are discoverable and document headless inputs")
+func bridgeHelp() throws {
+    let root = try runAFM("--help")
+    let bridge = try runAFM("bridge", "--help")
+    let chat = try runAFM("bridge", "chat", "--help")
+
+    #expect(root.status == 0)
+    #expect(root.stdout.contains("AGENT BRIDGE COMMANDS"))
+    #expect(root.stdout.contains("afm bridge"))
+    for subcommand in ["prepare", "ensure", "status", "models", "chat"] {
+        #expect(bridge.stdout.contains(subcommand))
+    }
+    for flag in ["--base", "--descriptor", "--prompt", "--model", "--max-tokens", "--temperature", "--top-p"] {
+        #expect(chat.stdout.contains(flag))
+    }
+    #expect(bridge.stdout.contains("does not require a TTY"))
+}
+
+@Test("Bridge prepare creates private directories without a TTY")
+func bridgePrepare() throws {
+    try withBridgeTemporaryDirectory { parent in
+        let base = parent.appending(path: ".afm")
+        let result = try runAFM(
+            "bridge", "prepare", "--base", base.path(),
+            environment: ["AFM_FORCE_NON_TTY": "1"]
+        )
+
+        #expect(result.status == 0)
+        let json = try parseJSONObject(result.stdout)
+        #expect(json["status"] as? String == "prepared")
+        #expect(json["baseDirectory"] as? String == base.path())
+        #expect(json["bridgeDirectory"] as? String == base.appending(path: "bridge").path())
+        #expect(json["descriptor"] as? String == base.appending(path: "bridge/connection.json").path())
+        #expect(try bridgePermissions(at: base.path()) == 0o700)
+        #expect(try bridgePermissions(at: base.appending(path: "bridge").path()) == 0o700)
+    }
+}
+
+@Test("Bridge prepare rejects descriptor paths without changing their parent")
+func bridgePrepareDescriptorIsReadOnly() throws {
+    try withBridgeTemporaryDirectory { parent in
+        #expect(Darwin.chmod(parent.path(), 0o755) == 0)
+        let permissionsBefore = try bridgePermissions(at: parent.path())
+        let descriptor = parent.appending(path: "connection.json")
+
+        let result = try runAFM("bridge", "prepare", "--descriptor", descriptor.path())
+
+        #expect(result.status == 64)
+        #expect(result.stderr.contains("--descriptor is read-only"))
+        #expect(try bridgePermissions(at: parent.path()) == permissionsBefore)
+        #expect(!FileManager.default.fileExists(atPath: descriptor.path()))
+    }
+}
+
+@Test("Bridge prepare refuses to chmod an existing base directory")
+func bridgePrepareDoesNotRepairExistingBase() throws {
+    try withBridgeTemporaryDirectory { parent in
+        let base = parent.appending(path: "existing-base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: false)
+        #expect(Darwin.chmod(base.path(), 0o755) == 0)
+
+        let result = try runAFM("bridge", "prepare", "--base", base.path())
+
+        #expect(result.status != 0)
+        #expect(result.stderr.contains("mode 755; expected 700"))
+        #expect(try bridgePermissions(at: base.path()) == 0o755)
+        #expect(!FileManager.default.fileExists(atPath: base.appending(path: "bridge").path()))
+    }
+}
+
+@Test("Bridge reports missing and stale hosts with launch guidance")
+func bridgeMissingAndStaleHostErrors() throws {
+    try withBridgeTemporaryDirectory { parent in
+        let descriptor = parent.appending(path: "connection.json")
+        let missing = try runAFM("bridge", "status", "--descriptor", descriptor.path())
+        #expect(missing.status != 0)
+        #expect(missing.stderr.contains("No Foundation Lab bridge host"))
+        #expect(missing.stderr.contains("launch Foundation Lab"))
+
+        let token = String(repeating: "s", count: 43)
+        try writeBridgeDescriptor(
+            at: descriptor,
+            port: 19_760,
+            token: token,
+            processIdentifier: Int32.max
+        )
+        let stale = try runAFM("bridge", "status", "--descriptor", descriptor.path())
+        #expect(stale.status != 0)
+        #expect(stale.stderr.contains("is stale"))
+        #expect(stale.stderr.contains("Launch or restart Foundation Lab"))
+        #expect(!stale.stdout.contains(token))
+        #expect(!stale.stderr.contains(token))
+    }
+}
+
+@Test("Bridge status, models, and chat work headlessly without exposing credentials")
+func bridgeHeadlessRoundTrip() async throws {
+    let token = "never-print-this-bridge-token-value-1234567"
+    #expect(token.utf8.count == 43)
+    let probe = BridgeGeneratorProbe()
+    let server = try AFMHTTPServer(
+        configuration: .init(
+            endpoint: .tcp(host: "127.0.0.1", port: 0),
+            security: .init(bearerToken: token)
+        ),
+        catalog: AFMStaticModelCatalog(models: [
+            .init(id: "system", isAvailable: true),
+            .init(id: "pcc", isAvailable: true)
+        ]),
+        generator: BridgeTestGenerator(probe: probe)
+    )
+    let address = try await server.start()
+    guard case .tcp(_, let port) = address else {
+        try await server.stop()
+        Issue.record("Expected a TCP bridge test server")
+        return
+    }
+
+    do {
+        let parent = try makeBridgeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let descriptor = parent.appending(path: "connection.json")
+        try writeBridgeDescriptor(
+            at: descriptor,
+            port: port,
+            token: token,
+            processIdentifier: getpid()
+        )
+        let environment = ["AFM_FORCE_NON_TTY": "1"]
+        let results = try runHeadlessBridgeCommands(descriptor: descriptor, environment: environment)
+        try await verifyHeadlessBridgeResults(results, probe: probe, token: token)
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+private struct BridgeHeadlessCommandResults {
+    let status: CommandResult
+    let ensure: CommandResult
+    let models: CommandResult
+    let chat: CommandResult
+
+    var output: [String] {
+        [
+            status.stdout, status.stderr, ensure.stdout, ensure.stderr,
+            models.stdout, models.stderr, chat.stdout, chat.stderr
+        ]
+    }
+}
+
+private func runHeadlessBridgeCommands(
+    descriptor: URL,
+    environment: [String: String]
+) throws -> BridgeHeadlessCommandResults {
+    let status = try runAFM(
+        ["bridge", "status", "--descriptor", descriptor.path()],
+        environment: environment
+    )
+    let ensure = try runAFM(
+        [
+            "bridge", "ensure", "--descriptor", descriptor.path(),
+            "--app", "/definitely/not/a/Foundation Lab.app"
+        ],
+        environment: environment
+    )
+    let models = try runAFM(
+        ["bridge", "models", "--descriptor", descriptor.path()],
+        environment: environment
+    )
+    let chat = try runAFM(
+        [
+            "bridge", "chat", "--descriptor", descriptor.path(),
+            "--model", "pcc", "--max-tokens", "128", "--temperature", "0.25",
+            "--top-p", "0.8", "--prompt", "Explain no-TTY PCC."
+        ],
+        environment: environment
+    )
+    return BridgeHeadlessCommandResults(status: status, ensure: ensure, models: models, chat: chat)
+}
+
+private func verifyHeadlessBridgeResults(
+    _ results: BridgeHeadlessCommandResults,
+    probe: BridgeGeneratorProbe,
+    token: String
+) async throws {
+    #expect(results.status.status == 0)
+    let statusJSON = try parseJSONObject(results.status.stdout)
+    #expect(statusJSON["status"] as? String == "running")
+    let statusModels = try #require(statusJSON["models"] as? [[String: Any]])
+    #expect(Set(statusModels.compactMap { $0["name"] as? String }) == ["system", "pcc"])
+
+    #expect(results.ensure.status == 0)
+    let ensureJSON = try parseJSONObject(results.ensure.stdout)
+    #expect(ensureJSON["status"] as? String == "already_running")
+
+    #expect(results.models.status == 0)
+    let modelsJSON = try parseJSONObject(results.models.stdout)
+    let modelEntries = try #require(modelsJSON["models"] as? [[String: Any]])
+    #expect(Set(modelEntries.compactMap { $0["id"] as? String }) == ["system", "pcc"])
+
+    #expect(results.chat.status == 0)
+    let chatJSON = try parseJSONObject(results.chat.stdout)
+    #expect(chatJSON["model"] as? String == "pcc")
+    #expect(chatJSON["response"] as? String == "Headless bridge response")
+    let usage = try #require(chatJSON["tokenUsage"] as? [String: Any])
+    #expect(usage["measurement"] as? String == "observed")
+    #expect(usage["totalTokenCount"] as? Int == 15)
+
+    let request = try #require(await probe.lastRequest())
+    #expect(request.model == "pcc")
+    #expect(request.maximumCompletionTokens == 128)
+    #expect(request.temperature == 0.25)
+    #expect(request.topP == 0.8)
+    for output in results.output {
+        #expect(!output.contains(token))
+    }
+}
+
+@Test("Bridge ensure dry-run does not require or launch an app")
+func bridgeEnsureDryRun() throws {
+    try withBridgeTemporaryDirectory { parent in
+        let descriptor = parent.appending(path: "missing.json")
+        let app = parent.appending(path: "Never Launch This.app")
+        let result = try runAFM(
+            "bridge", "ensure", "--descriptor", descriptor.path(),
+            "--app", app.path(), "--timeout", "0.1", "--dry-run",
+            environment: ["AFM_FORCE_NON_TTY": "1"]
+        )
+
+        #expect(result.status == 0)
+        let json = try parseJSONObject(result.stdout)
+        #expect(json["status"] as? String == "dry_run")
+        #expect(json["application"] as? String == app.path())
+        #expect(!FileManager.default.fileExists(atPath: app.path()))
+    }
+}
+
+private actor BridgeGeneratorProbe {
+    private var request: AFMChatGenerationRequest?
+
+    func capture(_ request: AFMChatGenerationRequest) {
+        self.request = request
+    }
+
+    func lastRequest() -> AFMChatGenerationRequest? {
+        request
+    }
+}
+
+private struct BridgeTestGenerator: AFMChatCompletionGenerating {
+    let probe: BridgeGeneratorProbe
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        await probe.capture(request)
+        return .init(
+            content: "Headless bridge response",
+            usage: .init(
+                input: .init(totalTokenCount: 10, cachedTokenCount: 2),
+                output: .init(totalTokenCount: 5, reasoningTokenCount: 1),
+                measurement: .observed,
+                scope: .response
+            )
+        )
+    }
+}
+
+private enum BridgeTestError: Error {
+    case posix(String, CInt)
+}
+
+private func withBridgeTemporaryDirectory<Result>(
+    _ operation: (URL) throws -> Result
+) throws -> Result {
+    let directory = try makeBridgeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    return try operation(directory)
+}
+
+private func makeBridgeTemporaryDirectory() throws -> URL {
+    let directory = URL(fileURLWithPath: "/tmp/afm-cli-bridge-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    guard Darwin.chmod(directory.path(), 0o700) == 0 else {
+        throw BridgeTestError.posix("secure temporary directory", errno)
+    }
+    return directory
+}
+
+private func bridgePermissions(at path: String) throws -> mode_t {
+    var status = stat()
+    guard Darwin.lstat(path, &status) == 0 else {
+        throw BridgeTestError.posix("inspect \(path)", errno)
+    }
+    return status.st_mode & 0o777
+}
+
+private func writeBridgeDescriptor(
+    at url: URL,
+    port: Int,
+    token: String,
+    processIdentifier: Int32
+) throws {
+    let object: [String: Any] = [
+        "version": 1,
+        "endpoint": ["loopbackTCP": ["host": "127.0.0.1", "port": port]],
+        "bearerToken": token,
+        "processIdentifier": processIdentifier,
+        "launchIdentifier": UUID().uuidString,
+        "modelIdentifiers": ["system", "pcc"],
+        "startedAt": 0
+    ]
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    try data.write(to: url, options: .atomic)
+    guard Darwin.chmod(url.path(), 0o600) == 0 else {
+        throw BridgeTestError.posix("secure descriptor", errno)
+    }
+}

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
@@ -2,6 +2,7 @@ import AFMServer
 import Darwin
 import Foundation
 import Testing
+@testable import AFMCLI
 
 @Test("Bridge commands are discoverable and document headless inputs")
 func bridgeHelp() throws {
@@ -242,6 +243,108 @@ func bridgeEnsureDryRun() throws {
     }
 }
 
+@Test("Bridge requests retry rotated descriptors only when explicitly allowed")
+func bridgeDescriptorRotationRetryPolicy() async throws {
+    let parent = try makeBridgeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: parent) }
+    let descriptor = parent.appending(path: "connection.json")
+    let paths = ResolvedBridgePaths(
+        baseDirectory: nil,
+        bridgeDirectory: parent.path(),
+        descriptorPath: descriptor.path(),
+        descriptorFileName: descriptor.lastPathComponent
+    )
+    try writeBridgeDescriptor(
+        at: descriptor,
+        port: 19_760,
+        token: String(repeating: "r", count: 43),
+        processIdentifier: getpid()
+    )
+
+    var retriedAttempts = 0
+    let retried: (host: AFMBridgeCommandConnection, response: Int) = try await performBridgeRequest(
+        paths: paths
+    ) { _ in
+        retriedAttempts += 1
+        if retriedAttempts == 1 {
+            try writeBridgeDescriptor(
+                at: descriptor,
+                port: 19_761,
+                token: String(repeating: "s", count: 43),
+                processIdentifier: getpid()
+            )
+            throw BridgeOperationTestError.expectedFailure
+        }
+        return 42
+    }
+    #expect(retried.response == 42)
+    #expect(retriedAttempts == 2)
+
+    var nonRetryingAttempts = 0
+    await #expect(throws: BridgeOperationTestError.expectedFailure) {
+        let _: (host: AFMBridgeCommandConnection, response: Int) = try await performBridgeRequest(
+            paths: paths,
+            retryAfterDescriptorRotation: false
+        ) { _ in
+            nonRetryingAttempts += 1
+            try writeBridgeDescriptor(
+                at: descriptor,
+                port: 19_762,
+                token: String(repeating: "t", count: 43),
+                processIdentifier: getpid()
+            )
+            throw BridgeOperationTestError.expectedFailure
+        }
+    }
+    #expect(nonRetryingAttempts == 1)
+}
+
+@Test("Bridge command connections preserve request cancellation")
+func bridgeCommandConnectionCancellation() async throws {
+    let token = String(repeating: "c", count: 43)
+    let probe = BridgeCancellationProbe()
+    let server = try AFMHTTPServer(
+        configuration: .init(
+            endpoint: .tcp(host: "127.0.0.1", port: 0),
+            security: .init(bearerToken: token)
+        ),
+        catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+        generator: BridgeCancellationGenerator(probe: probe)
+    )
+    let address = try await server.start()
+    guard case .tcp(_, let port) = address else {
+        try await server.stop()
+        Issue.record("Expected a TCP bridge test server")
+        return
+    }
+
+    let parent = try makeBridgeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: parent) }
+    let descriptor = parent.appending(path: "connection.json")
+    try writeBridgeDescriptor(at: descriptor, port: port, token: token, processIdentifier: getpid())
+    let paths = ResolvedBridgePaths(
+        baseDirectory: nil,
+        bridgeDirectory: parent.path(),
+        descriptorPath: descriptor.path(),
+        descriptorFileName: descriptor.lastPathComponent
+    )
+    let connection = try AFMBridgeCommandConnection.connect(paths: paths)
+    let body = Data(#"{"model":"system","messages":[{"role":"user","content":"Wait"}]}"#.utf8)
+    let request = Task { try await connection.chat(body: body) }
+    await probe.waitUntilStarted()
+    request.cancel()
+
+    do {
+        _ = try await request.value
+        Issue.record("Expected cancellation")
+    } catch is CancellationError {
+        // Expected.
+    } catch {
+        Issue.record("Expected CancellationError, got \(error)")
+    }
+    try await server.stop()
+}
+
 private actor BridgeGeneratorProbe {
     private var request: AFMChatGenerationRequest?
 
@@ -251,6 +354,20 @@ private actor BridgeGeneratorProbe {
 
     func lastRequest() -> AFMChatGenerationRequest? {
         request
+    }
+}
+
+private actor BridgeCancellationProbe {
+    private var started = false
+
+    func markStarted() {
+        started = true
+    }
+
+    func waitUntilStarted() async {
+        while !started {
+            await Task.yield()
+        }
     }
 }
 
@@ -269,6 +386,23 @@ private struct BridgeTestGenerator: AFMChatCompletionGenerating {
             )
         )
     }
+}
+
+private struct BridgeCancellationGenerator: AFMChatCompletionGenerating {
+    let probe: BridgeCancellationProbe
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        await probe.markStarted()
+        try await ContinuousClock().sleep(for: .seconds(30))
+        return .init(
+            content: "Unexpected",
+            usage: .init(inputTokenCount: 1, measurement: .estimated, scope: .response)
+        )
+    }
+}
+
+private enum BridgeOperationTestError: Error {
+    case expectedFailure
 }
 
 private enum BridgeTestError: Error {

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBridgeTests.swift
@@ -299,6 +299,51 @@ func bridgeDescriptorRotationRetryPolicy() async throws {
     #expect(nonRetryingAttempts == 1)
 }
 
+@Test("Bridge descriptor rotation never retries a cancelled operation")
+func bridgeDescriptorRotationCancellation() async throws {
+    let parent = try makeBridgeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: parent) }
+    let descriptor = parent.appending(path: "connection.json")
+    let paths = ResolvedBridgePaths(
+        baseDirectory: nil,
+        bridgeDirectory: parent.path(),
+        descriptorPath: descriptor.path(),
+        descriptorFileName: descriptor.lastPathComponent
+    )
+    try writeBridgeDescriptor(
+        at: descriptor,
+        port: 19_760,
+        token: String(repeating: "c", count: 43),
+        processIdentifier: getpid()
+    )
+
+    var attemptedLaunchIdentifiers: [UUID] = []
+    do {
+        let _: (host: AFMBridgeCommandConnection, response: Int) = try await performBridgeRequest(
+            paths: paths
+        ) { host in
+            attemptedLaunchIdentifiers.append(host.descriptor.launchIdentifier)
+            try writeBridgeDescriptor(
+                at: descriptor,
+                port: 19_761,
+                token: String(repeating: "d", count: 43),
+                processIdentifier: getpid()
+            )
+            throw CancellationError()
+        }
+        Issue.record("Expected cancellation")
+    } catch is CancellationError {
+        // Expected.
+    } catch {
+        Issue.record("Expected CancellationError, got \(error)")
+    }
+
+    #expect(attemptedLaunchIdentifiers.count == 1)
+    let attemptedLaunchIdentifier = try #require(attemptedLaunchIdentifiers.first)
+    let rotatedDescriptor = try paths.readDescriptor()
+    #expect(rotatedDescriptor.launchIdentifier != attemptedLaunchIdentifier)
+}
+
 @Test("Bridge command connections preserve request cancellation")
 func bridgeCommandConnectionCancellation() async throws {
     let token = String(repeating: "c", count: 43)


### PR DESCRIPTION
## Summary

- add a reusable authenticated `AFMBridgeClient` for the signed Foundation Lab host
- add `afm bridge prepare`, `ensure` (`launch`), `status`, `models`, and one-shot `chat`
- keep every operational command non-interactive and TTY-independent, with JSON as the pipe default
- preserve explicit `system` versus `pcc` routing and return shared provenance-aware token usage
- retry one descriptor rotation, use authenticated health as truth, and treat the recorded PID only as a stale hint
- refuse redirects, proxies, cookies, credentials, unsafe descriptors, non-loopback hosts, and oversized responses
- keep bearer credentials internal and out of text, JSON, verbose, dry-run, errors, and process arguments

## Stack

This is based on #176, which adds the signed macOS app host and public PCC entitlement path.

## Verification

- `swift test` passed with Xcode 26.6 and Xcode 27
- `Packages/AFMServer`: 64 tests passed with each toolchain
- strict focused SwiftLint: 0 violations
- signed, pipe-only end to end: `status`, `models`, `chat --model system`, and `chat --model pcc` all passed with observed token metadata
- terminated the signed host, then `afm bridge ensure --app ...` relaunched it without a TTY; launch identifier, bearer token, and descriptor inode all rotated before PCC succeeded again
- Xcode 26-built `afm` also completed a live system request through the Xcode 27-built signed host
