### PR TITLE
Add backpressured chat completion streaming

### DIFF
--- a/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
@@ -2,7 +2,7 @@ import Foundation
 import NIOCore
 import NIOHTTP1
 
-final class AFMAsyncHTTPResponseWriter: @unchecked Sendable {
+actor AFMAsyncHTTPResponseWriter {
     enum WriterError: Error {
         case invalidEmissionSequence
         case inactiveChannel

--- a/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMAsyncHTTPResponseWriter.swift
@@ -1,0 +1,108 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
+final class AFMAsyncHTTPResponseWriter: @unchecked Sendable {
+    enum WriterError: Error {
+        case invalidEmissionSequence
+        case inactiveChannel
+    }
+
+    private let channel: any Channel
+    private let version: HTTPVersion
+    private let closeAfterResponse: Bool
+    private var responseStarted = false
+    private var isStreaming = false
+    private var responseEnded = false
+
+    var hasStarted: Bool {
+        responseStarted
+    }
+
+    init(channel: any Channel, version: HTTPVersion, closeAfterResponse: Bool) {
+        self.channel = channel
+        self.version = version
+        self.closeAfterResponse = closeAfterResponse || version != .http1_1
+    }
+
+    func write(_ emission: AFMHTTPEmission) async throws {
+        guard channel.isActive else { throw WriterError.inactiveChannel }
+        switch emission {
+        case .fixed(let response):
+            guard !responseStarted, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            responseStarted = true
+            try await writeFixed(response)
+            responseEnded = true
+        case .streamHead(let status, let headers):
+            guard !responseStarted, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            responseStarted = true
+            isStreaming = true
+            try await writeStreamHead(status: status, headers: headers)
+        case .streamBody(let data):
+            guard isStreaming, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            try await writeBody(data)
+        case .streamEnd:
+            guard isStreaming, !responseEnded else { throw WriterError.invalidEmissionSequence }
+            try await writeEnd()
+            responseEnded = true
+        }
+    }
+
+    func abort() async {
+        if channel.isActive {
+            try? await channel.close().get()
+        }
+    }
+
+    private func writeFixed(_ response: AFMHTTPResponse) async throws {
+        var headers = response.headers
+        headers.replaceOrAdd(name: "content-type", value: "application/json")
+        headers.replaceOrAdd(name: "content-length", value: String(response.body.count))
+        addSecurityHeaders(to: &headers, streaming: false)
+        try await writeHead(status: response.status, headers: headers)
+        if !response.body.isEmpty {
+            try await writeBody(response.body)
+        }
+        try await writeEnd()
+    }
+
+    private func writeStreamHead(status: HTTPResponseStatus, headers originalHeaders: HTTPHeaders) async throws {
+        var headers = originalHeaders
+        headers.replaceOrAdd(name: "content-type", value: "text/event-stream")
+        headers.remove(name: "content-length")
+        if version == .http1_1 {
+            headers.replaceOrAdd(name: "transfer-encoding", value: "chunked")
+        }
+        addSecurityHeaders(to: &headers, streaming: true)
+        try await writeHead(status: status, headers: headers)
+    }
+
+    private func addSecurityHeaders(to headers: inout HTTPHeaders, streaming: Bool) {
+        headers.replaceOrAdd(name: "cache-control", value: streaming ? "no-cache" : "no-store")
+        headers.replaceOrAdd(name: "x-content-type-options", value: "nosniff")
+        if closeAfterResponse {
+            headers.replaceOrAdd(name: "connection", value: "close")
+        } else if streaming {
+            headers.replaceOrAdd(name: "connection", value: "keep-alive")
+        }
+    }
+
+    private func writeHead(status: HTTPResponseStatus, headers: HTTPHeaders) async throws {
+        let head = HTTPResponseHead(version: version, status: status, headers: headers)
+        try await channel.writeAndFlush(HTTPServerResponsePart.head(head)).get()
+    }
+
+    private func writeBody(_ data: Data) async throws {
+        guard !data.isEmpty else { return }
+        var buffer = channel.allocator.buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        try await channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buffer))).get()
+    }
+
+    private func writeEnd() async throws {
+        try await channel.writeAndFlush(HTTPServerResponsePart.end(nil)).get()
+        if closeAfterResponse, channel.isActive {
+            try await channel.close().get()
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct AFMChatCompletionChunk: Encodable {
+    struct Choice: Encodable {
+        struct Delta: Encodable {
+            let role: String?
+            let content: String?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(role, forKey: .role)
+                try container.encodeIfPresent(content, forKey: .content)
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case role
+                case content
+            }
+        }
+
+        let index: Int
+        let delta: Delta
+        let finishReason: AFMChatFinishReason?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(index, forKey: .index)
+            try container.encode(delta, forKey: .delta)
+            try container.encodeNil(forKey: .logprobs)
+            if let finishReason {
+                try container.encode(finishReason, forKey: .finishReason)
+            } else {
+                try container.encodeNil(forKey: .finishReason)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case index
+            case delta
+            case logprobs
+            case finishReason = "finish_reason"
+        }
+    }
+
+    let id: String
+    let object = "chat.completion.chunk"
+    let created: Int64
+    let model: String
+    let choices: [Choice]
+    let usage: AFMChatUsagePayload?
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(object, forKey: .object)
+        try container.encode(created, forKey: .created)
+        try container.encode(model, forKey: .model)
+        try container.encode(choices, forKey: .choices)
+        if let usage {
+            try container.encode(usage, forKey: .usage)
+        } else {
+            try container.encodeNil(forKey: .usage)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case created
+        case model
+        case choices
+        case usage
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
@@ -5,16 +5,19 @@ struct AFMChatCompletionChunk: Encodable {
         struct Delta: Encodable {
             let role: String?
             let content: String?
+            let refusal: String?
 
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(role, forKey: .role)
                 try container.encodeIfPresent(content, forKey: .content)
+                try container.encodeIfPresent(refusal, forKey: .refusal)
             }
 
             private enum CodingKeys: String, CodingKey {
                 case role
                 case content
+                case refusal
             }
         }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
@@ -45,6 +45,8 @@ public struct AFMChatMessage: Sendable, Equatable {
 public struct AFMChatGenerationRequest: Sendable, Equatable {
     public let model: String
     public let messages: [AFMChatMessage]
+    public let stream: Bool
+    public let streamOptions: AFMChatStreamOptions?
     public let temperature: Double?
     public let topP: Double?
     public let maximumCompletionTokens: Int?
@@ -52,12 +54,16 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
     public init(
         model: String = "system",
         messages: [AFMChatMessage],
+        stream: Bool = false,
+        streamOptions: AFMChatStreamOptions? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
         maximumCompletionTokens: Int? = nil
     ) {
         self.model = model
         self.messages = messages
+        self.stream = stream
+        self.streamOptions = streamOptions
         self.temperature = temperature
         self.topP = topP
         self.maximumCompletionTokens = maximumCompletionTokens
@@ -74,21 +80,18 @@ extension AFMChatGenerationRequest: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AFMJSONKey.self)
         try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
-        try rejectUnsupportedFields(
-            ["tools", "tool_choice", "response_format", "stream_options"],
-            in: container,
-            decoder: decoder
-        )
-
-        if try container.decodeIfPresent(Bool.self, forKey: .init("stream")) == true {
-            throw AFMChatRequestValidationError.unsupportedField("stream")
-        }
+        try rejectUnsupportedFields(["response_format"], in: container, decoder: decoder)
 
         let model = try container.decodeIfPresent(String.self, forKey: .init("model")) ?? "system"
         guard container.contains(.init("messages")) else {
             throw AFMChatRequestValidationError.missingField("messages")
         }
         let messages = try container.decode([AFMChatMessage].self, forKey: .init("messages"))
+        let stream = try container.decodeIfPresent(Bool.self, forKey: .init("stream")) ?? false
+        let streamOptions = try container.decodeIfPresent(
+            AFMChatStreamOptions.self,
+            forKey: .init("stream_options")
+        )
         let temperature = try container.decodeIfPresent(Double.self, forKey: .init("temperature"))
         let topP = try container.decodeIfPresent(Double.self, forKey: .init("top_p"))
         let maximumCompletionTokens = try container.decodeIfPresent(
@@ -98,6 +101,8 @@ extension AFMChatGenerationRequest: Decodable {
         let legacyMaximumTokens = try container.decodeIfPresent(Int.self, forKey: .init("max_tokens"))
 
         try Self.validateModel(model)
+        try Self.validateStreaming(stream: stream, streamOptions: streamOptions)
+        try Self.validateEmptyToolSentinel(in: container)
         try Self.validateOptions(
             temperature: temperature,
             topP: topP,
@@ -109,6 +114,8 @@ extension AFMChatGenerationRequest: Decodable {
         self.init(
             model: model,
             messages: messages,
+            stream: stream,
+            streamOptions: streamOptions,
             temperature: temperature,
             topP: topP,
             maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens
@@ -130,6 +137,36 @@ extension AFMChatGenerationRequest: Decodable {
     private static func validateModel(_ model: String) throws {
         guard !model.isEmpty, model == model.trimmingCharacters(in: .whitespacesAndNewlines) else {
             throw AFMChatRequestValidationError.invalidField("model", message: "Model must be a non-empty identifier.")
+        }
+    }
+
+    private static func validateStreaming(
+        stream: Bool,
+        streamOptions: AFMChatStreamOptions?
+    ) throws {
+        guard stream || streamOptions == nil else {
+            throw AFMChatRequestValidationError.invalidField(
+                "stream_options",
+                message: "stream_options may only be used when stream is true."
+            )
+        }
+    }
+
+    private static func validateEmptyToolSentinel(
+        in container: KeyedDecodingContainer<AFMJSONKey>
+    ) throws {
+        let toolsKey = AFMJSONKey("tools")
+        if container.contains(toolsKey), try !container.decodeNil(forKey: toolsKey) {
+            let tools = try container.nestedUnkeyedContainer(forKey: toolsKey)
+            guard tools.isAtEnd else {
+                throw AFMChatRequestValidationError.unsupportedField("tools")
+            }
+        }
+
+        let toolChoiceKey = AFMJSONKey("tool_choice")
+        if let toolChoice = try container.decodeIfPresent(String.self, forKey: toolChoiceKey),
+           toolChoice != "auto" {
+            throw AFMChatRequestValidationError.unsupportedField("tool_choice")
         }
     }
 
@@ -182,7 +219,7 @@ struct AFMChatRequestValidationError: Error, Equatable, Sendable {
 
     static func unsupportedField(_ parameter: String) -> Self {
         .init(
-            message: "Field '\(parameter)' is not supported by non-streaming chat completions yet.",
+            message: "Field '\(parameter)' is not supported by this chat completions endpoint.",
             parameter: parameter,
             code: "unsupported_field"
         )

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionResponse.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionResponse.swift
@@ -3,6 +3,7 @@ import FoundationModelsKit
 
 public enum AFMChatFinishReason: String, Sendable, Equatable, Encodable {
     case stop
+    case length
     case contentFilter = "content_filter"
 }
 
@@ -27,6 +28,24 @@ public struct AFMChatGenerationResult: Sendable, Equatable {
 
 public protocol AFMChatCompletionGenerating: Sendable {
     func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult
+
+    func stream(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult
+}
+
+public extension AFMChatCompletionGenerating {
+    func stream(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        let result = try await generate(request)
+        if let content = result.content, !content.isEmpty {
+            try await event(.contentDelta(content))
+        }
+        return result
+    }
 }
 
 public enum AFMChatGenerationError: Error, Sendable, Equatable {

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationModelsKit
 import NIOHTTP1
 
 actor AFMGenerationGate {
@@ -72,7 +73,104 @@ struct AFMChatCompletionService: Sendable {
         }
     }
 
-    private func validateModel(_ identifier: String) -> AFMHTTPResponse? {
+    func writeResponse(
+        for body: Data,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        let request: AFMChatGenerationRequest
+        do {
+            request = try AFMChatGenerationRequest.decode(body)
+        } catch let error as AFMChatRequestValidationError {
+            try await emission(.fixed(validationErrorResponse(error)))
+            return
+        }
+
+        guard request.stream else {
+            try await emission(.fixed(try await response(for: body)))
+            return
+        }
+        if let modelError = validateModel(request.model) {
+            try await emission(.fixed(modelError))
+            return
+        }
+        guard await gate.tryAcquire() else {
+            try await emission(.fixed(serverBusyResponse()))
+            return
+        }
+
+        try await writeStreamingResponse(request, emitting: emission)
+    }
+}
+
+private extension AFMChatCompletionService {
+    func writeStreamingResponse(
+        _ request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        var sentStreamHead = false
+        do {
+            let identifier = "chatcmpl-\(UUID().uuidString)"
+            let created = clock.unixTime()
+            try await emission(.streamHead(status: .ok, headers: .init()))
+            sentStreamHead = true
+            try await writeChunk(
+                identifier: identifier,
+                created: created,
+                role: "assistant",
+                request: request,
+                emitting: emission
+            )
+
+            let result = try await streamWithTimeout(request) { event in
+                switch event {
+                case .contentDelta(let content):
+                    try await writeChunk(
+                        identifier: identifier,
+                        created: created,
+                        content: content,
+                        request: request,
+                        emitting: emission
+                    )
+                }
+            }
+            try await writeChunk(
+                identifier: identifier,
+                created: created,
+                finishReason: result.finishReason,
+                request: request,
+                emitting: emission
+            )
+            if request.streamOptions?.includeUsage == true {
+                try await writeUsageChunk(
+                    result.usage,
+                    identifier: identifier,
+                    created: created,
+                    request: request,
+                    emitting: emission
+                )
+            }
+            try await emission(.streamBody(AFMServerSentEventEncoder().done))
+            try await emission(.streamEnd)
+            await gate.release()
+        } catch is CancellationError {
+            await gate.release()
+            throw CancellationError()
+        } catch let error as AFMAsyncHTTPResponseWriter.WriterError {
+            await gate.release()
+            throw error
+        } catch {
+            await gate.release()
+            if sentStreamHead {
+                let response = generationErrorResponse(error)
+                try await emission(.streamBody(AFMServerSentEventEncoder().event(json: response.body)))
+                try await emission(.streamEnd)
+            } else {
+                try await emission(.fixed(generationErrorResponse(error)))
+            }
+        }
+    }
+
+    func validateModel(_ identifier: String) -> AFMHTTPResponse? {
         guard let model = catalog.models().first(where: { $0.id == identifier }) else {
             return .apiError(
                 status: .notFound,
@@ -93,7 +191,16 @@ struct AFMChatCompletionService: Sendable {
         return nil
     }
 
-    private func generateWithTimeout(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+    func serverBusyResponse() -> AFMHTTPResponse {
+        .apiError(
+            status: .tooManyRequests,
+            message: "The local model is already handling the configured number of requests.",
+            code: "server_busy",
+            type: "rate_limit_error"
+        )
+    }
+
+    func generateWithTimeout(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
         try await withThrowingTaskGroup(of: AFMChatGenerationResult.self) { group in
             group.addTask {
                 try await generator.generate(request)
@@ -110,7 +217,27 @@ struct AFMChatCompletionService: Sendable {
         }
     }
 
-    private func completionResponse(
+    func streamWithTimeout(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        try await withThrowingTaskGroup(of: AFMChatGenerationResult.self) { group in
+            group.addTask {
+                try await generator.stream(request, emitting: event)
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: .seconds(timeoutSeconds))
+                throw AFMChatServiceError.timedOut
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw AFMChatServiceError.missingResult
+            }
+            return result
+        }
+    }
+
+    func completionResponse(
         _ result: AFMChatGenerationResult,
         request: AFMChatGenerationRequest
     ) -> AFMHTTPResponse {
@@ -131,7 +258,49 @@ struct AFMChatCompletionService: Sendable {
         )
     }
 
-    private func validationErrorResponse(_ error: AFMChatRequestValidationError) -> AFMHTTPResponse {
+    func writeChunk(
+        identifier: String,
+        created: Int64,
+        role: String? = nil,
+        content: String? = nil,
+        finishReason: AFMChatFinishReason? = nil,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        let chunk = AFMChatCompletionChunk(
+            id: identifier,
+            created: created,
+            model: request.model,
+            choices: [
+                .init(
+                    index: 0,
+                    delta: .init(role: role, content: content),
+                    finishReason: finishReason
+                )
+            ],
+            usage: nil
+        )
+        try await emission(.streamBody(try AFMServerSentEventEncoder().event(chunk)))
+    }
+
+    func writeUsageChunk(
+        _ usage: ModelTokenUsage,
+        identifier: String,
+        created: Int64,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        let chunk = AFMChatCompletionChunk(
+            id: identifier,
+            created: created,
+            model: request.model,
+            choices: [],
+            usage: .init(usage)
+        )
+        try await emission(.streamBody(try AFMServerSentEventEncoder().event(chunk)))
+    }
+
+    func validationErrorResponse(_ error: AFMChatRequestValidationError) -> AFMHTTPResponse {
         .apiError(
             status: .badRequest,
             message: error.message,
@@ -140,7 +309,7 @@ struct AFMChatCompletionService: Sendable {
         )
     }
 
-    private func generationErrorResponse(_ error: Error) -> AFMHTTPResponse {
+    func generationErrorResponse(_ error: Error) -> AFMHTTPResponse {
         switch error {
         case AFMChatServiceError.timedOut:
             .apiError(
@@ -193,7 +362,7 @@ struct AFMChatCompletionService: Sendable {
         }
     }
 
-    private func generationFailure(
+    func generationFailure(
         _ status: HTTPResponseStatus,
         _ message: String,
         _ code: String,

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
@@ -133,22 +133,13 @@ private extension AFMChatCompletionService {
                     )
                 }
             }
-            try await writeChunk(
+            try await writeTerminalChunks(
+                result,
                 identifier: identifier,
                 created: created,
-                finishReason: result.finishReason,
                 request: request,
                 emitting: emission
             )
-            if request.streamOptions?.includeUsage == true {
-                try await writeUsageChunk(
-                    result.usage,
-                    identifier: identifier,
-                    created: created,
-                    request: request,
-                    emitting: emission
-                )
-            }
             try await emission(.streamBody(AFMServerSentEventEncoder().done))
             try await emission(.streamEnd)
             await gate.release()
@@ -263,6 +254,7 @@ private extension AFMChatCompletionService {
         created: Int64,
         role: String? = nil,
         content: String? = nil,
+        refusal: String? = nil,
         finishReason: AFMChatFinishReason? = nil,
         request: AFMChatGenerationRequest,
         emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
@@ -274,13 +266,62 @@ private extension AFMChatCompletionService {
             choices: [
                 .init(
                     index: 0,
-                    delta: .init(role: role, content: content),
+                    delta: .init(role: role, content: content, refusal: refusal),
                     finishReason: finishReason
                 )
             ],
             usage: nil
         )
         try await emission(.streamBody(try AFMServerSentEventEncoder().event(chunk)))
+    }
+
+    func writeRefusalChunk(
+        _ refusal: String?,
+        identifier: String,
+        created: Int64,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        guard let refusal else { return }
+        try await writeChunk(
+            identifier: identifier,
+            created: created,
+            refusal: refusal,
+            request: request,
+            emitting: emission
+        )
+    }
+
+    func writeTerminalChunks(
+        _ result: AFMChatGenerationResult,
+        identifier: String,
+        created: Int64,
+        request: AFMChatGenerationRequest,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
+        try await writeRefusalChunk(
+            result.refusal,
+            identifier: identifier,
+            created: created,
+            request: request,
+            emitting: emission
+        )
+        try await writeChunk(
+            identifier: identifier,
+            created: created,
+            finishReason: result.finishReason,
+            request: request,
+            emitting: emission
+        )
+        if request.streamOptions?.includeUsage == true {
+            try await writeUsageChunk(
+                result.usage,
+                identifier: identifier,
+                created: created,
+                request: request,
+                emitting: emission
+            )
+        }
     }
 
     func writeUsageChunk(

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatGenerationEvent.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatGenerationEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum AFMChatGenerationEvent: Sendable, Equatable {
+    case contentDelta(String)
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatStreamOptions.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatStreamOptions.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct AFMChatStreamOptions: Sendable, Equatable {
+    public let includeUsage: Bool
+
+    public init(includeUsage: Bool = false) {
+        self.includeUsage = includeUsage
+    }
+}
+
+extension AFMChatStreamOptions: Decodable {
+    private static let allowedFields: Set<String> = ["include_usage"]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        includeUsage = try container.decodeIfPresent(Bool.self, forKey: .init("include_usage")) ?? false
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -25,7 +25,51 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         do {
             let response = try await session.respond(to: prepared.prompt, options: prepared.options)
             let usage = await responseUsage(response, prepared: prepared)
-            return AFMChatGenerationResult(content: response.content, usage: usage)
+            return AFMChatGenerationResult(
+                content: response.content,
+                finishReason: finishReason(for: request, usage: usage),
+                usage: usage
+            )
+        } catch {
+            if Self.isRefusal(error) {
+                return await refusalResult(prepared: prepared)
+            }
+            throw Self.mappedError(error)
+        }
+    }
+
+    public func stream(
+        _ request: AFMChatGenerationRequest,
+        emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        let prepared = try AFMChatTranscriptBuilder.prepare(request)
+        let session = try sessionBuilder(request.model, prepared.transcript)
+        let responseStream = session.streamResponse(to: prepared.prompt, options: prepared.options)
+        var accumulator = AFMSnapshotDeltaAccumulator()
+
+        do {
+            for try await snapshot in responseStream {
+                try Task.checkCancellation()
+                let delta = try accumulator.append(snapshot: snapshot.content)
+                if !delta.isEmpty {
+                    try await event(.contentDelta(delta))
+                }
+            }
+
+            try Task.checkCancellation()
+            let response = try await responseStream.collect()
+            let finalDelta = try accumulator.append(snapshot: response.content)
+            if !finalDelta.isEmpty {
+                try await event(.contentDelta(finalDelta))
+            }
+            try Task.checkCancellation()
+            let usage = await responseUsage(response, prepared: prepared)
+            let result = AFMChatGenerationResult(
+                content: response.content,
+                finishReason: finishReason(for: request, usage: usage),
+                usage: usage
+            )
+            return result
         } catch {
             if Self.isRefusal(error) {
                 return await refusalResult(prepared: prepared)
@@ -61,6 +105,19 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
             finishReason: .contentFilter,
             usage: usage
         )
+    }
+
+    private func finishReason(
+        for request: AFMChatGenerationRequest,
+        usage: ModelTokenUsage
+    ) -> AFMChatFinishReason {
+        guard let limit = request.maximumCompletionTokens,
+              let output = usage.output,
+              output.totalTokenCount >= limit,
+              output.totalTokenCount > 0 else {
+            return .stop
+        }
+        return .length
     }
 
     private func fallbackUsage(input: Transcript, output: String) async -> ModelTokenUsage {

--- a/Packages/AFMServer/Sources/AFMServer/AFMHTTPEmission.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMHTTPEmission.swift
@@ -1,0 +1,9 @@
+import Foundation
+import NIOHTTP1
+
+enum AFMHTTPEmission: Sendable {
+    case fixed(AFMHTTPResponse)
+    case streamHead(status: HTTPResponseStatus, headers: HTTPHeaders)
+    case streamBody(Data)
+    case streamEnd
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
@@ -177,7 +177,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             } catch is CancellationError {
                 return
             } catch {
-                if !writer.hasStarted {
+                if !(await writer.hasStarted) {
                     try? await writer.write(
                         .fixed(
                             .apiError(

--- a/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMHTTPHandler.swift
@@ -82,17 +82,7 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
                 return
             }
             cancelGeneration()
-            responseWasSent = true
-            send(
-                .apiError(
-                    status: .badRequest,
-                    message: "Only one request may be active on a connection.",
-                    code: "invalid_http_request"
-                ),
-                version: head.version,
-                close: true,
-                context: context
-            )
+            context.close(promise: nil)
             return
         }
 
@@ -171,43 +161,61 @@ final class AFMHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         context: ChannelHandlerContext
     ) {
         let router = router
+        responseWasSent = true
+        let writer = AFMAsyncHTTPResponseWriter(
+            channel: context.channel,
+            version: head.version,
+            closeAfterResponse: !head.isKeepAlive
+        )
         let contextReference = AFMChannelContextReference(context)
         let eventLoop = context.eventLoop
         generationTask = Task { [weak self] in
-            let response: AFMHTTPResponse
             do {
-                response = try await router.chatCompletionResponse(body: body, origin: origin)
+                try await router.writeChatCompletionResponse(body: body, origin: origin) { emission in
+                    try await writer.write(emission)
+                }
             } catch is CancellationError {
                 return
             } catch {
-                response = .apiError(
-                    status: .internalServerError,
-                    message: "The chat completion request failed.",
-                    code: "internal_error",
-                    type: "server_error"
-                )
+                if !writer.hasStarted {
+                    try? await writer.write(
+                        .fixed(
+                            .apiError(
+                                status: .internalServerError,
+                                message: "The chat completion request failed.",
+                                code: "internal_error",
+                                type: "server_error"
+                            )
+                        )
+                    )
+                } else {
+                    await writer.abort()
+                }
             }
             guard !Task.isCancelled else { return }
             eventLoop.execute { [weak self] in
-                self?.completeChatCompletion(
-                    response,
-                    head: head,
-                    context: contextReference.context
-                )
+                self?.completeChatCompletion(context: contextReference.context)
             }
         }
     }
 
-    private func completeChatCompletion(
-        _ response: AFMHTTPResponse,
-        head: HTTPRequestHead,
-        context: ChannelHandlerContext
-    ) {
+    private func completeChatCompletion(context: ChannelHandlerContext) {
         generationTask = nil
-        guard requestHead != nil, !responseWasSent, context.channel.isActive else { return }
-        let shouldClose = !head.isKeepAlive || shouldCloseForPipelinedRequest
+        guard requestHead != nil, context.channel.isActive else { return }
+        let shouldClose = shouldCloseForPipelinedRequest
         resetRequestState()
-        send(response, version: head.version, close: shouldClose, context: context)
+        if shouldClose {
+            isClosingResponse = true
+            context.close(promise: nil)
+        }
+    }
+}
+
+private final class AFMChannelContextReference: @unchecked Sendable {
+    let context: ChannelHandlerContext
+
+    init(_ context: ChannelHandlerContext) {
+        self.context = context
     }
 }
 
@@ -303,13 +311,5 @@ private extension AFMHTTPHandler {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return mediaType == "application/json"
-    }
-}
-
-private final class AFMChannelContextReference: @unchecked Sendable {
-    let context: ChannelHandlerContext
-
-    init(_ context: ChannelHandlerContext) {
-        self.context = context
     }
 }

--- a/Packages/AFMServer/Sources/AFMServer/AFMRequestRouter.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMRequestRouter.swift
@@ -89,16 +89,27 @@ struct AFMRequestRouter: Sendable {
         return route.addingOrigin(originResult.origin)
     }
 
-    func chatCompletionResponse(body: Data, origin: String?) async throws -> AFMHTTPResponse {
+    func writeChatCompletionResponse(
+        body: Data,
+        origin: String?,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws {
         guard let chatCompletions else {
-            return AFMHTTPResponse.apiError(
-                status: .notImplemented,
-                message: "Chat completions are not configured for this server.",
-                code: "not_implemented",
-                type: "server_error"
-            ).addingOrigin(origin)
+            try await emission(
+                .fixed(
+                    AFMHTTPResponse.apiError(
+                        status: .notImplemented,
+                        message: "Chat completions are not configured for this server.",
+                        code: "not_implemented",
+                        type: "server_error"
+                    ).addingOrigin(origin)
+                )
+            )
+            return
         }
-        return try await chatCompletions.response(for: body).addingOrigin(origin)
+        try await chatCompletions.writeResponse(for: body) { response in
+            try await emission(response.addingOrigin(origin))
+        }
     }
 
     func requiresJSONBody(_ request: HTTPRequestHead) -> Bool {
@@ -211,6 +222,22 @@ private extension AFMHTTPResponse {
         updatedHeaders.add(name: "access-control-allow-origin", value: origin)
         updatedHeaders.add(name: "vary", value: "Origin")
         return .init(status: status, headers: updatedHeaders, body: body)
+    }
+}
+
+private extension AFMHTTPEmission {
+    func addingOrigin(_ origin: String?) -> Self {
+        guard let origin else { return self }
+        switch self {
+        case .fixed(let response):
+            return .fixed(response.addingOrigin(origin))
+        case .streamHead(let status, var headers):
+            headers.add(name: "access-control-allow-origin", value: origin)
+            headers.add(name: "vary", value: "Origin")
+            return .streamHead(status: status, headers: headers)
+        case .streamBody, .streamEnd:
+            return self
+        }
     }
 }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMServerSentEventEncoder.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMServerSentEventEncoder.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct AFMServerSentEventEncoder: Sendable {
+    private let encoder: JSONEncoder
+
+    init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    func event<T: Encodable>(_ value: T) throws -> Data {
+        event(json: try encoder.encode(value))
+    }
+
+    func event(json: Data) -> Data {
+        var data = Data("data: ".utf8)
+        data.append(json)
+        data.append(Data("\n\n".utf8))
+        return data
+    }
+
+    var done: Data {
+        Data("data: [DONE]\n\n".utf8)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMSnapshotDeltaAccumulator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMSnapshotDeltaAccumulator.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct AFMSnapshotDeltaAccumulator: Sendable {
+    enum AccumulationError: Error, Equatable {
+        case nonMonotonicSnapshot
+    }
+
+    private(set) var content = ""
+
+    mutating func append(snapshot: String) throws -> String {
+        guard snapshot.hasPrefix(content) else {
+            throw AccumulationError.nonMonotonicSnapshot
+        }
+        let delta = String(snapshot.dropFirst(content.count))
+        content = snapshot
+        return delta
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
@@ -30,7 +30,8 @@ struct AFMAsyncHTTPResponseWriterTests {
             Issue.record("Unexpected writer error: \(error)")
         }
 
-        #expect(writer.hasStarted)
+        let hasStarted = await writer.hasStarted
+        #expect(hasStarted)
         let outbound = try #require(
             try channel.readOutbound(as: HTTPServerResponsePart.self)
         )

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMAsyncHTTPResponseWriterTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import Testing
+@testable import AFMServer
+
+@Suite("Async HTTP response writer")
+struct AFMAsyncHTTPResponseWriterTests {
+    @Test("A partial fixed response remains marked as started")
+    func partialFixedResponseTracksStartedState() async throws {
+        let channel = EmbeddedChannel(handler: FailingBodyHandler())
+        try await channel.connect(
+            to: SocketAddress(unixDomainSocketPath: "/afm-writer-test")
+        ).get()
+        let writer = AFMAsyncHTTPResponseWriter(
+            channel: channel,
+            version: .http1_1,
+            closeAfterResponse: false
+        )
+
+        do {
+            try await writer.write(
+                .fixed(.init(status: .ok, body: Data("body".utf8)))
+            )
+            Issue.record("Expected the response body write to fail")
+        } catch let error as WriteFailure {
+            #expect(error == .body)
+        } catch {
+            Issue.record("Unexpected writer error: \(error)")
+        }
+
+        #expect(writer.hasStarted)
+        let outbound = try #require(
+            try channel.readOutbound(as: HTTPServerResponsePart.self)
+        )
+        guard case .head(let head) = outbound else {
+            Issue.record("Expected the response head to be written before the body failed")
+            return
+        }
+        #expect(head.status == .ok)
+        #expect(try channel.readOutbound(as: HTTPServerResponsePart.self) == nil)
+        _ = try? channel.finish()
+    }
+}
+
+private extension AFMAsyncHTTPResponseWriterTests {
+    enum WriteFailure: Error, Equatable {
+        case body
+    }
+
+    final class FailingBodyHandler: ChannelOutboundHandler, @unchecked Sendable {
+        typealias OutboundIn = HTTPServerResponsePart
+        typealias OutboundOut = HTTPServerResponsePart
+
+        func write(
+            context: ChannelHandlerContext,
+            data: NIOAny,
+            promise: EventLoopPromise<Void>?
+        ) {
+            let part = unwrapOutboundIn(data)
+            if case .body = part {
+                promise?.fail(WriteFailure.body)
+            } else {
+                context.write(wrapOutboundOut(part), promise: promise)
+            }
+        }
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
@@ -28,6 +28,40 @@ func chatRequestContentAndAlias() throws {
     #expect(request.maximumCompletionTokens == 42)
     #expect(request.temperature == 0.5)
     #expect(request.topP == 0.9)
+    #expect(!request.stream)
+    #expect(request.streamOptions == nil)
+}
+
+@Test("Chat requests accept Apple's streaming tool sentinel and usage option")
+func chatRequestAppleStreamingShape() throws {
+    let request = try decodeChatRequest(
+        """
+        {
+          "model": "system",
+          "messages": [{"role": "user", "content": "Hi"}],
+          "stream": true,
+          "stream_options": {"include_usage": true},
+          "tools": [],
+          "tool_choice": "auto"
+        }
+        """
+    )
+
+    #expect(request.stream)
+    #expect(request.streamOptions == .init(includeUsage: true))
+}
+
+@Test("Chat requests accept omitted and null tool sentinels")
+func chatRequestNullToolSentinels() throws {
+    let omitted = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"stream":true}"#
+    )
+    let null = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"stream":true,"tools":null,"tool_choice":null}"#
+    )
+
+    #expect(omitted.stream)
+    #expect(null.stream)
 }
 
 @Test("Chat requests reconstruct assistant tool calls and matching tool outputs")
@@ -44,8 +78,26 @@ func chatRequestToolHistory() throws {
 @Test(
     "Unsupported and unknown chat fields return precise validation errors",
     arguments: [
-        (#"{"messages":[{"role":"user","content":"Hi"}],"stream":true}"#, "stream", "unsupported_field"),
-        (#"{"messages":[{"role":"user","content":"Hi"}],"tools":[]}"#, "tools", "unsupported_field"),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function"}]}"#,
+            "tools",
+            "unsupported_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"tool_choice":"required"}"#,
+            "tool_choice",
+            "unsupported_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"stream_options":{"include_usage":true}}"#,
+            "stream_options",
+            "invalid_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"stream":true,"stream_options":{"extra":true}}"#,
+            "stream_options.extra",
+            "unknown_field"
+        ),
         (#"{"messages":[{"role":"user","content":"Hi"}],"response_format":{}}"#, "response_format", "unsupported_field"),
         (#"{"messages":[{"role":"user","content":"Hi"}],"surprise":1}"#, "surprise", "unknown_field"),
         (

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingIntegrationTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingIntegrationTests.swift
@@ -1,0 +1,310 @@
+import Darwin
+import Foundation
+import FoundationModelsKit
+import Testing
+@testable import AFMServer
+
+@Suite("Streaming chat transport")
+struct AFMChatStreamingIntegrationTests {
+    @Test("TCP streams the first SSE delta before generation completes")
+    func tcpStreamingFlushesIncrementally() async throws {
+        let probe = StagedProbe()
+        let server = try Self.server(generator: StagedGenerator(probe: probe))
+
+        do {
+            let address = try await server.start()
+            guard case .tcp(_, let port) = address else {
+                Issue.record("Expected a TCP address")
+                try await server.stop()
+                return
+            }
+            let descriptor = try Self.connect(port: port)
+            defer { Darwin.close(descriptor) }
+            try Self.write(Self.request(port: port), to: descriptor)
+
+            await probe.waitUntilFirstDeltaWasWritten()
+            let prefix = try Self.readUntil(#""content":"first""#, from: descriptor)
+            #expect(!(await probe.didComplete()))
+            #expect(prefix.lowercased().contains("content-type: text/event-stream"))
+            #expect(prefix.lowercased().contains("transfer-encoding: chunked"))
+            let header = prefix.split(separator: "\r\n\r\n", maxSplits: 1).first.map(String.init) ?? ""
+            #expect(!header.lowercased().contains("content-length:"))
+            #expect(prefix.contains(#""role":"assistant""#))
+
+            await probe.release()
+            let response = prefix + (try Self.readToEnd(from: descriptor))
+            #expect(response.hasPrefix("HTTP/1.1 200 OK"))
+            #expect(response.contains(#""content":"second""#))
+            #expect(response.contains(#""finish_reason":"stop""#))
+            #expect(response.contains(#""choices":[],"created":123"#))
+            #expect(response.contains(#""prompt_tokens":2"#))
+            #expect(response.contains("data: [DONE]\n\n"))
+            #expect(try Self.offset(of: #""content":"first""#, in: response) < Self.offset(of: #""content":"second""#, in: response))
+            #expect(try Self.offset(of: #""finish_reason":"stop""#, in: response) < Self.offset(of: "data: [DONE]", in: response))
+            #expect(await probe.didComplete())
+            try await server.stop()
+        } catch {
+            await probe.release()
+            try? await server.stop()
+            throw error
+        }
+    }
+
+    @Test("A TCP disconnect cancels streaming generation")
+    func tcpStreamingDisconnectCancellation() async throws {
+        let probe = CancellationProbe()
+        let server = try Self.server(generator: PausingGenerator(probe: probe))
+
+        do {
+            let address = try await server.start()
+            guard case .tcp(_, let port) = address else {
+                Issue.record("Expected a TCP address")
+                try await server.stop()
+                return
+            }
+            let descriptor = try Self.connect(port: port)
+            try Self.write(Self.request(port: port, close: false), to: descriptor)
+            await probe.waitUntilStarted()
+
+            var reset = linger(l_onoff: 1, l_linger: 0)
+            #expect(
+                setsockopt(
+                    descriptor,
+                    SOL_SOCKET,
+                    SO_LINGER,
+                    &reset,
+                    socklen_t(MemoryLayout<linger>.size)
+                ) == 0
+            )
+            #expect(Darwin.close(descriptor) == 0)
+            await probe.waitUntilCancelled()
+            try await server.stop()
+        } catch {
+            try? await server.stop()
+            throw error
+        }
+    }
+}
+
+private extension AFMChatStreamingIntegrationTests {
+    struct StagedGenerator: AFMChatCompletionGenerating {
+        let probe: StagedProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            Self.result
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            try await event(.contentDelta("first"))
+            await probe.markFirstDeltaWasWritten()
+            await probe.waitUntilReleased()
+            try await event(.contentDelta("second"))
+            await probe.markCompleted()
+            return Self.result
+        }
+
+        static let result = AFMChatGenerationResult(
+            content: "firstsecond",
+            usage: .init(
+                input: .init(totalTokenCount: 2),
+                output: .init(totalTokenCount: 2),
+                measurement: .estimated,
+                scope: .response
+            )
+        )
+    }
+
+    struct PausingGenerator: AFMChatCompletionGenerating {
+        let probe: CancellationProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            throw CancellationError()
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            try await withTaskCancellationHandler {
+                try await event(.contentDelta("first"))
+                await probe.markStarted()
+                try await ContinuousClock().sleep(for: .seconds(30))
+                return StagedGenerator.result
+            } onCancel: {
+                Task { await probe.markCancelled() }
+            }
+        }
+    }
+
+    actor StagedProbe {
+        private var firstDeltaWasWritten = false
+        private var completed = false
+        private var released = false
+        private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+        func markFirstDeltaWasWritten() { firstDeltaWasWritten = true }
+        func markCompleted() { completed = true }
+        func didComplete() -> Bool { completed }
+
+        func waitUntilFirstDeltaWasWritten() async {
+            while !firstDeltaWasWritten {
+                await Task.yield()
+            }
+        }
+
+        func waitUntilReleased() async {
+            guard !released else { return }
+            await withCheckedContinuation { releaseContinuation = $0 }
+        }
+
+        func release() {
+            released = true
+            releaseContinuation?.resume()
+            releaseContinuation = nil
+        }
+    }
+
+    actor CancellationProbe {
+        private var started = false
+        private var cancelled = false
+
+        func markStarted() { started = true }
+        func markCancelled() { cancelled = true }
+
+        func waitUntilStarted() async {
+            while !started {
+                await Task.yield()
+            }
+        }
+
+        func waitUntilCancelled() async {
+            while !cancelled {
+                await Task.yield()
+            }
+        }
+    }
+
+    struct TestClock: AFMServerClock {
+        func unixTime() -> Int64 { 123 }
+    }
+
+    struct SocketError: Error {
+        let operation: String
+        let code: Int32
+    }
+
+    static func server(generator: any AFMChatCompletionGenerating) throws -> AFMHTTPServer {
+        try AFMHTTPServer(
+            configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)),
+            catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+            clock: TestClock(),
+            generator: generator
+        )
+    }
+
+    static func request(port: Int, close: Bool = true) -> String {
+        let body = #"""
+        {"model":"system","messages":[{"role":"user","content":"Hi"}],"stream":true,
+        "stream_options":{"include_usage":true},"tools":[],"tool_choice":"auto"}
+        """#
+        var request = "POST /v1/chat/completions HTTP/1.1\r\n"
+        request += "Host: 127.0.0.1:\(port)\r\n"
+        request += "Content-Type: application/json\r\n"
+        request += "Content-Length: \(body.utf8.count)\r\n"
+        if close {
+            request += "Connection: close\r\n"
+        }
+        return request + "\r\n" + body
+    }
+
+    static func connect(port: Int) throws -> CInt {
+        let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw SocketError(operation: "socket", code: errno) }
+        var shouldClose = true
+        defer {
+            if shouldClose {
+                Darwin.close(descriptor)
+            }
+        }
+
+        var timeout = timeval(tv_sec: 2, tv_usec: 0)
+        guard setsockopt(
+            descriptor,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            &timeout,
+            socklen_t(MemoryLayout<timeval>.size)
+        ) == 0 else {
+            throw SocketError(operation: "setsockopt", code: errno)
+        }
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(port).bigEndian
+        guard "127.0.0.1".withCString({ inet_pton(AF_INET, $0, &address.sin_addr) }) == 1 else {
+            throw SocketError(operation: "inet_pton", code: errno)
+        }
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else { throw SocketError(operation: "connect", code: errno) }
+        shouldClose = false
+        return descriptor
+    }
+
+    static func write(_ request: String, to descriptor: CInt) throws {
+        try Array(request.utf8).withUnsafeBytes { buffer in
+            var sent = 0
+            while sent < buffer.count {
+                let count = Darwin.write(
+                    descriptor,
+                    buffer.baseAddress?.advanced(by: sent),
+                    buffer.count - sent
+                )
+                guard count > 0 else { throw SocketError(operation: "write", code: errno) }
+                sent += count
+            }
+        }
+    }
+
+    static func readUntil(_ needle: String, from descriptor: CInt) throws -> String {
+        var response = ""
+        while !response.contains(needle) {
+            let chunk = try readChunk(from: descriptor)
+            guard !chunk.isEmpty else { break }
+            response += chunk
+        }
+        return response
+    }
+
+    static func readToEnd(from descriptor: CInt) throws -> String {
+        var response = ""
+        while true {
+            let chunk = try readChunk(from: descriptor)
+            guard !chunk.isEmpty else { return response }
+            response += chunk
+        }
+    }
+
+    static func readChunk(from descriptor: CInt) throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 4_096)
+        let count = Darwin.read(descriptor, &bytes, bytes.count)
+        if count > 0 {
+            return String(bytes: bytes.prefix(count), encoding: .utf8) ?? ""
+        }
+        if count == 0 {
+            return ""
+        }
+        throw SocketError(operation: "read", code: errno)
+    }
+
+    static func offset(of needle: String, in value: String) throws -> Int {
+        let range = try #require(value.range(of: needle))
+        return value.distance(from: value.startIndex, to: range.lowerBound)
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
@@ -1,0 +1,386 @@
+import Foundation
+import FoundationModelsKit
+import NIOHTTP1
+import Testing
+@testable import AFMServer
+
+@Suite("Streaming chat completions")
+struct AFMChatStreamingServiceTests {
+    @Test("Streaming emits role, content deltas, finish, usage, and DONE")
+    func completeStreamShape() async throws {
+        let usage = ModelTokenUsage(
+            input: .init(totalTokenCount: 11, cachedTokenCount: 2),
+            output: .init(totalTokenCount: 7, reasoningTokenCount: 3),
+            measurement: .observed,
+            scope: .response
+        )
+        let generator = StreamingGenerator(
+            deltas: ["Hel", "lo"],
+            result: .init(content: "Hello", usage: usage)
+        )
+        let emissions = try await Self.collect(
+            Self.service(generator: generator),
+            body: Self.streamBody(includeUsage: true)
+        )
+
+        let firstEmission = try #require(emissions.first)
+        guard case .streamHead(let status, _) = firstEmission else {
+            Issue.record("Expected a streaming response head")
+            return
+        }
+        #expect(status == .ok)
+        let lastEmission = try #require(emissions.last)
+        guard case .streamEnd = lastEmission else {
+            Issue.record("Expected the stream to end")
+            return
+        }
+
+        let bodies = Self.streamBodies(emissions)
+        #expect(bodies.last == "data: [DONE]\n\n")
+        let chunks = try bodies.dropLast().map(Self.eventObject)
+        #expect(chunks.count == 5)
+
+        let firstChoice = try Self.choice(in: chunks[0])
+        let firstDelta = try #require(firstChoice["delta"] as? [String: Any])
+        #expect(firstDelta["role"] as? String == "assistant")
+        #expect(firstDelta["content"] == nil)
+        #expect(firstChoice["finish_reason"] is NSNull)
+
+        #expect(try Self.content(in: chunks[1]) == "Hel")
+        #expect(try Self.content(in: chunks[2]) == "lo")
+
+        let finishChoice = try Self.choice(in: chunks[3])
+        #expect(finishChoice["finish_reason"] as? String == "stop")
+        #expect((finishChoice["delta"] as? [String: Any])?.isEmpty == true)
+
+        #expect((chunks[4]["choices"] as? [Any])?.isEmpty == true)
+        let usageJSON = try #require(chunks[4]["usage"] as? [String: Any])
+        #expect(usageJSON["prompt_tokens"] as? Int == 11)
+        #expect(usageJSON["completion_tokens"] as? Int == 7)
+        #expect(usageJSON["total_tokens"] as? Int == 18)
+        #expect(usageJSON["afm_measurement"] as? String == "observed")
+        let promptDetails = try #require(usageJSON["prompt_tokens_details"] as? [String: Any])
+        let completionDetails = try #require(usageJSON["completion_tokens_details"] as? [String: Any])
+        #expect(promptDetails["cached_tokens"] as? Int == 2)
+        #expect(completionDetails["reasoning_tokens"] as? Int == 3)
+
+        let identifiers = chunks.compactMap { $0["id"] as? String }
+        #expect(Set(identifiers).count == 1)
+        #expect(identifiers.first?.hasPrefix("chatcmpl-") == true)
+        #expect(chunks.allSatisfy { $0["object"] as? String == "chat.completion.chunk" })
+        #expect(chunks.allSatisfy { $0["created"] as? Int == 123 })
+        #expect(chunks.allSatisfy { $0["model"] as? String == "system" })
+    }
+
+    @Test("Streaming omits usage unless requested and preserves length finish reason")
+    func streamWithoutUsage() async throws {
+        let generator = StreamingGenerator(
+            deltas: ["Done"],
+            result: .init(content: "Done", finishReason: .length, usage: Self.standardUsage())
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: Self.streamBody())
+        let bodies = Self.streamBodies(emissions)
+        let chunks = try bodies.dropLast().map(Self.eventObject)
+
+        #expect(chunks.count == 3)
+        #expect(try Self.choice(in: chunks[2])["finish_reason"] as? String == "length")
+        #expect(chunks.allSatisfy { !((($0["choices"] as? [Any])?.isEmpty) ?? false) })
+        #expect(bodies.last == "data: [DONE]\n\n")
+    }
+
+    @Test("Streaming refusals finish with content_filter")
+    func streamRefusal() async throws {
+        let generator = StreamingGenerator(
+            deltas: [],
+            result: .init(
+                content: nil,
+                refusal: "Declined",
+                finishReason: .contentFilter,
+                usage: Self.standardUsage()
+            )
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: Self.streamBody())
+        let chunks = try Self.streamBodies(emissions).dropLast().map(Self.eventObject)
+
+        #expect(chunks.count == 2)
+        #expect(try Self.choice(in: chunks[1])["finish_reason"] as? String == "content_filter")
+    }
+
+    @Test("Streaming awaits each emitted body before requesting the next delta")
+    func streamBackpressure() async throws {
+        let probe = BackpressureProbe()
+        let blocker = StreamBlocker()
+        let recorder = EmissionRecorder()
+        let chatService = Self.service(generator: BackpressureGenerator(probe: probe))
+        let task = Task {
+            try await chatService.writeResponse(for: Self.streamBody()) { emission in
+                await recorder.record(emission)
+                if case .streamBody(let data) = emission,
+                   String(bytes: data, encoding: .utf8)?.contains(#""content":"first""#) == true {
+                    await blocker.block()
+                }
+            }
+        }
+
+        await probe.waitUntilFirstAttempt()
+        await blocker.waitUntilBlocked()
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+        #expect(!(await probe.didAttemptSecond()))
+
+        await blocker.release()
+        try await task.value
+        #expect(await probe.didAttemptSecond())
+        #expect(Self.streamBodies(await recorder.snapshot()).contains { $0.contains(#""content":"second""#) })
+    }
+
+    @Test("A streaming timeout cancels generation and stays inside SSE framing")
+    func streamTimeout() async throws {
+        let probe = CancellationProbe()
+        let chatService = Self.service(
+            generator: PausingGenerator(probe: probe),
+            policy: .init(maximumConcurrentGenerations: 1, timeoutSeconds: 0.01)
+        )
+        let emissions = try await Self.collect(chatService, body: Self.streamBody())
+        await probe.waitUntilCancelled()
+
+        let firstEmission = try #require(emissions.first)
+        guard case .streamHead = firstEmission else {
+            Issue.record("Expected timeout after the SSE response started")
+            return
+        }
+        let lastEmission = try #require(emissions.last)
+        guard case .streamEnd = lastEmission else {
+            Issue.record("Expected the timed-out SSE response to end")
+            return
+        }
+        let errorEvent = try #require(Self.streamBodies(emissions).last)
+        let error = try Self.eventObject(errorEvent)
+        let errorBody = try #require(error["error"] as? [String: Any])
+        #expect(errorBody["code"] as? String == "model_timeout")
+
+        let retry = try await Self.collect(chatService, body: Self.streamBody())
+        let retryFirstEmission = try #require(retry.first)
+        guard case .streamHead = retryFirstEmission else {
+            Issue.record("Expected the generation permit to be released after timeout")
+            return
+        }
+    }
+
+    @Test("Streaming validation errors stay as JSON before the SSE response starts")
+    func streamValidationError() async throws {
+        let generator = StreamingGenerator(deltas: [], result: Self.standardResult())
+        let body = Data(
+            #"{"messages":[{"role":"user","content":"Hi"}],"stream":true,"tools":[{}]}"#.utf8
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: body)
+
+        #expect(emissions.count == 1)
+        guard case .fixed(let response) = try #require(emissions.first) else {
+            Issue.record("Expected a fixed JSON validation response")
+            return
+        }
+        #expect(response.status == .badRequest)
+        let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        #expect(error["code"] as? String == "unsupported_field")
+        #expect(error["param"] as? String == "tools")
+    }
+}
+
+private extension AFMChatStreamingServiceTests {
+    actor StreamingGenerator: AFMChatCompletionGenerating {
+        let deltas: [String]
+        let result: AFMChatGenerationResult
+
+        init(deltas: [String], result: AFMChatGenerationResult) {
+            self.deltas = deltas
+            self.result = result
+        }
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            result
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            for delta in deltas {
+                try await event(.contentDelta(delta))
+            }
+            return result
+        }
+    }
+
+    struct BackpressureGenerator: AFMChatCompletionGenerating {
+        let probe: BackpressureProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            AFMChatStreamingServiceTests.standardResult()
+        }
+
+        func stream(
+            _ request: AFMChatGenerationRequest,
+            emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
+        ) async throws -> AFMChatGenerationResult {
+            await probe.markFirstAttempt()
+            try await event(.contentDelta("first"))
+            await probe.markSecondAttempt()
+            try await event(.contentDelta("second"))
+            return AFMChatStreamingServiceTests.standardResult()
+        }
+    }
+
+    struct PausingGenerator: AFMChatCompletionGenerating {
+        let probe: CancellationProbe
+
+        func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+            await probe.markStarted()
+            return try await withTaskCancellationHandler {
+                try await ContinuousClock().sleep(for: .seconds(30))
+                return AFMChatStreamingServiceTests.standardResult()
+            } onCancel: {
+                Task { await probe.markCancelled() }
+            }
+        }
+    }
+
+    actor EmissionRecorder {
+        private var emissions: [AFMHTTPEmission] = []
+
+        func record(_ emission: AFMHTTPEmission) {
+            emissions.append(emission)
+        }
+
+        func snapshot() -> [AFMHTTPEmission] {
+            emissions
+        }
+    }
+
+    actor BackpressureProbe {
+        private var firstAttempted = false
+        private var secondAttempted = false
+
+        func markFirstAttempt() { firstAttempted = true }
+        func markSecondAttempt() { secondAttempted = true }
+        func didAttemptSecond() -> Bool { secondAttempted }
+
+        func waitUntilFirstAttempt() async {
+            while !firstAttempted {
+                await Task.yield()
+            }
+        }
+    }
+
+    actor StreamBlocker {
+        private var isBlocked = false
+        private var isReleased = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func block() async {
+            isBlocked = true
+            guard !isReleased else { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func waitUntilBlocked() async {
+            while !isBlocked {
+                await Task.yield()
+            }
+        }
+
+        func release() {
+            isReleased = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    actor CancellationProbe {
+        private var cancelled = false
+
+        func markStarted() {}
+        func markCancelled() { cancelled = true }
+
+        func waitUntilCancelled() async {
+            while !cancelled {
+                await Task.yield()
+            }
+        }
+    }
+
+    struct TestClock: AFMServerClock {
+        func unixTime() -> Int64 { 123 }
+    }
+
+    static func service(
+        generator: any AFMChatCompletionGenerating,
+        policy: AFMServerGenerationPolicy = .init()
+    ) -> AFMChatCompletionService {
+        AFMChatCompletionService(
+            catalog: AFMStaticModelCatalog(models: [.init(id: "system", isAvailable: true)]),
+            generator: generator,
+            clock: TestClock(),
+            policy: policy
+        )
+    }
+
+    static func collect(
+        _ service: AFMChatCompletionService,
+        body: Data
+    ) async throws -> [AFMHTTPEmission] {
+        let recorder = EmissionRecorder()
+        try await service.writeResponse(for: body) { emission in
+            await recorder.record(emission)
+        }
+        return await recorder.snapshot()
+    }
+
+    static func streamBody(includeUsage: Bool = false) -> Data {
+        let options = includeUsage ? #", "stream_options":{"include_usage":true}"# : ""
+        return Data(
+            #"{"model":"system","messages":[{"role":"user","content":"Hi"}],"stream":true\#(options)}"#.utf8
+        )
+    }
+
+    static func streamBodies(_ emissions: [AFMHTTPEmission]) -> [String] {
+        emissions.compactMap { emission in
+            guard case .streamBody(let data) = emission else { return nil }
+            return String(bytes: data, encoding: .utf8)
+        }
+    }
+
+    static func eventObject(_ event: String) throws -> [String: Any] {
+        let prefix = "data: "
+        #expect(event.hasPrefix(prefix))
+        let json = event.dropFirst(prefix.count).dropLast(2)
+        return try #require(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+    }
+
+    static func choice(in chunk: [String: Any]) throws -> [String: Any] {
+        let choices = try #require(chunk["choices"] as? [[String: Any]])
+        return try #require(choices.first)
+    }
+
+    static func content(in chunk: [String: Any]) throws -> String? {
+        let delta = try #require(try choice(in: chunk)["delta"] as? [String: Any])
+        return delta["content"] as? String
+    }
+
+    static func standardUsage() -> ModelTokenUsage {
+        .init(
+            input: .init(totalTokenCount: 1),
+            output: .init(totalTokenCount: 1),
+            measurement: .estimated,
+            scope: .response
+        )
+    }
+
+    static func standardResult() -> AFMChatGenerationResult {
+        .init(content: "firstsecond", usage: standardUsage())
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
@@ -102,8 +102,12 @@ struct AFMChatStreamingServiceTests {
         let emissions = try await Self.collect(Self.service(generator: generator), body: Self.streamBody())
         let chunks = try Self.streamBodies(emissions).dropLast().map(Self.eventObject)
 
-        #expect(chunks.count == 2)
-        #expect(try Self.choice(in: chunks[1])["finish_reason"] as? String == "content_filter")
+        #expect(chunks.count == 3)
+        let refusalChoice = try Self.choice(in: chunks[1])
+        let refusalDelta = try #require(refusalChoice["delta"] as? [String: Any])
+        #expect(refusalDelta["refusal"] as? String == "Declined")
+        #expect(refusalChoice["finish_reason"] is NSNull)
+        #expect(try Self.choice(in: chunks[2])["finish_reason"] as? String == "content_filter")
     }
 
     @Test("Streaming awaits each emitted body before requesting the next delta")

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -106,7 +106,6 @@ func tcpPipelinedChatCompletion() async throws {
         let response = try await responseTask.value
         #expect(response.components(separatedBy: "HTTP/1.1 200 OK").count == 2)
         #expect(response.contains(#""object":"chat.completion""#))
-        #expect(response.contains("connection: close"))
         #expect(!response.contains(#""status":"afm serve is running""#))
         #expect(!response.contains("HTTP/1.1 400 Bad Request"))
         try await server.stop()

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMSnapshotDeltaAccumulatorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMSnapshotDeltaAccumulatorTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import AFMServer
+
+@Test("Snapshot accumulation emits only new cumulative content")
+func snapshotAccumulatorDeltas() throws {
+    var accumulator = AFMSnapshotDeltaAccumulator()
+
+    #expect(try accumulator.append(snapshot: "Hel") == "Hel")
+    #expect(try accumulator.append(snapshot: "Hello") == "lo")
+    #expect(try accumulator.append(snapshot: "Hello") == "")
+    #expect(accumulator.content == "Hello")
+}
+
+@Test("Snapshot accumulation preserves extended grapheme clusters")
+func snapshotAccumulatorUnicode() throws {
+    var accumulator = AFMSnapshotDeltaAccumulator()
+
+    #expect(try accumulator.append(snapshot: "Hello 👨‍👩‍👧‍👦") == "Hello 👨‍👩‍👧‍👦")
+    #expect(try accumulator.append(snapshot: "Hello 👨‍👩‍👧‍👦!") == "!")
+}
+
+@Test("Snapshot accumulation rejects rewritten content")
+func snapshotAccumulatorRejectsNonMonotonicContent() throws {
+    var accumulator = AFMSnapshotDeltaAccumulator()
+    _ = try accumulator.append(snapshot: "Hello")
+
+    #expect(throws: AFMSnapshotDeltaAccumulator.AccumulationError.nonMonotonicSnapshot) {
+        try accumulator.append(snapshot: "Hallo")
+    }
+}

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -178,7 +178,8 @@ afm feedback export --prompt "What is the capital of France?" --sentiment positi
 ### Start the local server
 
 `afm serve` starts a transport for local integrations. It provides `GET /health`,
-`GET /v1/models`, and non-streaming `POST /v1/chat/completions`.
+`GET /v1/models`, and OpenAI-compatible `POST /v1/chat/completions`, including
+incremental server-sent event streaming.
 
 ```bash
 afm serve
@@ -187,14 +188,20 @@ curl http://127.0.0.1:1976/v1/models
 curl http://127.0.0.1:1976/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"system","messages":[{"role":"user","content":"Hello"}]}'
+curl -N http://127.0.0.1:1976/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"system","messages":[{"role":"user","content":"Hello"}],"stream":true,"stream_options":{"include_usage":true},"tools":[],"tool_choice":"auto"}'
 ```
 
 Chat requests are stateless: send the complete system, developer, user,
 assistant, and tool history each time. String content and typed text parts are
 supported, along with `temperature`, `top_p`, `max_completion_tokens`, and the
-legacy `max_tokens` alias. Streaming, image parts, response formats, and
-client-defined tools return a precise `400` until their dedicated endpoints are
-implemented. Responses include input/output usage plus an `afm_measurement`
+legacy `max_tokens` alias. Streaming emits assistant role and content deltas,
+a terminal finish reason, and `[DONE]`. Set `stream_options.include_usage` to
+receive a final empty-choices usage chunk. The empty `tools: []` and
+`tool_choice: "auto"` sentinels used by Apple's client are accepted; client-defined
+tools, image parts, and response formats return a precise `400` until their
+dedicated endpoints are implemented. Responses include input/output usage plus an `afm_measurement`
 value of `observed`, `tokenized`, or `estimated` so fallback counts are never
 presented as runtime observation.
 


### PR DESCRIPTION
## Summary

- add real SSE streaming to POST /v1/chat/completions while preserving the canonical stream=false default
- accept the native fm stream sentinel, stream_options.include_usage, empty tools, and tool_choice=auto
- emit role, incremental content, finish reason, optional usage, and [DONE] with stable completion metadata
- make every network write await backpressure and cancel generation when the client disconnects
- keep pre-header failures as JSON and post-header failures inside the SSE envelope
- report Xcode 27 framework-observed usage and an exact tokenized Xcode 26 fallback with explicit provenance

## Verification

- Xcode 26.6: AFMServer 81 tests passed
- Xcode 27: AFMServer 81 tests passed
- strict SwiftLint: 0 violations in 226 files
- live non-TTY smoke tests exercised both toolchains
- integration coverage proves the first SSE delta flushes before generation completes, disconnect cancellation, bounded writes, and partial-response error handling

## Compatibility notes

The native fm help text documents the singular /v1/chat/completion path, but the executable actually serves the plural /v1/chat/completions path. This PR follows the working native route and the OpenAI-compatible route already established by AFMServer. Unlike native fm, omitting stream remains non-streaming to preserve standard Chat Completions behavior.