### PR TITLE
Add JSON schema response formats

### DIFF
--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
@@ -50,6 +50,7 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
     public let temperature: Double?
     public let topP: Double?
     public let maximumCompletionTokens: Int?
+    public let responseFormat: AFMChatResponseFormat?
 
     public init(
         model: String = "system",
@@ -58,7 +59,8 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
         streamOptions: AFMChatStreamOptions? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
-        maximumCompletionTokens: Int? = nil
+        maximumCompletionTokens: Int? = nil,
+        responseFormat: AFMChatResponseFormat? = nil
     ) {
         self.model = model
         self.messages = messages
@@ -67,6 +69,7 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
         self.temperature = temperature
         self.topP = topP
         self.maximumCompletionTokens = maximumCompletionTokens
+        self.responseFormat = responseFormat
     }
 }
 
@@ -80,7 +83,6 @@ extension AFMChatGenerationRequest: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AFMJSONKey.self)
         try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
-        try rejectUnsupportedFields(["response_format"], in: container, decoder: decoder)
 
         let model = try container.decodeIfPresent(String.self, forKey: .init("model")) ?? "system"
         guard container.contains(.init("messages")) else {
@@ -99,6 +101,10 @@ extension AFMChatGenerationRequest: Decodable {
             forKey: .init("max_completion_tokens")
         )
         let legacyMaximumTokens = try container.decodeIfPresent(Int.self, forKey: .init("max_tokens"))
+        let responseFormat = try container.decodeIfPresent(
+            AFMChatResponseFormat.self,
+            forKey: .init("response_format")
+        )
 
         try Self.validateModel(model)
         try Self.validateStreaming(stream: stream, streamOptions: streamOptions)
@@ -118,7 +124,8 @@ extension AFMChatGenerationRequest: Decodable {
             streamOptions: streamOptions,
             temperature: temperature,
             topP: topP,
-            maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens
+            maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens,
+            responseFormat: responseFormat
         )
     }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatJSONSchema.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatJSONSchema.swift
@@ -1,0 +1,179 @@
+import Foundation
+import FoundationModels
+import FoundationModelsKit
+
+/// An OpenAI-compatible named JSON schema for a chat completion response.
+public struct AFMChatJSONSchema: Sendable, Equatable {
+    public let name: String
+    public let description: String?
+    public let strict: Bool
+    public let schema: FoundationModelsJSONSchema
+
+    public init(
+        name: String,
+        description: String? = nil,
+        strict: Bool = false,
+        schema: FoundationModelsJSONSchema
+    ) {
+        self.name = name
+        self.description = description
+        self.strict = strict
+        self.schema = schema
+    }
+
+    /// Builds the Foundation Models generation schema using the response format name as its root name.
+    public func generationSchema() throws -> GenerationSchema {
+        try schema.generationSchema(rootName: name, rootDescription: description)
+    }
+
+    /// Returns a stable, sorted-key JSON representation of the schema.
+    public func canonicalSchemaJSON() throws -> String {
+        try schema.jsonString()
+    }
+}
+
+extension AFMChatJSONSchema: Decodable {
+    private static let allowedFields: Set<String> = ["name", "description", "schema", "strict"]
+    private static let schemaParameter = "response_format.json_schema.schema"
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+
+        let name = try Self.decodeRequired(
+            String.self,
+            field: "name",
+            from: container,
+            decoder: decoder
+        )
+        guard (1...64).contains(name.count), name.allSatisfy(Self.isAllowedNameCharacter) else {
+            let message = "response_format.json_schema.name must be 1 to 64 characters "
+                + "and contain only letters, numbers, underscores, or hyphens."
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "name"),
+                message: message
+            )
+        }
+
+        let description = try container.decodeIfPresent(
+            String.self,
+            forKey: AFMJSONKey("description")
+        )
+        let strict = try Self.decodeStrict(from: container)
+        let schema: FoundationModelsJSONSchema
+        do {
+            schema = try Self.decodeRequired(
+                FoundationModelsJSONSchema.self,
+                field: "schema",
+                from: container,
+                decoder: decoder
+            )
+            try schema.validate()
+        } catch let error as FoundationModelsJSONSchemaError {
+            throw Self.requestValidationError(for: error)
+        }
+
+        guard schema.type == "object" else {
+            throw AFMChatRequestValidationError.invalidField(
+                "\(Self.schemaParameter).type",
+                message: "The root response schema must have type 'object'."
+            )
+        }
+        try Self.validateObjectConstraints(schema, strict: strict, at: Self.schemaParameter)
+
+        self.init(name: name, description: description, strict: strict, schema: schema)
+    }
+
+    private static func decodeRequired<Value: Decodable>(
+        _ type: Value.Type,
+        field: String,
+        from container: KeyedDecodingContainer<AFMJSONKey>,
+        decoder: Decoder
+    ) throws -> Value {
+        let key = AFMJSONKey(field)
+        guard container.contains(key) else {
+            throw AFMChatRequestValidationError.missingField(
+                parameterPath(decoder.codingPath, field: field)
+            )
+        }
+        return try container.decode(type, forKey: key)
+    }
+
+    private static func decodeStrict(
+        from container: KeyedDecodingContainer<AFMJSONKey>
+    ) throws -> Bool {
+        let key = AFMJSONKey("strict")
+        guard container.contains(key) else {
+            return false
+        }
+        return try container.decode(Bool.self, forKey: key)
+    }
+
+    private static func isAllowedNameCharacter(_ character: Character) -> Bool {
+        character.isASCII && (character.isLetter || character.isNumber || character == "_" || character == "-")
+    }
+
+    private static func requestValidationError(
+        for error: FoundationModelsJSONSchemaError
+    ) -> AFMChatRequestValidationError {
+        let suffix = error.path == "$" ? "" : String(error.path.dropFirst())
+        let parameter = schemaParameter + suffix
+        let code = error.kind == .unsupportedKeyword ? "unsupported_field" : "invalid_field"
+        return AFMChatRequestValidationError(
+            message: error.message,
+            parameter: parameter,
+            code: code
+        )
+    }
+
+    private static func validateObjectConstraints(
+        _ schema: FoundationModelsJSONSchema,
+        strict: Bool,
+        at path: String
+    ) throws {
+        if try schema.resolvedType() == .object {
+            if schema.additionalProperties == true {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(path).additionalProperties",
+                    message: "additionalProperties must be false when provided."
+                )
+            }
+            if strict, schema.additionalProperties != false {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(path).additionalProperties",
+                    message: "Strict response schemas must set additionalProperties to false for every object."
+                )
+            }
+            let propertyNames = Set(schema.properties?.keys.map(\.self) ?? [])
+            if strict, Set(schema.required ?? []) != propertyNames {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(path).required",
+                    message: "Strict response schemas must list every object property in required."
+                )
+            }
+            for (name, property) in schema.properties ?? [:] {
+                try validateObjectConstraints(
+                    property,
+                    strict: strict,
+                    at: appendingProperty(name, to: path)
+                )
+            }
+        }
+        if let items = schema.items {
+            try validateObjectConstraints(items, strict: strict, at: "\(path).items")
+        }
+    }
+
+    private static func appendingProperty(_ name: String, to path: String) -> String {
+        let propertiesPath = "\(path).properties"
+        let isIdentifier = name.first?.isLetter == true
+            && name.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+        guard !isIdentifier else {
+            return "\(propertiesPath).\(name)"
+        }
+        let escapedName = name
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\(propertiesPath)[\"\(escapedName)\"]"
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatResponseFormat.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatResponseFormat.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The output representation requested from a chat completion.
+public enum AFMChatResponseFormat: Sendable, Equatable {
+    /// Unstructured text output.
+    case text
+
+    /// Output constrained by a JSON generation schema.
+    case jsonSchema(AFMChatJSONSchema)
+}
+
+extension AFMChatResponseFormat: Decodable {
+    private static let textFields: Set<String> = ["type"]
+    private static let jsonSchemaFields: Set<String> = ["type", "json_schema"]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        let typeKey = AFMJSONKey("type")
+        guard container.contains(typeKey) else {
+            throw AFMChatRequestValidationError.missingField(
+                parameterPath(decoder.codingPath, field: "type")
+            )
+        }
+
+        let type = try container.decode(String.self, forKey: typeKey)
+        switch type {
+        case "text":
+            try rejectUnknownFields(in: container, allowed: Self.textFields, decoder: decoder)
+            self = .text
+        case "json_schema":
+            try rejectUnknownFields(in: container, allowed: Self.jsonSchemaFields, decoder: decoder)
+            let schemaKey = AFMJSONKey("json_schema")
+            guard container.contains(schemaKey) else {
+                throw AFMChatRequestValidationError.missingField(
+                    parameterPath(decoder.codingPath, field: "json_schema")
+                )
+            }
+            self = try .jsonSchema(container.decode(AFMChatJSONSchema.self, forKey: schemaKey))
+        case "json_object":
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "type"),
+                message: "response_format type 'json_object' is not supported. Use 'json_schema' instead."
+            )
+        default:
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "type"),
+                message: "response_format type '\(type)' is not supported."
+            )
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatTranscriptBuilder.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatTranscriptBuilder.swift
@@ -1,0 +1,149 @@
+import FoundationModels
+
+enum AFMChatTranscriptBuilder {
+    static func prepare(_ request: AFMChatGenerationRequest) throws -> AFMPreparedChatGeneration {
+        guard !request.messages.isEmpty else {
+            throw AFMChatGenerationError.unsupportedInput
+        }
+        let finalMessage = request.messages[request.messages.index(before: request.messages.endIndex)]
+        let history = finalMessage.role == .user ? request.messages.dropLast() : request.messages[...]
+        let entries = try transcriptEntries(for: history)
+        let promptContent = activePromptContent(for: finalMessage)
+        let prompt = Prompt(promptContent)
+        let options = generationOptions(for: request)
+        let responseSchema = try preparedResponseSchema(for: request.responseFormat)
+        let transcriptResponseFormat = responseSchema.map {
+            Transcript.ResponseFormat(schema: $0.generationSchema)
+        }
+        let inputPrompt = Transcript.Prompt(
+            segments: segments(promptContent),
+            options: options,
+            responseFormat: transcriptResponseFormat
+        )
+        let inputTranscript = Transcript(entries: entries + [.prompt(inputPrompt)])
+        let transcript = Transcript(entries: entries)
+        return AFMPreparedChatGeneration(
+            transcript: transcript,
+            prompt: prompt,
+            inputTranscript: inputTranscript,
+            options: options,
+            responseSchema: responseSchema
+        )
+    }
+
+    static func segments(_ content: [String]) -> [Transcript.Segment] {
+        content.map { .text(.init(content: $0)) }
+    }
+
+    private static func transcriptEntries(
+        for messages: ArraySlice<AFMChatMessage>
+    ) throws -> [Transcript.Entry] {
+        var entries: [Transcript.Entry] = []
+        var toolNames: [String: String] = [:]
+        let instructionMessages = messages.prefix { $0.role == .system || $0.role == .developer }
+        let instructionSegments = instructionMessages.flatMap { segments($0.contentSegments ?? []) }
+        if !instructionSegments.isEmpty {
+            entries.append(.instructions(.init(segments: instructionSegments, toolDefinitions: [])))
+        }
+
+        for message in messages.dropFirst(instructionMessages.count) {
+            try append(message, to: &entries, toolNames: &toolNames)
+        }
+        return entries
+    }
+
+    private static func append(
+        _ message: AFMChatMessage,
+        to entries: inout [Transcript.Entry],
+        toolNames: inout [String: String]
+    ) throws {
+        switch message.role {
+        case .system, .developer:
+            break
+        case .user:
+            entries.append(.prompt(.init(segments: segments(message.contentSegments ?? []))))
+        case .assistant:
+            try appendAssistant(message, to: &entries, toolNames: &toolNames)
+        case .tool:
+            try appendToolOutput(message, to: &entries, toolNames: toolNames)
+        }
+    }
+
+    private static func appendAssistant(
+        _ message: AFMChatMessage,
+        to entries: inout [Transcript.Entry],
+        toolNames: inout [String: String]
+    ) throws {
+        if let content = message.contentSegments {
+            entries.append(.response(.init(assetIDs: [], segments: segments(content))))
+        }
+        guard !message.toolCalls.isEmpty else { return }
+        let calls = try message.toolCalls.map { call in
+            toolNames[call.id] = call.name
+            return Transcript.ToolCall(
+                id: call.id,
+                toolName: call.name,
+                arguments: try GeneratedContent(json: call.arguments)
+            )
+        }
+        entries.append(.toolCalls(.init(calls)))
+    }
+
+    private static func appendToolOutput(
+        _ message: AFMChatMessage,
+        to entries: inout [Transcript.Entry],
+        toolNames: [String: String]
+    ) throws {
+        guard let identifier = message.toolCallID,
+              let toolName = message.name ?? toolNames[identifier] else {
+            throw AFMChatGenerationError.unsupportedInput
+        }
+        entries.append(
+            .toolOutput(
+                .init(
+                    id: identifier,
+                    toolName: toolName,
+                    segments: segments(message.contentSegments ?? [])
+                )
+            )
+        )
+    }
+
+    private static func activePromptContent(for finalMessage: AFMChatMessage) -> [String] {
+        if finalMessage.role == .user {
+            return finalMessage.contentSegments ?? []
+        }
+        return [""]
+    }
+
+    private static func preparedResponseSchema(
+        for responseFormat: AFMChatResponseFormat?
+    ) throws -> AFMPreparedResponseSchema? {
+        guard case .jsonSchema(let responseSchema)? = responseFormat else {
+            return nil
+        }
+        let generationSchema = try responseSchema.generationSchema()
+        return AFMPreparedResponseSchema(
+            name: responseSchema.name,
+            generationSchema: generationSchema,
+            fallbackTokenText: generationSchema.debugDescription
+        )
+    }
+
+    private static func generationOptions(for request: AFMChatGenerationRequest) -> GenerationOptions {
+        let sampling = request.topP.map { GenerationOptions.SamplingMode.random(probabilityThreshold: $0) }
+        #if compiler(>=6.4)
+        return GenerationOptions(
+            samplingMode: sampling,
+            temperature: request.temperature,
+            maximumResponseTokens: request.maximumCompletionTokens
+        )
+        #else
+        return GenerationOptions(
+            sampling: sampling,
+            temperature: request.temperature,
+            maximumResponseTokens: request.maximumCompletionTokens
+        )
+        #endif
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -23,12 +23,10 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         let session = try sessionBuilder(request.model, prepared.transcript)
 
         do {
-            let response = try await session.respond(to: prepared.prompt, options: prepared.options)
-            let usage = await responseUsage(response, prepared: prepared)
-            return AFMChatGenerationResult(
-                content: response.content,
-                finishReason: finishReason(for: request, usage: usage),
-                usage: usage
+            return try await generationResult(
+                for: request,
+                prepared: prepared,
+                session: session
             )
         } catch {
             if Self.isRefusal(error) {
@@ -44,10 +42,23 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
     ) async throws -> AFMChatGenerationResult {
         let prepared = try AFMChatTranscriptBuilder.prepare(request)
         let session = try sessionBuilder(request.model, prepared.transcript)
-        let responseStream = session.streamResponse(to: prepared.prompt, options: prepared.options)
-        var accumulator = AFMSnapshotDeltaAccumulator()
 
         do {
+            if prepared.responseSchema != nil {
+                let result = try await generationResult(
+                    for: request,
+                    prepared: prepared,
+                    session: session
+                )
+                try Task.checkCancellation()
+                if let content = result.content, !content.isEmpty {
+                    try await event(.contentDelta(content))
+                }
+                return result
+            }
+
+            let responseStream = session.streamResponse(to: prepared.prompt, options: prepared.options)
+            var accumulator = AFMSnapshotDeltaAccumulator()
             for try await snapshot in responseStream {
                 try Task.checkCancellation()
                 let delta = try accumulator.append(snapshot: snapshot.content)
@@ -63,7 +74,11 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
                 try await event(.contentDelta(finalDelta))
             }
             try Task.checkCancellation()
-            let usage = await responseUsage(response, prepared: prepared)
+            let usage = await responseUsage(
+                response,
+                prepared: prepared,
+                fallbackOutput: outputEntry(response.content)
+            )
             let result = AFMChatGenerationResult(
                 content: response.content,
                 finishReason: finishReason(for: request, usage: usage),
@@ -78,21 +93,63 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         }
     }
 
-    private func responseUsage(
-        _ response: LanguageModelSession.Response<String>,
-        prepared: AFMPreparedChatGeneration
-    ) async -> ModelTokenUsage {
+    private func generationResult(
+        for request: AFMChatGenerationRequest,
+        prepared: AFMPreparedChatGeneration,
+        session: LanguageModelSession
+    ) async throws -> AFMChatGenerationResult {
+        if let responseSchema = prepared.responseSchema {
+            let response = try await session.respond(
+                to: prepared.prompt,
+                schema: responseSchema.generationSchema,
+                includeSchemaInPrompt: true,
+                options: prepared.options
+            )
+            let content = response.content.jsonString
+            let usage = await responseUsage(
+                response,
+                prepared: prepared,
+                fallbackOutput: structuredOutputEntry(
+                    response.content,
+                    source: responseSchema.name
+                )
+            )
+            return AFMChatGenerationResult(
+                content: content,
+                finishReason: finishReason(for: request, usage: usage),
+                usage: usage
+            )
+        }
+
+        let response = try await session.respond(to: prepared.prompt, options: prepared.options)
+        let usage = await responseUsage(
+            response,
+            prepared: prepared,
+            fallbackOutput: outputEntry(response.content)
+        )
+        return AFMChatGenerationResult(
+            content: response.content,
+            finishReason: finishReason(for: request, usage: usage),
+            usage: usage
+        )
+    }
+
+    private func responseUsage<Content>(
+        _ response: LanguageModelSession.Response<Content>,
+        prepared: AFMPreparedChatGeneration,
+        fallbackOutput: Transcript.Entry
+    ) async -> ModelTokenUsage where Content: Generable {
         #if compiler(>=6.4)
         if #available(iOS 27.0, macOS 27.0, *) {
             return ModelTokenUsage(observing: response.usage)
         }
         #endif
 
-        return await fallbackUsage(input: prepared.inputTranscript, output: response.content)
+        return await fallbackUsage(prepared: prepared, output: fallbackOutput)
     }
 
     private func refusalResult(prepared: AFMPreparedChatGeneration) async -> AFMChatGenerationResult {
-        let inputUsage = await prepared.inputTranscript.tokenUsage(using: .default)
+        let inputUsage = await fallbackInputUsage(prepared: prepared)
         let usage = ModelTokenUsage(
             input: .init(totalTokenCount: inputUsage.totalTokenCount),
             output: .init(totalTokenCount: 0),
@@ -120,155 +177,77 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         return .length
     }
 
-    private func fallbackUsage(input: Transcript, output: String) async -> ModelTokenUsage {
-        async let inputUsage = input.tokenUsage(using: .default)
-        async let outputUsage = outputEntry(output).tokenUsage(using: .default)
+    private func fallbackUsage(
+        prepared: AFMPreparedChatGeneration,
+        output: Transcript.Entry
+    ) async -> ModelTokenUsage {
+        async let inputUsage = fallbackInputUsage(prepared: prepared)
+        async let outputUsage = output.tokenUsage(using: .default)
         let (resolvedInput, resolvedOutput) = await (inputUsage, outputUsage)
-        let measurement: ModelTokenUsage.Measurement =
-            resolvedInput.measurement == .tokenized && resolvedOutput.measurement == .tokenized
-            ? .tokenized
-            : .estimated
-        return ModelTokenUsage(
-            input: .init(totalTokenCount: resolvedInput.totalTokenCount),
-            output: .init(totalTokenCount: resolvedOutput.totalTokenCount),
-            measurement: measurement,
-            scope: .response
+        return Self.responseScopedFallbackUsage(
+            input: resolvedInput,
+            output: resolvedOutput
+        )
+    }
+
+    private func fallbackInputUsage(
+        prepared: AFMPreparedChatGeneration
+    ) async -> ModelTokenUsage {
+        let usage = await prepared.inputTranscript.tokenUsage(using: .default)
+        return Self.schemaAwareFallbackInputUsage(
+            transcriptUsage: usage,
+            schemaText: prepared.responseSchema?.fallbackTokenText
         )
     }
 
     private func outputEntry(_ content: String) -> Transcript.Entry {
         .response(.init(assetIDs: [], segments: AFMChatTranscriptBuilder.segments([content])))
     }
-}
 
-struct AFMPreparedChatGeneration {
-    let transcript: Transcript
-    let prompt: Prompt
-    let inputTranscript: Transcript
-    let options: GenerationOptions
-}
-
-enum AFMChatTranscriptBuilder {
-    static func prepare(_ request: AFMChatGenerationRequest) throws -> AFMPreparedChatGeneration {
-        guard !request.messages.isEmpty else {
-            throw AFMChatGenerationError.unsupportedInput
-        }
-        let finalMessage = request.messages[request.messages.index(before: request.messages.endIndex)]
-        let history = finalMessage.role == .user ? request.messages.dropLast() : request.messages[...]
-        let entries = try transcriptEntries(for: history)
-        let promptContent = activePromptContent(for: finalMessage)
-        let prompt = Prompt(promptContent)
-        let inputPrompt = Transcript.Prompt(segments: segments(promptContent))
-        let inputTranscript = Transcript(entries: entries + [.prompt(inputPrompt)])
-        let transcript = Transcript(entries: entries)
-        return AFMPreparedChatGeneration(
-            transcript: transcript,
-            prompt: prompt,
-            inputTranscript: inputTranscript,
-            options: generationOptions(for: request)
-        )
-    }
-
-    static func segments(_ content: [String]) -> [Transcript.Segment] {
-        content.map { .text(.init(content: $0)) }
-    }
-
-    private static func transcriptEntries(
-        for messages: ArraySlice<AFMChatMessage>
-    ) throws -> [Transcript.Entry] {
-        var entries: [Transcript.Entry] = []
-        var toolNames: [String: String] = [:]
-        let instructionMessages = messages.prefix { $0.role == .system || $0.role == .developer }
-        let instructionSegments = instructionMessages.flatMap { segments($0.contentSegments ?? []) }
-        if !instructionSegments.isEmpty {
-            entries.append(.instructions(.init(segments: instructionSegments, toolDefinitions: [])))
-        }
-
-        for message in messages.dropFirst(instructionMessages.count) {
-            try append(message, to: &entries, toolNames: &toolNames)
-        }
-        return entries
-    }
-
-    private static func append(
-        _ message: AFMChatMessage,
-        to entries: inout [Transcript.Entry],
-        toolNames: inout [String: String]
-    ) throws {
-        switch message.role {
-        case .system, .developer:
-            break
-        case .user:
-            entries.append(.prompt(.init(segments: segments(message.contentSegments ?? []))))
-        case .assistant:
-            try appendAssistant(message, to: &entries, toolNames: &toolNames)
-        case .tool:
-            try appendToolOutput(message, to: &entries, toolNames: toolNames)
-        }
-    }
-
-    private static func appendAssistant(
-        _ message: AFMChatMessage,
-        to entries: inout [Transcript.Entry],
-        toolNames: inout [String: String]
-    ) throws {
-        if let content = message.contentSegments {
-            entries.append(.response(.init(assetIDs: [], segments: segments(content))))
-        }
-        guard !message.toolCalls.isEmpty else { return }
-        let calls = try message.toolCalls.map { call in
-            toolNames[call.id] = call.name
-            return Transcript.ToolCall(
-                id: call.id,
-                toolName: call.name,
-                arguments: try GeneratedContent(json: call.arguments)
-            )
-        }
-        entries.append(.toolCalls(.init(calls)))
-    }
-
-    private static func appendToolOutput(
-        _ message: AFMChatMessage,
-        to entries: inout [Transcript.Entry],
-        toolNames: [String: String]
-    ) throws {
-        guard let identifier = message.toolCallID,
-              let toolName = message.name ?? toolNames[identifier] else {
-            throw AFMChatGenerationError.unsupportedInput
-        }
-        entries.append(
-            .toolOutput(
-                .init(
-                    id: identifier,
-                    toolName: toolName,
-                    segments: segments(message.contentSegments ?? [])
-                )
+    private func structuredOutputEntry(
+        _ content: GeneratedContent,
+        source: String
+    ) -> Transcript.Entry {
+        .response(
+            .init(
+                assetIDs: [],
+                segments: [.structure(.init(source: source, content: content))]
             )
         )
     }
+}
 
-    private static func activePromptContent(for finalMessage: AFMChatMessage) -> [String] {
-        if finalMessage.role == .user {
-            return finalMessage.contentSegments ?? []
+extension AFMFoundationModelsChatGenerator {
+    static func schemaAwareFallbackInputUsage(
+        transcriptUsage: ModelTokenUsage,
+        schemaText: String?
+    ) -> ModelTokenUsage {
+        // Apple's tokenizer receives the prompt responseFormat in the transcript.
+        // Only the text estimator needs the schema added separately.
+        guard transcriptUsage.measurement == .estimated, let schemaText else {
+            return transcriptUsage
         }
-        return [""]
+        return ModelTokenUsage(
+            inputTokenCount: transcriptUsage.input.totalTokenCount + estimateTokens(from: schemaText),
+            measurement: .estimated,
+            scope: transcriptUsage.scope
+        )
     }
 
-    private static func generationOptions(for request: AFMChatGenerationRequest) -> GenerationOptions {
-        let sampling = request.topP.map { GenerationOptions.SamplingMode.random(probabilityThreshold: $0) }
-        #if compiler(>=6.4)
-        return GenerationOptions(
-            samplingMode: sampling,
-            temperature: request.temperature,
-            maximumResponseTokens: request.maximumCompletionTokens
+    static func responseScopedFallbackUsage(
+        input: ModelTokenUsage,
+        output: ModelTokenUsage
+    ) -> ModelTokenUsage {
+        let measurement: ModelTokenUsage.Measurement =
+            input.measurement == .tokenized && output.measurement == .tokenized
+            ? .tokenized
+            : .estimated
+        return ModelTokenUsage(
+            input: .init(totalTokenCount: input.totalTokenCount),
+            output: .init(totalTokenCount: output.totalTokenCount),
+            measurement: measurement,
+            scope: .response
         )
-        #else
-        return GenerationOptions(
-            sampling: sampling,
-            temperature: request.temperature,
-            maximumResponseTokens: request.maximumCompletionTokens
-        )
-        #endif
     }
 }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMPreparedChatGeneration.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMPreparedChatGeneration.swift
@@ -1,0 +1,9 @@
+import FoundationModels
+
+struct AFMPreparedChatGeneration {
+    let transcript: Transcript
+    let prompt: Prompt
+    let inputTranscript: Transcript
+    let options: GenerationOptions
+    let responseSchema: AFMPreparedResponseSchema?
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMPreparedResponseSchema.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMPreparedResponseSchema.swift
@@ -1,0 +1,7 @@
+import FoundationModels
+
+struct AFMPreparedResponseSchema {
+    let name: String
+    let generationSchema: GenerationSchema
+    let fallbackTokenText: String
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatCompletionServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatCompletionServiceTests.swift
@@ -44,6 +44,47 @@ func chatCompletionResponseShape() async throws {
     #expect(recorded.count == 1)
 }
 
+@Test("Structured completions keep JSON in message content and preserve usage")
+func structuredChatCompletionResponse() async throws {
+    let usage = ModelTokenUsage(
+        input: .init(totalTokenCount: 21, cachedTokenCount: 3),
+        output: .init(totalTokenCount: 8, reasoningTokenCount: 2),
+        measurement: .observed,
+        scope: .response
+    )
+    let generator = RecordingGenerator(
+        result: .init(content: #"{"name":"Ada"}"#, usage: usage)
+    )
+    let response = try await testChatService(generator: generator).response(
+        for: structuredChatBody()
+    )
+
+    #expect(response.status == .ok)
+    let json = try serviceJSONObject(response.body)
+    let choices = try #require(json["choices"] as? [[String: Any]])
+    let message = try #require(choices.first?["message"] as? [String: Any])
+    let content = try #require(message["content"] as? String)
+    let structuredContent = try #require(
+        JSONSerialization.jsonObject(with: Data(content.utf8)) as? [String: String]
+    )
+    #expect(structuredContent == ["name": "Ada"])
+    #expect(choices.first?["finish_reason"] as? String == "stop")
+
+    let usageJSON = try #require(json["usage"] as? [String: Any])
+    #expect(usageJSON["prompt_tokens"] as? Int == 21)
+    #expect(usageJSON["completion_tokens"] as? Int == 8)
+    #expect(usageJSON["afm_measurement"] as? String == "observed")
+
+    let recorded = await generator.recordedRequests()
+    let responseFormat = try #require(recorded.first?.responseFormat)
+    guard case .jsonSchema(let schema) = responseFormat else {
+        Issue.record("Expected a JSON schema response format")
+        return
+    }
+    #expect(schema.name == "person")
+    #expect(schema.strict)
+}
+
 @Test("Refusals remain successful completions with null content")
 func chatCompletionRefusal() async throws {
     let usage = ModelTokenUsage(inputTokenCount: 4, measurement: .estimated, scope: .response)
@@ -189,6 +230,30 @@ private func standardResult() -> AFMChatGenerationResult {
 
 private func chatBody(model: String = "system") -> Data {
     Data(#"{"model":"\#(model)","messages":[{"role":"user","content":"Hi"}]}"#.utf8)
+}
+
+private func structuredChatBody() -> Data {
+    Data(
+        #"""
+        {
+          "model": "system",
+          "messages": [{"role": "user", "content": "Ada"}],
+          "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+              "name": "person",
+              "strict": true,
+              "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+        """#.utf8
+    )
 }
 
 private func serviceJSONObject(_ data: Data) throws -> [String: Any] {

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
@@ -30,6 +30,286 @@ func chatRequestContentAndAlias() throws {
     #expect(request.topP == 0.9)
     #expect(!request.stream)
     #expect(request.streamOptions == nil)
+    #expect(request.responseFormat == nil)
+}
+
+@Test("Chat requests accept omitted, null, and text response formats")
+func chatRequestTextResponseFormats() throws {
+    let omitted = try decodeChatRequest(validUserRequestJSON)
+    let null = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"response_format":null}"#
+    )
+    let text = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"text"}}"#
+    )
+
+    #expect(omitted.responseFormat == nil)
+    #expect(null.responseFormat == nil)
+    #expect(text.responseFormat == .text)
+}
+
+@Test("Chat requests decode non-strict JSON schema response formats")
+func chatRequestJSONSchemaResponseFormat() throws {
+    let request = try decodeChatRequest(
+        #"""
+        {
+          "messages": [{"role":"user","content":"Hi"}],
+          "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+              "name": "answer_1",
+              "description": "A concise answer.",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "answer": {"type": "string"},
+                  "confidence": {"type": "number"}
+                },
+                "required": ["answer"]
+              }
+            }
+          }
+        }
+        """#
+    )
+
+    guard case .jsonSchema(let responseSchema) = request.responseFormat else {
+        Issue.record("Expected a JSON schema response format")
+        return
+    }
+    #expect(responseSchema.name == "answer_1")
+    #expect(responseSchema.description == "A concise answer.")
+    #expect(!responseSchema.strict)
+    #expect(responseSchema.schema.required == ["answer"])
+    #expect(
+        try responseSchema.generationSchema().debugDescription.contains("A concise answer.")
+    )
+    #expect(
+        try responseSchema.canonicalSchemaJSON()
+            == #"{"properties":{"answer":{"type":"string"},"confidence":{"type":"number"}},"required":["answer"],"type":"object"}"#
+    )
+}
+
+@Test("Chat requests decode strict JSON schema response formats")
+func chatRequestStrictJSONSchemaResponseFormat() throws {
+    let request = try decodeChatRequest(
+        responseFormatRequestJSON(
+            jsonSchema: #"""
+            {
+              "name": "strict-answer",
+              "strict": true,
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "answer": {"type": "string"},
+                  "metadata": {
+                    "type": "object",
+                    "properties": {"source": {"type": "string"}},
+                    "required": ["source"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["answer", "metadata"],
+                "additionalProperties": false
+              }
+            }
+            """#
+        )
+    )
+
+    guard case .jsonSchema(let responseSchema) = request.responseFormat else {
+        Issue.record("Expected a JSON schema response format")
+        return
+    }
+    #expect(responseSchema.strict)
+    #expect(responseSchema.name == "strict-answer")
+}
+
+@Test("json_object returns the migration error for json_schema")
+func chatRequestRejectsJSONObjectResponseFormat() {
+    expectChatValidationError(
+        #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"json_object"}}"#,
+        parameter: "response_format.type",
+        code: "invalid_field",
+        message: "response_format type 'json_object' is not supported. Use 'json_schema' instead."
+    )
+}
+
+@Test(
+    "Response format wrappers reject missing, mistyped, and unknown fields",
+    arguments: [
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{}}"#,
+            "response_format.type",
+            "missing_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":1}}"#,
+            "response_format.type",
+            "invalid_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"yaml"}}"#,
+            "response_format.type",
+            "invalid_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"text","extra":true}}"#,
+            "response_format.extra",
+            "unknown_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"text","json_schema":null}}"#,
+            "response_format.json_schema",
+            "unknown_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"json_schema"}}"#,
+            "response_format.json_schema",
+            "missing_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"json_schema","json_schema":null}}"#,
+            "response_format.json_schema",
+            "invalid_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"json_schema","json_schema":{"extra":true}}}"#,
+            "response_format.json_schema.extra",
+            "unknown_field"
+        )
+    ]
+)
+func chatRequestResponseFormatWrapperValidation(json: String, parameter: String, code: String) {
+    expectChatValidationError(json, parameter: parameter, code: code)
+}
+
+@Test(
+    "JSON schema response formats validate name, schema, and strict types",
+    arguments: [
+        (jsonSchemaRequestJSON(#"{"schema":{"type":"object"}}"#), "response_format.json_schema.name", "missing_field"),
+        (jsonSchemaRequestJSON(#"{"name":1,"schema":{"type":"object"}}"#), "response_format.json_schema.name", "invalid_field"),
+        (jsonSchemaRequestJSON(#"{"name":"","schema":{"type":"object"}}"#), "response_format.json_schema.name", "invalid_field"),
+        (jsonSchemaRequestJSON(#"{"name":"bad name","schema":{"type":"object"}}"#), "response_format.json_schema.name", "invalid_field"),
+        (
+            jsonSchemaRequestJSON(
+                #"""
+                {
+                  "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "schema": {"type": "object"}
+                }
+                """#
+            ),
+            "response_format.json_schema.name",
+            "invalid_field"
+        ),
+        (jsonSchemaRequestJSON(#"{"name":"answer"}"#), "response_format.json_schema.schema", "missing_field"),
+        (jsonSchemaRequestJSON(#"{"name":"answer","schema":null}"#), "response_format.json_schema.schema", "invalid_field"),
+        (jsonSchemaRequestJSON(#"{"name":"answer","schema":[]}"#), "response_format.json_schema.schema", "invalid_field"),
+        (
+            jsonSchemaRequestJSON(#"{"name":"answer","strict":null,"schema":{"type":"object"}}"#),
+            "response_format.json_schema.strict",
+            "invalid_field"
+        )
+    ]
+)
+func chatRequestJSONSchemaWrapperValidation(json: String, parameter: String, code: String) {
+    expectChatValidationError(json, parameter: parameter, code: code)
+}
+
+@Test(
+    "JSON schemas preserve precise prefixed validation paths",
+    arguments: [
+        (
+            #"{"name":"answer","schema":{"type":"string"}}"#,
+            "response_format.json_schema.schema.type",
+            "invalid_field"
+        ),
+        (
+            #"{"name":"answer","schema":{"type":"object","properties":{"answer":{"type":"string","format":"date"}}}}"#,
+            "response_format.json_schema.schema.properties.answer.format",
+            "unsupported_field"
+        ),
+        (
+            #"{"name":"answer","schema":{"type":"object","properties":{"answers":{"type":"array"}}}}"#,
+            "response_format.json_schema.schema.properties.answers.items",
+            "invalid_field"
+        ),
+        (
+            #"{"name":"answer","schema":{"type":"object","properties":{},"required":["missing"]}}"#,
+            "response_format.json_schema.schema.required[0]",
+            "invalid_field"
+        ),
+        (
+            #"{"name":"answer","schema":{"type":"object","additionalProperties":true}}"#,
+            "response_format.json_schema.schema.additionalProperties",
+            "invalid_field"
+        )
+    ]
+)
+func chatRequestJSONSchemaValidationPaths(jsonSchema: String, parameter: String, code: String) {
+    expectChatValidationError(
+        jsonSchemaRequestJSON(jsonSchema),
+        parameter: parameter,
+        code: code
+    )
+}
+
+@Test(
+    "Strict JSON schemas require closed objects and every property",
+    arguments: [
+        (
+            #"{"name":"answer","strict":true,"schema":{"type":"object","properties":{},"required":[]}}"#,
+            "response_format.json_schema.schema.additionalProperties"
+        ),
+        (
+            #"""
+            {"name":"answer","strict":true,"schema":{
+              "type":"object","properties":{"answer":{"type":"string"}},
+              "required":[],"additionalProperties":false
+            }}
+            """#,
+            "response_format.json_schema.schema.required"
+        ),
+        (
+            #"""
+            {"name":"answer","strict":true,"schema":{
+              "type":"object","properties":{"metadata":{
+                "type":"object","properties":{"source":{"type":"string"}},
+                "required":[],"additionalProperties":false
+              }},"required":["metadata"],"additionalProperties":false
+            }}
+            """#,
+            "response_format.json_schema.schema.properties.metadata.required"
+        ),
+        (
+            #"""
+            {"name":"answer","strict":true,"schema":{
+              "type":"object","properties":{"metadata":{
+                "type":"object","properties":{},"required":[]
+              }},"required":["metadata"],"additionalProperties":false
+            }}
+            """#,
+            "response_format.json_schema.schema.properties.metadata.additionalProperties"
+        ),
+        (
+            #"""
+            {"name":"answer","strict":true,"schema":{
+              "type":"object","properties":{"metadata":{
+                "properties":{},"required":[]
+              }},"required":["metadata"],"additionalProperties":false
+            }}
+            """#,
+            "response_format.json_schema.schema.properties.metadata.additionalProperties"
+        )
+    ]
+)
+func chatRequestStrictJSONSchemaValidation(jsonSchema: String, parameter: String) {
+    expectChatValidationError(
+        jsonSchemaRequestJSON(jsonSchema),
+        parameter: parameter,
+        code: "invalid_field"
+    )
 }
 
 @Test("Chat requests accept Apple's streaming tool sentinel and usage option")
@@ -98,7 +378,6 @@ func chatRequestToolHistory() throws {
             "stream_options.extra",
             "unknown_field"
         ),
-        (#"{"messages":[{"role":"user","content":"Hi"}],"response_format":{}}"#, "response_format", "unsupported_field"),
         (#"{"messages":[{"role":"user","content":"Hi"}],"surprise":1}"#, "surprise", "unknown_field"),
         (
             #"{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"x"}}]}]}"#,
@@ -177,17 +456,35 @@ private let validToolHistoryJSON = #"""
 }
 """#
 
+private let validUserRequestJSON = #"{"messages":[{"role":"user","content":"Hi"}]}"#
+
+private func responseFormatRequestJSON(jsonSchema: String) -> String {
+    #"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"json_schema","json_schema":\#(jsonSchema)}}"#
+}
+
+private func jsonSchemaRequestJSON(_ jsonSchema: String) -> String {
+    responseFormatRequestJSON(jsonSchema: jsonSchema)
+}
+
 private func decodeChatRequest(_ json: String) throws -> AFMChatGenerationRequest {
     try AFMChatGenerationRequest.decode(Data(json.utf8))
 }
 
-private func expectChatValidationError(_ json: String, parameter: String, code: String) {
+private func expectChatValidationError(
+    _ json: String,
+    parameter: String,
+    code: String,
+    message: String? = nil
+) {
     do {
         _ = try decodeChatRequest(json)
         Issue.record("Expected chat request validation to fail")
     } catch let error as AFMChatRequestValidationError {
         #expect(error.parameter == parameter)
         #expect(error.code == code)
+        if let message {
+            #expect(error.message == message)
+        }
     } catch {
         Issue.record("Unexpected error: \(error)")
     }

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
@@ -88,6 +88,31 @@ struct AFMChatStreamingServiceTests {
         #expect(bodies.last == "data: [DONE]\n\n")
     }
 
+    @Test("Structured streaming emits one complete JSON delta before finish and usage")
+    func structuredStreamUsesSingleJSONDelta() async throws {
+        let content = #"{"name":"Ada"}"#
+        let generator = StreamingGenerator(
+            deltas: [content],
+            result: .init(content: content, usage: Self.standardUsage())
+        )
+        let emissions = try await Self.collect(
+            Self.service(generator: generator),
+            body: Self.structuredStreamBody()
+        )
+        let bodies = Self.streamBodies(emissions)
+        let chunks = try bodies.dropLast().map(Self.eventObject)
+
+        #expect(chunks.count == 4)
+        #expect(try Self.content(in: chunks[1]) == content)
+        let decodedContent = try #require(
+            JSONSerialization.jsonObject(with: Data(content.utf8)) as? [String: String]
+        )
+        #expect(decodedContent == ["name": "Ada"])
+        #expect(try Self.choice(in: chunks[2])["finish_reason"] as? String == "stop")
+        #expect((chunks[3]["choices"] as? [Any])?.isEmpty == true)
+        #expect(bodies.last == "data: [DONE]\n\n")
+    }
+
     @Test("Streaming refusals finish with content_filter")
     func streamRefusal() async throws {
         let generator = StreamingGenerator(
@@ -346,6 +371,32 @@ private extension AFMChatStreamingServiceTests {
         let options = includeUsage ? #", "stream_options":{"include_usage":true}"# : ""
         return Data(
             #"{"model":"system","messages":[{"role":"user","content":"Hi"}],"stream":true\#(options)}"#.utf8
+        )
+    }
+
+    static func structuredStreamBody() -> Data {
+        Data(
+            #"""
+            {
+              "model": "system",
+              "messages": [{"role": "user", "content": "Ada"}],
+              "stream": true,
+              "stream_options": {"include_usage": true},
+              "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                  "name": "person",
+                  "strict": true,
+                  "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """#.utf8
         )
     }
 

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatTranscriptBuilderTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatTranscriptBuilderTests.swift
@@ -89,6 +89,35 @@ func finalToolOutputReconstruction() throws {
     #expect(text(activePrompt.segments) == [""])
 }
 
+@Test("Structured response formats reach generation and transcript token accounting")
+func structuredResponseFormatPreparation() throws {
+    let request = try AFMChatGenerationRequest.decode(Data(structuredRequestJSON.utf8))
+    let prepared = try AFMChatTranscriptBuilder.prepare(request)
+
+    #expect(prepared.responseSchema?.name == "person")
+    #expect(prepared.responseSchema?.fallbackTokenText.contains("Structured person guidance") == true)
+    guard case .prompt(let activePrompt) = Array(prepared.inputTranscript).last else {
+        Issue.record("Expected the active structured prompt")
+        return
+    }
+    #expect(activePrompt.responseFormat != nil)
+}
+
+@Test("Text response formats keep schema guidance out of the transcript")
+func textResponseFormatPreparation() throws {
+    let request = try AFMChatGenerationRequest.decode(
+        Data(#"{"messages":[{"role":"user","content":"Hi"}],"response_format":{"type":"text"}}"#.utf8)
+    )
+    let prepared = try AFMChatTranscriptBuilder.prepare(request)
+
+    #expect(prepared.responseSchema == nil)
+    guard case .prompt(let activePrompt) = Array(prepared.inputTranscript).last else {
+        Issue.record("Expected the active text prompt")
+        return
+    }
+    #expect(activePrompt.responseFormat == nil)
+}
+
 private func text(_ segments: [Transcript.Segment]) -> [String] {
     segments.compactMap { segment in
         guard case .text(let text) = segment else { return nil }
@@ -120,5 +149,25 @@ private let finalToolRequestJSON = #"""
     ]},
     {"role":"tool","tool_call_id":"call_1","content":"Sunny"}
   ]
+}
+"""#
+
+private let structuredRequestJSON = #"""
+{
+  "messages": [{"role":"user","content":"Ada Lovelace"}],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "person",
+      "description": "Structured person guidance",
+      "strict": true,
+      "schema": {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": false
+      }
+    }
+  }
 }
 """#

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMFoundationModelsChatGeneratorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMFoundationModelsChatGeneratorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FoundationModels
+import FoundationModelsKit
 import Testing
 @testable import AFMServer
 
@@ -19,6 +20,58 @@ func foundationModelsGeneratorForwardsRequestedModel() async throws {
         try await generator.generate(request)
     }
     #expect(probe.modelIdentifier == "pcc")
+}
+
+@Test("Fallback usage preserves tokenized provenance only when both sides are tokenized")
+func fallbackUsageProvenance() {
+    let tokenizedInput = ModelTokenUsage(inputTokenCount: 8, measurement: .tokenized)
+    let tokenizedOutput = ModelTokenUsage(inputTokenCount: 5, measurement: .tokenized)
+    let estimatedOutput = ModelTokenUsage(inputTokenCount: 5, measurement: .estimated)
+
+    let tokenized = AFMFoundationModelsChatGenerator.responseScopedFallbackUsage(
+        input: tokenizedInput,
+        output: tokenizedOutput
+    )
+    let estimated = AFMFoundationModelsChatGenerator.responseScopedFallbackUsage(
+        input: tokenizedInput,
+        output: estimatedOutput
+    )
+
+    #expect(tokenized.input.totalTokenCount == 8)
+    #expect(tokenized.output?.totalTokenCount == 5)
+    #expect(tokenized.totalTokenCount == 13)
+    #expect(tokenized.measurement == .tokenized)
+    #expect(tokenized.scope == .response)
+    #expect(estimated.measurement == .estimated)
+}
+
+@Test("Schema fallback adds guidance once only when transcript usage is estimated")
+func schemaFallbackInputUsage() {
+    let schemaText = #"{"type":"object"}"#
+    let estimatedTranscript = ModelTokenUsage(
+        inputTokenCount: 7,
+        measurement: .estimated,
+        scope: .context
+    )
+    let tokenizedTranscript = ModelTokenUsage(
+        inputTokenCount: 11,
+        measurement: .tokenized,
+        scope: .context
+    )
+
+    let estimated = AFMFoundationModelsChatGenerator.schemaAwareFallbackInputUsage(
+        transcriptUsage: estimatedTranscript,
+        schemaText: schemaText
+    )
+    let tokenized = AFMFoundationModelsChatGenerator.schemaAwareFallbackInputUsage(
+        transcriptUsage: tokenizedTranscript,
+        schemaText: schemaText
+    )
+
+    #expect(estimated.totalTokenCount == 7 + estimateTokens(from: schemaText))
+    #expect(estimated.measurement == .estimated)
+    #expect(estimated.scope == .context)
+    #expect(tokenized == tokenizedTranscript)
 }
 
 private final class AFMSessionBuilderProbe: @unchecked Sendable {

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMHTTPServerIntegrationTests.swift
@@ -388,7 +388,7 @@ func unixSocketRejectsInsecureParent() async throws {
     await expectStartFailure(server, matching: .insecureParentDirectory)
 }
 
-private func testServer(
+func testServer(
     configuration: AFMServerConfiguration,
     generator: any AFMChatCompletionGenerating = IntegrationImmediateGenerator()
 ) throws -> AFMHTTPServer {
@@ -495,7 +495,7 @@ private enum IntegrationProbeError: Error {
     case timedOut
 }
 
-private func chatHTTPRequest(body: String, port: Int, close: Bool) -> String {
+func chatHTTPRequest(body: String, port: Int, close: Bool) -> String {
     var request = "POST /v1/chat/completions HTTP/1.1\r\n"
     request += "Host: 127.0.0.1:\(port)\r\n"
     request += "Content-Type: application/json\r\n"
@@ -569,7 +569,7 @@ private func expectStartFailure(
     }
 }
 
-private func sendRawHTTPRequest(_ request: String, port: Int) throws -> String {
+func sendRawHTTPRequest(_ request: String, port: Int) throws -> String {
     let descriptor = try connectTCPSocket(port: port)
     defer { Darwin.close(descriptor) }
 

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMStructuredHTTPServerIntegrationTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMStructuredHTTPServerIntegrationTests.swift
@@ -1,0 +1,63 @@
+import FoundationModelsKit
+import Testing
+@testable import AFMServer
+
+@Test("TCP transport preserves structured JSON as message content")
+func tcpStructuredChatCompletion() async throws {
+    let server = try testServer(
+        configuration: .init(endpoint: .tcp(host: "127.0.0.1", port: 0)),
+        generator: IntegrationStructuredGenerator()
+    )
+
+    do {
+        let address = try await server.start()
+        guard case .tcp(_, let port) = address else {
+            Issue.record("Expected a TCP address")
+            try await server.stop()
+            return
+        }
+        let body = #"""
+        {
+          "messages": [{"role": "user", "content": "Ada"}],
+          "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+              "name": "person",
+              "strict": true,
+              "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+        """#
+        let response = try sendRawHTTPRequest(
+            chatHTTPRequest(body: body, port: port, close: true),
+            port: port
+        )
+        #expect(response.hasPrefix("HTTP/1.1 200 OK"))
+        #expect(response.contains(#""content":"{\"name\":\"Ada\"}""#))
+        #expect(response.contains(#""finish_reason":"stop""#))
+        try await server.stop()
+    } catch {
+        try? await server.stop()
+        throw error
+    }
+}
+
+private struct IntegrationStructuredGenerator: AFMChatCompletionGenerating {
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        .init(
+            content: #"{"name":"Ada"}"#,
+            usage: .init(
+                input: .init(totalTokenCount: 4),
+                output: .init(totalTokenCount: 3),
+                measurement: .estimated,
+                scope: .response
+            )
+        )
+    }
+}

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -193,6 +193,9 @@ curl http://127.0.0.1:1976/v1/chat/completions \
 curl -N http://127.0.0.1:1976/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"system","messages":[{"role":"user","content":"Hello"}],"stream":true,"stream_options":{"include_usage":true},"tools":[],"tool_choice":"auto"}'
+curl http://127.0.0.1:1976/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"system","messages":[{"role":"user","content":"Extract a name from Ada Lovelace."}],"response_format":{"type":"json_schema","json_schema":{"name":"person","strict":true,"schema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}}}}'
 ```
 
 Chat requests are stateless: send the complete system, developer, user,
@@ -202,10 +205,13 @@ legacy `max_tokens` alias. Streaming emits assistant role and content deltas,
 a terminal finish reason, and `[DONE]`. Set `stream_options.include_usage` to
 receive a final empty-choices usage chunk. The empty `tools: []` and
 `tool_choice: "auto"` sentinels used by Apple's client are accepted; client-defined
-tools, image parts, and response formats return a precise `400` until their
-dedicated endpoints are implemented. Responses include input/output usage plus an `afm_measurement`
-value of `observed`, `tokenized`, or `estimated` so fallback counts are never
-presented as runtime observation.
+tools and image parts return a precise `400` until their dedicated endpoints
+are implemented. `response_format` accepts `text` and `json_schema`; structured
+responses return JSON text in `message.content`, and structured streams emit the
+complete JSON document as one content delta. The older `json_object` mode is not
+supported. Properties omitted from `required` are optional. Responses include
+input/output usage plus an `afm_measurement` value of `observed`, `tokenized`, or
+`estimated` so fallback counts are never presented as runtime observation.
 
 Generation concurrency defaults to one and excess requests receive `429`
 without being queued. Configure it with `--max-concurrent-generations`; use


### PR DESCRIPTION
## Summary

- add OpenAI-compatible response_format decoding for omitted, null, text, and json_schema requests
- reject json_object with a precise migration error and reject unknown or unsupported schema constraints before model execution
- constrain Foundation Models generation through the public GenerationSchema API on Xcode 26 and 27
- apply the response-format name and model-guiding description to the root dynamic schema
- return the generated JSON document as message.content for non-streaming responses
- buffer structured streaming and emit one complete JSON content delta, matching the useful native fm behavior without leaking partial invalid JSON
- preserve observed Xcode 27 usage and schema-aware tokenized or estimated fallback provenance on older runtimes

## Semantics

Strict schemas require an object root, additionalProperties=false on every object, and every property listed in required. Non-strict schemas retain normal JSON Schema semantics, so omitted required entries remain optional.

## Verification

- full root swift test passed with Xcode 26.6 and Xcode 27
- AFMServer: 96 tests passed on each toolchain
- exact CI lint configurations pass, including FoundationModelsKit package-local rules
- generic macOS and iOS Simulator app builds passed on both toolchains
- AFM CLI workflow passed, including universal release artifact construction
- request, validation-path, transcript, generator, streaming, usage, and real TCP response coverage
- git diff check clean

## Stack

Base: #179, which provides the shared FoundationModelsKit schema converter. #179 itself is based on #178.