### PR TITLE
Add safe tool calling to AFM server

### DIFF
--- a/Foundation Lab/AgentBridge/AgentBridgeController.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeController.swift
@@ -270,7 +270,7 @@ private extension AgentBridgeController {
             security: .init(bearerToken: bearerToken)
         )
         let generator = AFMFoundationModelsChatGenerator(
-            sessionBuilder: AgentBridgeSessionBuilder.makeSession
+            toolSessionBuilder: AgentBridgeSessionBuilder.makeSession
         )
         let server = try AFMHTTPServer(
             configuration: configuration,

--- a/Foundation Lab/AgentBridge/AgentBridgeSessionBuilder.swift
+++ b/Foundation Lab/AgentBridge/AgentBridgeSessionBuilder.swift
@@ -5,6 +5,7 @@ import FoundationModels
 nonisolated enum AgentBridgeSessionBuilder {
     static func makeSession(
         requestedModelIdentifier: String,
+        tools: [any Tool],
         transcript: Transcript
     ) throws -> LanguageModelSession {
         switch requestedModelIdentifier {
@@ -13,15 +14,18 @@ nonisolated enum AgentBridgeSessionBuilder {
             guard case .available = model.availability else {
                 throw AFMChatGenerationError.modelUnavailable
             }
-            return LanguageModelSession(model: model, transcript: transcript)
+            return LanguageModelSession(model: model, tools: tools, transcript: transcript)
         case "pcc":
-            return try makePrivateCloudSession(transcript: transcript)
+            return try makePrivateCloudSession(tools: tools, transcript: transcript)
         default:
             throw AFMChatGenerationError.modelUnavailable
         }
     }
 
-    private static func makePrivateCloudSession(transcript: Transcript) throws -> LanguageModelSession {
+    private static func makePrivateCloudSession(
+        tools: [any Tool],
+        transcript: Transcript
+    ) throws -> LanguageModelSession {
         #if compiler(>=6.4)
         if #available(macOS 27.0, *) {
             guard AgentBridgePrivateCloudAuthorization.isGranted else {
@@ -34,7 +38,7 @@ nonisolated enum AgentBridgeSessionBuilder {
             guard !model.quotaUsage.isLimitReached else {
                 throw AFMChatGenerationError.rateLimited
             }
-            return LanguageModelSession(model: model, transcript: transcript)
+            return LanguageModelSession(model: model, tools: tools, transcript: transcript)
         }
         #endif
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCaptureTool.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCaptureTool.swift
@@ -1,0 +1,27 @@
+import Foundation
+import FoundationModels
+
+struct AFMChatCaptureTool: Tool {
+    let name: String
+    let description: String
+    let parameters: GenerationSchema
+    let definitionIndex: Int
+    let recorder: AFMChatToolCallRecorder
+
+    func call(arguments: GeneratedContent) async throws -> Prompt {
+        await recorder.record(
+            definitionIndex: definitionIndex,
+            name: name,
+            arguments: arguments.jsonString
+        )
+        throw AFMChatToolCaptureSignal()
+    }
+}
+
+private struct AFMChatToolCaptureSignal: Error {}
+
+extension LanguageModelSession.ToolCallError {
+    var isAFMChatToolCapture: Bool {
+        underlyingError is AFMChatToolCaptureSignal
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionChunk.swift
@@ -6,18 +6,35 @@ struct AFMChatCompletionChunk: Encodable {
             let role: String?
             let content: String?
             let refusal: String?
+            let toolCalls: [AFMChatToolCallDeltaPayload]?
+
+            init(
+                role: String?,
+                content: String?,
+                refusal: String?,
+                toolCalls: [AFMChatToolCall]?
+            ) {
+                self.role = role
+                self.content = content
+                self.refusal = refusal
+                self.toolCalls = toolCalls?.enumerated().map {
+                    AFMChatToolCallDeltaPayload(index: $0.offset, call: $0.element)
+                }
+            }
 
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(role, forKey: .role)
                 try container.encodeIfPresent(content, forKey: .content)
                 try container.encodeIfPresent(refusal, forKey: .refusal)
+                try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
             }
 
             private enum CodingKeys: String, CodingKey {
                 case role
                 case content
                 case refusal
+                case toolCalls = "tool_calls"
             }
         }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionRequest.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationModelsKit
 
 public enum AFMChatRole: String, Sendable, Equatable {
     case system
@@ -50,6 +51,9 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
     public let temperature: Double?
     public let topP: Double?
     public let maximumCompletionTokens: Int?
+    public let tools: [AFMChatToolDefinition]
+    public let toolChoice: AFMChatToolChoice
+    public let parallelToolCalls: Bool
 
     public init(
         model: String = "system",
@@ -58,7 +62,35 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
         streamOptions: AFMChatStreamOptions? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
-        maximumCompletionTokens: Int? = nil
+        maximumCompletionTokens: Int? = nil,
+        tools: [AFMChatToolDefinition] = [],
+        parallelToolCalls: Bool = true
+    ) {
+        self.init(
+            model: model,
+            messages: messages,
+            stream: stream,
+            streamOptions: streamOptions,
+            temperature: temperature,
+            topP: topP,
+            maximumCompletionTokens: maximumCompletionTokens,
+            tools: tools,
+            toolChoice: tools.isEmpty ? .none : .auto,
+            parallelToolCalls: parallelToolCalls
+        )
+    }
+
+    public init(
+        model: String = "system",
+        messages: [AFMChatMessage],
+        stream: Bool = false,
+        streamOptions: AFMChatStreamOptions? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        maximumCompletionTokens: Int? = nil,
+        tools: [AFMChatToolDefinition] = [],
+        toolChoice: AFMChatToolChoice,
+        parallelToolCalls: Bool = true
     ) {
         self.model = model
         self.messages = messages
@@ -67,6 +99,9 @@ public struct AFMChatGenerationRequest: Sendable, Equatable {
         self.temperature = temperature
         self.topP = topP
         self.maximumCompletionTokens = maximumCompletionTokens
+        self.tools = tools
+        self.toolChoice = toolChoice
+        self.parallelToolCalls = parallelToolCalls
     }
 }
 
@@ -74,7 +109,7 @@ extension AFMChatGenerationRequest: Decodable {
     private static let allowedFields: Set<String> = [
         "model", "messages", "stream", "temperature", "top_p",
         "max_completion_tokens", "max_tokens", "tools", "tool_choice",
-        "response_format", "stream_options"
+        "parallel_tool_calls", "response_format", "stream_options"
     ]
 
     public init(from decoder: Decoder) throws {
@@ -99,10 +134,25 @@ extension AFMChatGenerationRequest: Decodable {
             forKey: .init("max_completion_tokens")
         )
         let legacyMaximumTokens = try container.decodeIfPresent(Int.self, forKey: .init("max_tokens"))
+        let tools = try container.decodeIfPresent([AFMChatToolDefinition].self, forKey: .init("tools")) ?? []
+        let explicitToolChoice = try container.decodeIfPresent(
+            AFMChatToolChoice.self,
+            forKey: .init("tool_choice")
+        )
+        let toolChoice = explicitToolChoice ?? (tools.isEmpty ? .none : .auto)
+        let parallelToolCalls = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .init("parallel_tool_calls")
+        ) ?? true
 
         try Self.validateModel(model)
         try Self.validateStreaming(stream: stream, streamOptions: streamOptions)
-        try Self.validateEmptyToolSentinel(in: container)
+        try Self.validateTools(
+            tools,
+            choice: toolChoice,
+            parallelToolCalls: parallelToolCalls
+        )
+        try Self.validateToolChoiceAvailability(toolChoice)
         try Self.validateOptions(
             temperature: temperature,
             topP: topP,
@@ -118,7 +168,10 @@ extension AFMChatGenerationRequest: Decodable {
             streamOptions: streamOptions,
             temperature: temperature,
             topP: topP,
-            maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens
+            maximumCompletionTokens: maximumCompletionTokens ?? legacyMaximumTokens,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls
         )
     }
 
@@ -149,24 +202,6 @@ extension AFMChatGenerationRequest: Decodable {
                 "stream_options",
                 message: "stream_options may only be used when stream is true."
             )
-        }
-    }
-
-    private static func validateEmptyToolSentinel(
-        in container: KeyedDecodingContainer<AFMJSONKey>
-    ) throws {
-        let toolsKey = AFMJSONKey("tools")
-        if container.contains(toolsKey), try !container.decodeNil(forKey: toolsKey) {
-            let tools = try container.nestedUnkeyedContainer(forKey: toolsKey)
-            guard tools.isAtEnd else {
-                throw AFMChatRequestValidationError.unsupportedField("tools")
-            }
-        }
-
-        let toolChoiceKey = AFMJSONKey("tool_choice")
-        if let toolChoice = try container.decodeIfPresent(String.self, forKey: toolChoiceKey),
-           toolChoice != "auto" {
-            throw AFMChatRequestValidationError.unsupportedField("tool_choice")
         }
     }
 
@@ -227,5 +262,17 @@ struct AFMChatRequestValidationError: Error, Equatable, Sendable {
 
     static func unknownField(_ parameter: String) -> Self {
         .init(message: "Unknown field '\(parameter)'.", parameter: parameter, code: "unknown_field")
+    }
+
+    static func toolSchema(
+        _ error: FoundationModelsJSONSchemaError,
+        parameter: String
+    ) -> Self {
+        let suffix = error.path == "$" ? "" : String(error.path.dropFirst())
+        return .init(
+            message: error.message,
+            parameter: parameter + suffix,
+            code: error.kind == .unsupportedKeyword ? "unsupported_schema_keyword" : "invalid_tool_schema"
+        )
     }
 }

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionResponse.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionResponse.swift
@@ -5,6 +5,7 @@ public enum AFMChatFinishReason: String, Sendable, Equatable, Encodable {
     case stop
     case length
     case contentFilter = "content_filter"
+    case toolCalls = "tool_calls"
 }
 
 public struct AFMChatGenerationResult: Sendable, Equatable {
@@ -12,17 +13,20 @@ public struct AFMChatGenerationResult: Sendable, Equatable {
     public let refusal: String?
     public let finishReason: AFMChatFinishReason
     public let usage: ModelTokenUsage
+    public let toolCalls: [AFMChatToolCall]
 
     public init(
         content: String?,
         refusal: String? = nil,
         finishReason: AFMChatFinishReason = .stop,
-        usage: ModelTokenUsage
+        usage: ModelTokenUsage,
+        toolCalls: [AFMChatToolCall] = []
     ) {
         self.content = content
         self.refusal = refusal
         self.finishReason = finishReason
         self.usage = usage
+        self.toolCalls = toolCalls
     }
 }
 
@@ -56,6 +60,9 @@ public enum AFMChatGenerationError: Error, Sendable, Equatable {
     case unsupportedInput
     case concurrentRequest
     case timedOut
+    case unsupportedToolChoice
+    case requiredToolNotCalled
+    case toolCallLimitExceeded
 }
 
 struct AFMChatCompletionPayload: Encodable {
@@ -64,18 +71,27 @@ struct AFMChatCompletionPayload: Encodable {
             let role = "assistant"
             let content: String?
             let refusal: String?
+            let toolCalls: [AFMChatToolCallPayload]?
+
+            init(content: String?, refusal: String?, toolCalls: [AFMChatToolCall]) {
+                self.content = content
+                self.refusal = refusal
+                self.toolCalls = toolCalls.isEmpty ? nil : toolCalls.map(AFMChatToolCallPayload.init)
+            }
 
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encode(role, forKey: .role)
                 try container.encodeIfPresentOrNil(content, forKey: .content)
                 try container.encodeIfPresentOrNil(refusal, forKey: .refusal)
+                try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
             }
 
             private enum CodingKeys: String, CodingKey {
                 case role
                 case content
                 case refusal
+                case toolCalls = "tool_calls"
             }
         }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatCompletionService.swift
@@ -20,6 +20,18 @@ actor AFMGenerationGate {
     }
 }
 
+private actor AFMToolStreamContentBuffer {
+    private var deltas: [String] = []
+
+    func append(_ delta: String) {
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [String] {
+        deltas
+    }
+}
+
 struct AFMChatCompletionService: Sendable {
     private let catalog: any AFMModelCatalog
     private let generator: any AFMChatCompletionGenerating
@@ -121,18 +133,12 @@ private extension AFMChatCompletionService {
                 emitting: emission
             )
 
-            let result = try await streamWithTimeout(request) { event in
-                switch event {
-                case .contentDelta(let content):
-                    try await writeChunk(
-                        identifier: identifier,
-                        created: created,
-                        content: content,
-                        request: request,
-                        emitting: emission
-                    )
-                }
-            }
+            let result = try await streamAndWriteContent(
+                request,
+                identifier: identifier,
+                created: created,
+                emitting: emission
+            )
             try await writeTerminalChunks(
                 result,
                 identifier: identifier,
@@ -159,6 +165,44 @@ private extension AFMChatCompletionService {
                 try await emission(.fixed(generationErrorResponse(error)))
             }
         }
+    }
+
+    func streamAndWriteContent(
+        _ request: AFMChatGenerationRequest,
+        identifier: String,
+        created: Int64,
+        emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
+    ) async throws -> AFMChatGenerationResult {
+        let buffersToolContent = !request.tools.isEmpty && request.toolChoice != .none
+        let contentBuffer = AFMToolStreamContentBuffer()
+        let result = try await streamWithTimeout(request) { event in
+            switch event {
+            case .contentDelta(let content):
+                if buffersToolContent {
+                    await contentBuffer.append(content)
+                } else {
+                    try await writeChunk(
+                        identifier: identifier,
+                        created: created,
+                        content: content,
+                        request: request,
+                        emitting: emission
+                    )
+                }
+            }
+        }
+        if result.toolCalls.isEmpty {
+            for content in await contentBuffer.snapshot() {
+                try await writeChunk(
+                    identifier: identifier,
+                    created: created,
+                    content: content,
+                    request: request,
+                    emitting: emission
+                )
+            }
+        }
+        return result
     }
 
     func validateModel(_ identifier: String) -> AFMHTTPResponse? {
@@ -240,7 +284,11 @@ private extension AFMChatCompletionService {
                 choices: [
                     .init(
                         index: 0,
-                        message: .init(content: result.content, refusal: result.refusal),
+                        message: .init(
+                            content: result.content,
+                            refusal: result.refusal,
+                            toolCalls: result.toolCalls
+                        ),
                         finishReason: result.finishReason
                     )
                 ],
@@ -255,6 +303,7 @@ private extension AFMChatCompletionService {
         role: String? = nil,
         content: String? = nil,
         refusal: String? = nil,
+        toolCalls: [AFMChatToolCall]? = nil,
         finishReason: AFMChatFinishReason? = nil,
         request: AFMChatGenerationRequest,
         emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
@@ -266,7 +315,12 @@ private extension AFMChatCompletionService {
             choices: [
                 .init(
                     index: 0,
-                    delta: .init(role: role, content: content, refusal: refusal),
+                    delta: .init(
+                        role: role,
+                        content: content,
+                        refusal: refusal,
+                        toolCalls: toolCalls
+                    ),
                     finishReason: finishReason
                 )
             ],
@@ -299,6 +353,15 @@ private extension AFMChatCompletionService {
         request: AFMChatGenerationRequest,
         emitting emission: @escaping @Sendable (AFMHTTPEmission) async throws -> Void
     ) async throws {
+        if !result.toolCalls.isEmpty {
+            try await writeChunk(
+                identifier: identifier,
+                created: created,
+                toolCalls: result.toolCalls,
+                request: request,
+                emitting: emission
+            )
+        }
         try await writeRefusalChunk(
             result.refusal,
             identifier: identifier,
@@ -351,7 +414,10 @@ private extension AFMChatCompletionService {
     }
 
     func generationErrorResponse(_ error: Error) -> AFMHTTPResponse {
-        switch error {
+        if let toolErrorResponse = toolGenerationErrorResponse(error) {
+            return toolErrorResponse
+        }
+        return switch error {
         case AFMChatServiceError.timedOut:
             .apiError(
                 status: .gatewayTimeout,
@@ -400,6 +466,37 @@ private extension AFMChatCompletionService {
             generationFailure(.gatewayTimeout, "The local model request timed out.", "model_timeout")
         default:
             generationFailure(.internalServerError, "The local model request failed.", "model_error")
+        }
+    }
+
+    func toolGenerationErrorResponse(_ error: Error) -> AFMHTTPResponse? {
+        switch error {
+        case AFMChatGenerationError.unsupportedToolChoice:
+            .apiError(
+                status: .badRequest,
+                message: "This OS cannot guarantee the requested tool_choice semantics.",
+                code: "unsupported_tool_choice",
+                type: "invalid_request_error",
+                parameter: "tool_choice"
+            )
+        case AFMChatGenerationError.requiredToolNotCalled:
+            .apiError(
+                status: .internalServerError,
+                message: "The model did not satisfy the required tool choice.",
+                code: "required_tool_not_called",
+                type: "server_error",
+                parameter: "tool_choice"
+            )
+        case AFMChatGenerationError.toolCallLimitExceeded:
+            .apiError(
+                status: .badRequest,
+                message: "The model exceeded the local tool-call size or count limit.",
+                code: "tool_call_limit_exceeded",
+                type: "invalid_request_error",
+                parameter: "tools"
+            )
+        default:
+            nil
         }
     }
 

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatRequestValidation.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatRequestValidation.swift
@@ -1,6 +1,194 @@
 import Foundation
+import FoundationModelsKit
 
 extension AFMChatGenerationRequest {
+    static func validateTools(
+        _ tools: [AFMChatToolDefinition],
+        choice: AFMChatToolChoice,
+        parallelToolCalls: Bool
+    ) throws {
+        guard tools.count <= AFMChatToolLimits.maximumDefinitions else {
+            throw AFMChatRequestValidationError.invalidField(
+                "tools",
+                message: "At most \(AFMChatToolLimits.maximumDefinitions) tools may be provided."
+            )
+        }
+        if !parallelToolCalls, !tools.isEmpty, choice != .none {
+            throw AFMChatRequestValidationError.unsupportedField("parallel_tool_calls")
+        }
+
+        let names = try validateToolDefinitions(tools)
+        try validateToolChoice(choice, declaredNames: names, hasTools: !tools.isEmpty)
+    }
+
+    static func validateToolChoiceAvailability(_ choice: AFMChatToolChoice) throws {
+        guard choice.requiresInvocation else { return }
+        #if compiler(>=6.4)
+        guard #available(iOS 27.0, macOS 27.0, *) else {
+            throw unsupportedToolChoice()
+        }
+        #else
+        throw unsupportedToolChoice()
+        #endif
+    }
+
+    private static func unsupportedToolChoice() -> AFMChatRequestValidationError {
+        .init(
+            message: "This OS cannot guarantee the requested tool_choice semantics.",
+            parameter: "tool_choice",
+            code: "unsupported_tool_choice"
+        )
+    }
+
+    private static func validateToolDefinitions(
+        _ tools: [AFMChatToolDefinition]
+    ) throws -> Set<String> {
+        var names = Set<String>()
+        var totalSchemaBytes = 0
+        for (index, tool) in tools.enumerated() {
+            let basePath = "tools[\(index)].function"
+            try validateToolName(tool.name, at: "\(basePath).name")
+            guard names.insert(tool.name).inserted else {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(basePath).name",
+                    message: "Tool names must be unique."
+                )
+            }
+            guard tool.description.utf8.count <= AFMChatToolLimits.maximumDescriptionBytes else {
+                throw AFMChatRequestValidationError.invalidField(
+                    "\(basePath).description",
+                    message: "Tool descriptions may not exceed \(AFMChatToolLimits.maximumDescriptionBytes) UTF-8 bytes."
+                )
+            }
+            let parametersPath = "\(basePath).parameters"
+            totalSchemaBytes += try validateToolSchema(tool.parameters, at: parametersPath)
+            if tool.strict == true {
+                try validateStrictToolSchema(tool.parameters, at: parametersPath)
+            }
+        }
+        guard totalSchemaBytes <= AFMChatToolLimits.maximumTotalSchemaBytes else {
+            throw AFMChatRequestValidationError.invalidField(
+                "tools",
+                message: "Combined tool schemas may not exceed \(AFMChatToolLimits.maximumTotalSchemaBytes) bytes."
+            )
+        }
+        return names
+    }
+
+    private static func validateToolChoice(
+        _ choice: AFMChatToolChoice,
+        declaredNames: Set<String>,
+        hasTools: Bool
+    ) throws {
+        switch choice {
+        case .required where !hasTools:
+            throw AFMChatRequestValidationError.invalidField(
+                "tool_choice",
+                message: "tool_choice 'required' requires at least one tool."
+            )
+        case .function(let name):
+            try validateToolName(name, at: "tool_choice.function.name")
+            guard declaredNames.contains(name) else {
+                throw AFMChatRequestValidationError.invalidField(
+                    "tool_choice.function.name",
+                    message: "The selected function must match a declared tool."
+                )
+            }
+        case .auto, .none, .required:
+            break
+        }
+    }
+
+    private static func validateToolSchema(
+        _ schema: FoundationModelsJSONSchema,
+        at path: String
+    ) throws -> Int {
+        do {
+            try schema.validate()
+            guard try schema.resolvedType() == .object else {
+                throw FoundationModelsJSONSchemaError(
+                    kind: .invalidSchema,
+                    path: "$.type",
+                    message: "Tool parameter schemas must have an object root."
+                )
+            }
+            let schemaBytes = try schema.jsonData().count
+            guard schemaBytes <= AFMChatToolLimits.maximumSchemaBytes else {
+                throw AFMChatRequestValidationError.invalidField(
+                    path,
+                    message: "Each tool schema may not exceed \(AFMChatToolLimits.maximumSchemaBytes) bytes."
+                )
+            }
+            return schemaBytes
+        } catch let error as FoundationModelsJSONSchemaError {
+            throw AFMChatRequestValidationError.toolSchema(error, parameter: path)
+        }
+    }
+
+    private static func validateToolName(_ name: String, at path: String) throws {
+        let isValid = (1...64).contains(name.utf8.count) && name.utf8.allSatisfy { byte in
+            byte.isASCIILetter || byte.isASCIIDigit || byte == 45 || byte == 95
+        }
+        guard isValid else {
+            throw AFMChatRequestValidationError.invalidField(
+                path,
+                message: "Tool names must contain 1-64 ASCII letters, digits, hyphens, or underscores."
+            )
+        }
+    }
+
+    private static func validateStrictToolSchema(
+        _ schema: FoundationModelsJSONSchema,
+        at path: String
+    ) throws {
+        switch try schema.resolvedType() {
+        case .object:
+            guard schema.additionalProperties == false else {
+                throw strictToolSchemaError(
+                    at: "\(path).additionalProperties",
+                    message: "Strict tool schemas must set additionalProperties to false for every object."
+                )
+            }
+            let required = Set(schema.required ?? [])
+            if let optionalProperty = (schema.properties ?? [:]).keys.sorted().first(where: { !required.contains($0) }) {
+                throw strictToolSchemaError(
+                    at: "\(path).required",
+                    message: "Strict tool schemas must list property '\(optionalProperty)' as required."
+                )
+            }
+            for propertyName in (schema.properties ?? [:]).keys.sorted() {
+                guard let property = schema.properties?[propertyName] else { continue }
+                try validateStrictToolSchema(
+                    property,
+                    at: appendSchemaPath("\(path).properties", component: propertyName)
+                )
+            }
+        case .array:
+            if let items = schema.items {
+                try validateStrictToolSchema(items, at: "\(path).items")
+            }
+        case .string, .integer, .number, .boolean:
+            break
+        }
+    }
+
+    private static func strictToolSchemaError(
+        at path: String,
+        message: String
+    ) -> AFMChatRequestValidationError {
+        .init(message: message, parameter: path, code: "invalid_tool_schema")
+    }
+
+    private static func appendSchemaPath(_ path: String, component: String) -> String {
+        let isIdentifier = component.first?.isLetter == true
+            && component.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+        guard !isIdentifier else { return "\(path).\(component)" }
+        let escaped = component
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\(path)[\"\(escaped)\"]"
+    }
+
     static func validateMessages(_ messages: [AFMChatMessage]) throws {
         guard !messages.isEmpty else {
             throw AFMChatRequestValidationError.invalidField(
@@ -91,5 +279,15 @@ extension AFMChatGenerationRequest {
                 message: "Tool response name does not match its tool call."
             )
         }
+    }
+}
+
+private extension UInt8 {
+    var isASCIILetter: Bool {
+        (65...90).contains(self) || (97...122).contains(self)
+    }
+
+    var isASCIIDigit: Bool {
+        (48...57).contains(self)
     }
 }

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatToolCallPayload.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatToolCallPayload.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct AFMChatToolCallPayload: Encodable {
+    struct Function: Encodable {
+        let name: String
+        let arguments: String
+    }
+
+    let id: String
+    let type = "function"
+    let function: Function
+
+    init(_ call: AFMChatToolCall) {
+        id = call.id
+        function = .init(name: call.name, arguments: call.arguments)
+    }
+}
+
+struct AFMChatToolCallDeltaPayload: Encodable {
+    struct Function: Encodable {
+        let name: String
+        let arguments: String
+    }
+
+    let index: Int
+    let id: String
+    let type = "function"
+    let function: Function
+
+    init(index: Int, call: AFMChatToolCall) {
+        self.index = index
+        id = call.id
+        function = .init(name: call.name, arguments: call.arguments)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatToolCallRecorder.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatToolCallRecorder.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+actor AFMChatToolCallRecorder {
+    struct RecordedCall: Sendable {
+        let definitionIndex: Int
+        let sequence: Int
+        let name: String
+        let arguments: String
+    }
+
+    struct Snapshot: Sendable {
+        let calls: [RecordedCall]
+        let exceededLimit: Bool
+        let invalidArguments: Bool
+    }
+
+    private var calls: [RecordedCall] = []
+    private var exceededLimit = false
+    private var invalidArguments = false
+    private var totalArgumentBytes = 0
+
+    func record(definitionIndex: Int, name: String, arguments: String) {
+        guard let canonicalArguments = Self.canonicalJSONObject(arguments) else {
+            invalidArguments = true
+            return
+        }
+        let argumentBytes = canonicalArguments.utf8.count
+        let (newTotal, overflowed) = totalArgumentBytes.addingReportingOverflow(argumentBytes)
+        guard calls.count < AFMChatToolLimits.maximumCapturedCalls,
+              argumentBytes <= AFMChatToolLimits.maximumArgumentsBytes,
+              !overflowed,
+              newTotal <= AFMChatToolLimits.maximumTotalArgumentsBytes else {
+            exceededLimit = true
+            return
+        }
+        calls.append(
+            .init(
+                definitionIndex: definitionIndex,
+                sequence: calls.count,
+                name: name,
+                arguments: canonicalArguments
+            )
+        )
+        totalArgumentBytes = newTotal
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            calls: calls,
+            exceededLimit: exceededLimit,
+            invalidArguments: invalidArguments
+        )
+    }
+
+    private static func canonicalJSONObject(_ value: String) -> String? {
+        guard let data = value.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              object is [String: Any],
+              let canonical = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: canonical, encoding: .utf8)
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatToolChoice.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatToolChoice.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public enum AFMChatToolChoice: Sendable, Equatable {
+    case auto
+    case none
+    case required
+    case function(name: String)
+
+    var requiresInvocation: Bool {
+        switch self {
+        case .required, .function:
+            true
+        case .auto, .none:
+            false
+        }
+    }
+}
+
+extension AFMChatToolChoice: Decodable {
+    private static let allowedFields: Set<String> = ["type", "function"]
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer()
+        if let string = try? value.decode(String.self) {
+            switch string {
+            case "auto":
+                self = .auto
+            case "none":
+                self = .none
+            case "required":
+                self = .required
+            default:
+                throw AFMChatRequestValidationError.invalidField(
+                    parameterPath(decoder.codingPath),
+                    message: "tool_choice must be 'auto', 'none', 'required', or a named function."
+                )
+            }
+            return
+        }
+
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        let type = try container.decode(String.self, forKey: .init("type"))
+        guard type == "function" else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "type"),
+                message: "Only named function tool choices are supported."
+            )
+        }
+        let function = try container.decode(NamedFunction.self, forKey: .init("function"))
+        self = .function(name: function.name)
+    }
+}
+
+private struct NamedFunction: Decodable {
+    let name: String
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: ["name"], decoder: decoder)
+        name = try container.decode(String.self, forKey: .init("name"))
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatToolDefinition.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatToolDefinition.swift
@@ -1,0 +1,72 @@
+import Foundation
+import FoundationModelsKit
+
+public struct AFMChatToolDefinition: Sendable, Equatable {
+    public let name: String
+    public let description: String
+    public let parameters: FoundationModelsJSONSchema
+    public let strict: Bool?
+
+    public init(
+        name: String,
+        description: String = "",
+        parameters: FoundationModelsJSONSchema = .init(type: "object"),
+        strict: Bool? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.strict = strict
+    }
+}
+
+extension AFMChatToolDefinition: Decodable {
+    private static let allowedFields: Set<String> = ["type", "function"]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        let type = try container.decode(String.self, forKey: .init("type"))
+        guard type == "function" else {
+            throw AFMChatRequestValidationError.invalidField(
+                parameterPath(decoder.codingPath, field: "type"),
+                message: "Only function tools are supported."
+            )
+        }
+        let function = try container.decode(Function.self, forKey: .init("function"))
+        self = .init(
+            name: function.name,
+            description: function.description,
+            parameters: function.parameters,
+            strict: function.strict
+        )
+    }
+}
+
+private struct Function: Decodable {
+    let name: String
+    let description: String
+    let parameters: FoundationModelsJSONSchema
+    let strict: Bool?
+
+    private static let allowedFields: Set<String> = ["name", "description", "parameters", "strict"]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AFMJSONKey.self)
+        try rejectUnknownFields(in: container, allowed: Self.allowedFields, decoder: decoder)
+        name = try container.decode(String.self, forKey: .init("name"))
+        description = try container.decodeIfPresent(String.self, forKey: .init("description")) ?? ""
+        strict = try container.decodeIfPresent(Bool.self, forKey: .init("strict"))
+        do {
+            parameters = try container.decodeIfPresent(
+                FoundationModelsJSONSchema.self,
+                forKey: .init("parameters")
+            ) ?? .init(type: "object")
+        } catch let error as FoundationModelsJSONSchemaError {
+            throw AFMChatRequestValidationError.toolSchema(
+                error,
+                parameter: parameterPath(decoder.codingPath, field: "parameters")
+            )
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatToolLimits.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatToolLimits.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum AFMChatToolLimits {
+    static let maximumDefinitions = 16
+    static let maximumDescriptionBytes = 4_096
+    static let maximumSchemaBytes = 65_536
+    static let maximumTotalSchemaBytes = 131_072
+    static let maximumCapturedCalls = 32
+    static let maximumArgumentsBytes = 65_536
+    static let maximumTotalArgumentsBytes = 131_072
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMChatToolRuntime.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMChatToolRuntime.swift
@@ -1,0 +1,73 @@
+import Foundation
+import FoundationModels
+import FoundationModelsKit
+
+struct AFMChatToolRuntime {
+    let tools: [any Tool]
+    let transcriptDefinitions: [Transcript.ToolDefinition]
+    private let recorder: AFMChatToolCallRecorder
+
+    var isActive: Bool {
+        !tools.isEmpty
+    }
+
+    init(request: AFMChatGenerationRequest) throws {
+        let selectedDefinitions: [(offset: Int, element: AFMChatToolDefinition)]
+        switch request.toolChoice {
+        case .none:
+            selectedDefinitions = []
+        case .auto, .required:
+            selectedDefinitions = Array(request.tools.enumerated())
+        case .function(let name):
+            selectedDefinitions = request.tools.enumerated().filter { $0.element.name == name }
+        }
+
+        let recorder = AFMChatToolCallRecorder()
+        let captureTools = try selectedDefinitions.map { index, definition in
+            AFMChatCaptureTool(
+                name: definition.name,
+                description: definition.description,
+                parameters: try definition.parameters.generationSchema(
+                    rootName: "\(definition.name)Arguments"
+                ),
+                definitionIndex: index,
+                recorder: recorder
+            )
+        }
+        self.recorder = recorder
+        tools = captureTools
+        transcriptDefinitions = captureTools.map {
+            Transcript.ToolDefinition(
+                name: $0.name,
+                description: $0.description,
+                parameters: $0.parameters
+            )
+        }
+    }
+
+    func capturedCalls() async throws -> [AFMChatToolCall] {
+        let snapshot = await recorder.snapshot()
+        guard !snapshot.exceededLimit else {
+            throw AFMChatGenerationError.toolCallLimitExceeded
+        }
+        guard !snapshot.invalidArguments else {
+            throw AFMChatGenerationError.unsupportedInput
+        }
+        let sortedCalls = snapshot.calls.sorted { left, right in
+            if left.definitionIndex != right.definitionIndex {
+                return left.definitionIndex < right.definitionIndex
+            }
+            if left.arguments != right.arguments {
+                return left.arguments < right.arguments
+            }
+            return left.sequence < right.sequence
+        }
+        return sortedCalls.map { call in
+            AFMChatToolCall(
+                id: "call_\(UUID().uuidString)",
+                name: call.name,
+                arguments: call.arguments
+            )
+        }
+    }
+}

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsChatGenerator.swift
@@ -3,33 +3,51 @@ import FoundationModels
 import FoundationModelsKit
 
 public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
-    private let sessionBuilder: AFMFoundationModelsSessionBuilder
+    private let sessionBuilder: AFMFoundationModelsToolSessionBuilder
 
     public init() {
-        sessionBuilder = { requestedModelIdentifier, transcript in
+        sessionBuilder = { requestedModelIdentifier, tools, transcript in
             guard requestedModelIdentifier == "system" else {
                 throw AFMChatGenerationError.modelUnavailable
             }
-            return LanguageModelSession(model: .default, transcript: transcript)
+            return LanguageModelSession(model: .default, tools: tools, transcript: transcript)
         }
     }
 
     public init(sessionBuilder: @escaping AFMFoundationModelsSessionBuilder) {
-        self.sessionBuilder = sessionBuilder
+        self.sessionBuilder = { requestedModelIdentifier, tools, transcript in
+            guard tools.isEmpty else {
+                throw AFMChatGenerationError.unsupportedInput
+            }
+            return try sessionBuilder(requestedModelIdentifier, transcript)
+        }
+    }
+
+    public init(toolSessionBuilder: @escaping AFMFoundationModelsToolSessionBuilder) {
+        sessionBuilder = toolSessionBuilder
     }
 
     public func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
-        let prepared = try AFMChatTranscriptBuilder.prepare(request)
-        let session = try sessionBuilder(request.model, prepared.transcript)
+        let toolRuntime = try AFMChatToolRuntime(request: request)
+        let prepared = try AFMChatTranscriptBuilder.prepare(
+            request,
+            toolDefinitions: toolRuntime.transcriptDefinitions
+        )
+        let session = try sessionBuilder(request.model, toolRuntime.tools, prepared.transcript)
 
         do {
             let response = try await session.respond(to: prepared.prompt, options: prepared.options)
+            guard !request.toolChoice.requiresInvocation else {
+                throw AFMChatGenerationError.requiredToolNotCalled
+            }
             let usage = await responseUsage(response, prepared: prepared)
             return AFMChatGenerationResult(
                 content: response.content,
                 finishReason: finishReason(for: request, usage: usage),
                 usage: usage
             )
+        } catch let error as LanguageModelSession.ToolCallError where error.isAFMChatToolCapture {
+            return try await toolCallResult(runtime: toolRuntime, prepared: prepared)
         } catch {
             if Self.isRefusal(error) {
                 return await refusalResult(prepared: prepared)
@@ -42,8 +60,12 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         _ request: AFMChatGenerationRequest,
         emitting event: @escaping @Sendable (AFMChatGenerationEvent) async throws -> Void
     ) async throws -> AFMChatGenerationResult {
-        let prepared = try AFMChatTranscriptBuilder.prepare(request)
-        let session = try sessionBuilder(request.model, prepared.transcript)
+        let toolRuntime = try AFMChatToolRuntime(request: request)
+        let prepared = try AFMChatTranscriptBuilder.prepare(
+            request,
+            toolDefinitions: toolRuntime.transcriptDefinitions
+        )
+        let session = try sessionBuilder(request.model, toolRuntime.tools, prepared.transcript)
         let responseStream = session.streamResponse(to: prepared.prompt, options: prepared.options)
         var accumulator = AFMSnapshotDeltaAccumulator()
 
@@ -51,7 +73,7 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
             for try await snapshot in responseStream {
                 try Task.checkCancellation()
                 let delta = try accumulator.append(snapshot: snapshot.content)
-                if !delta.isEmpty {
+                if !toolRuntime.isActive, !delta.isEmpty {
                     try await event(.contentDelta(delta))
                 }
             }
@@ -59,10 +81,16 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
             try Task.checkCancellation()
             let response = try await responseStream.collect()
             let finalDelta = try accumulator.append(snapshot: response.content)
-            if !finalDelta.isEmpty {
+            if !toolRuntime.isActive, !finalDelta.isEmpty {
                 try await event(.contentDelta(finalDelta))
             }
+            if toolRuntime.isActive, !response.content.isEmpty {
+                try await event(.contentDelta(response.content))
+            }
             try Task.checkCancellation()
+            guard !request.toolChoice.requiresInvocation else {
+                throw AFMChatGenerationError.requiredToolNotCalled
+            }
             let usage = await responseUsage(response, prepared: prepared)
             let result = AFMChatGenerationResult(
                 content: response.content,
@@ -70,6 +98,8 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
                 usage: usage
             )
             return result
+        } catch let error as LanguageModelSession.ToolCallError where error.isAFMChatToolCapture {
+            return try await toolCallResult(runtime: toolRuntime, prepared: prepared)
         } catch {
             if Self.isRefusal(error) {
                 return await refusalResult(prepared: prepared)
@@ -107,6 +137,24 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
         )
     }
 
+    private func toolCallResult(
+        runtime: AFMChatToolRuntime,
+        prepared: AFMPreparedChatGeneration
+    ) async throws -> AFMChatGenerationResult {
+        let calls = try await runtime.capturedCalls()
+        guard !calls.isEmpty else {
+            throw AFMChatGenerationError.unsupportedInput
+        }
+        let output = try toolCallsEntry(calls)
+        let usage = await fallbackUsage(input: prepared.inputTranscript, output: output)
+        return AFMChatGenerationResult(
+            content: nil,
+            finishReason: .toolCalls,
+            usage: usage,
+            toolCalls: calls
+        )
+    }
+
     private func finishReason(
         for request: AFMChatGenerationRequest,
         usage: ModelTokenUsage
@@ -121,8 +169,12 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
     }
 
     private func fallbackUsage(input: Transcript, output: String) async -> ModelTokenUsage {
+        await fallbackUsage(input: input, output: outputEntry(output))
+    }
+
+    private func fallbackUsage(input: Transcript, output: Transcript.Entry) async -> ModelTokenUsage {
         async let inputUsage = input.tokenUsage(using: .default)
-        async let outputUsage = outputEntry(output).tokenUsage(using: .default)
+        async let outputUsage = output.tokenUsage(using: .default)
         let (resolvedInput, resolvedOutput) = await (inputUsage, outputUsage)
         let measurement: ModelTokenUsage.Measurement =
             resolvedInput.measurement == .tokenized && resolvedOutput.measurement == .tokenized
@@ -139,6 +191,17 @@ public struct AFMFoundationModelsChatGenerator: AFMChatCompletionGenerating {
     private func outputEntry(_ content: String) -> Transcript.Entry {
         .response(.init(assetIDs: [], segments: AFMChatTranscriptBuilder.segments([content])))
     }
+
+    private func toolCallsEntry(_ calls: [AFMChatToolCall]) throws -> Transcript.Entry {
+        let transcriptCalls = try calls.map { call in
+            Transcript.ToolCall(
+                id: call.id,
+                toolName: call.name,
+                arguments: try GeneratedContent(json: call.arguments)
+            )
+        }
+        return .toolCalls(.init(transcriptCalls))
+    }
 }
 
 struct AFMPreparedChatGeneration {
@@ -149,7 +212,10 @@ struct AFMPreparedChatGeneration {
 }
 
 enum AFMChatTranscriptBuilder {
-    static func prepare(_ request: AFMChatGenerationRequest) throws -> AFMPreparedChatGeneration {
+    static func prepare(
+        _ request: AFMChatGenerationRequest,
+        toolDefinitions: [Transcript.ToolDefinition] = []
+    ) throws -> AFMPreparedChatGeneration {
         guard !request.messages.isEmpty else {
             throw AFMChatGenerationError.unsupportedInput
         }
@@ -159,14 +225,38 @@ enum AFMChatTranscriptBuilder {
         let promptContent = activePromptContent(for: finalMessage)
         let prompt = Prompt(promptContent)
         let inputPrompt = Transcript.Prompt(segments: segments(promptContent))
-        let inputTranscript = Transcript(entries: entries + [.prompt(inputPrompt)])
+        let inputEntries = adding(toolDefinitions, to: entries) + [.prompt(inputPrompt)]
+        let inputTranscript = Transcript(entries: inputEntries)
         let transcript = Transcript(entries: entries)
         return AFMPreparedChatGeneration(
             transcript: transcript,
             prompt: prompt,
             inputTranscript: inputTranscript,
-            options: generationOptions(for: request)
+            options: try generationOptions(for: request)
         )
+    }
+
+    private static func adding(
+        _ toolDefinitions: [Transcript.ToolDefinition],
+        to entries: [Transcript.Entry]
+    ) -> [Transcript.Entry] {
+        guard !toolDefinitions.isEmpty else { return entries }
+        var result = entries
+        if let first = result.first, case .instructions(let instructions) = first {
+            result[0] = .instructions(
+                .init(
+                    id: instructions.id,
+                    segments: instructions.segments,
+                    toolDefinitions: instructions.toolDefinitions + toolDefinitions
+                )
+            )
+        } else {
+            result.insert(
+                .instructions(.init(segments: [], toolDefinitions: toolDefinitions)),
+                at: 0
+            )
+        }
+        return result
     }
 
     static func segments(_ content: [String]) -> [Transcript.Segment] {
@@ -254,15 +344,31 @@ enum AFMChatTranscriptBuilder {
         return [""]
     }
 
-    private static func generationOptions(for request: AFMChatGenerationRequest) -> GenerationOptions {
+    private static func generationOptions(for request: AFMChatGenerationRequest) throws -> GenerationOptions {
         let sampling = request.topP.map { GenerationOptions.SamplingMode.random(probabilityThreshold: $0) }
         #if compiler(>=6.4)
-        return GenerationOptions(
+        var options = GenerationOptions(
             samplingMode: sampling,
             temperature: request.temperature,
             maximumResponseTokens: request.maximumCompletionTokens
         )
+        if #available(iOS 27.0, macOS 27.0, *) {
+            switch request.toolChoice {
+            case .auto:
+                options.toolCallingMode = .allowed
+            case .none:
+                options.toolCallingMode = .disallowed
+            case .required, .function:
+                options.toolCallingMode = .required
+            }
+        } else if request.toolChoice.requiresInvocation {
+            throw AFMChatGenerationError.unsupportedToolChoice
+        }
+        return options
         #else
+        guard !request.toolChoice.requiresInvocation else {
+            throw AFMChatGenerationError.unsupportedToolChoice
+        }
         return GenerationOptions(
             sampling: sampling,
             temperature: request.temperature,

--- a/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsSessionBuilder.swift
+++ b/Packages/AFMServer/Sources/AFMServer/AFMFoundationModelsSessionBuilder.swift
@@ -4,3 +4,9 @@ public typealias AFMFoundationModelsSessionBuilder = @Sendable (
     _ requestedModelIdentifier: String,
     _ transcript: Transcript
 ) throws -> LanguageModelSession
+
+public typealias AFMFoundationModelsToolSessionBuilder = @Sendable (
+    _ requestedModelIdentifier: String,
+    _ tools: [any Tool],
+    _ transcript: Transcript
+) throws -> LanguageModelSession

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatCompletionServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatCompletionServiceTests.swift
@@ -27,6 +27,7 @@ func chatCompletionResponseShape() async throws {
     #expect(message["role"] as? String == "assistant")
     #expect(message["content"] as? String == "Hello")
     #expect(message["refusal"] is NSNull)
+    #expect(message["tool_calls"] == nil)
     #expect(choices.first?["finish_reason"] as? String == "stop")
     #expect(choices.first?["logprobs"] is NSNull)
 
@@ -42,6 +43,56 @@ func chatCompletionResponseShape() async throws {
     #expect(completionDetails["reasoning_tokens"] as? Int == 3)
     let recorded = await generator.recordedRequests()
     #expect(recorded.count == 1)
+}
+
+@Test("Tool calls use canonical OpenAI message fields and finish reason")
+func chatCompletionToolCallShape() async throws {
+    let usage = ModelTokenUsage(
+        input: .init(totalTokenCount: 14),
+        output: .init(totalTokenCount: 9),
+        measurement: .tokenized,
+        scope: .response
+    )
+    let generator = RecordingGenerator(
+        result: .init(
+            content: nil,
+            finishReason: .toolCalls,
+            usage: usage,
+            toolCalls: [
+                .init(id: "call_a", name: "weather", arguments: #"{"city":"Paris"}"#),
+                .init(id: "call_b", name: "calendar", arguments: #"{"day":"Monday"}"#)
+            ]
+        )
+    )
+
+    let response = try await testChatService(generator: generator).response(for: chatBody())
+    let json = try serviceJSONObject(response.body)
+    let choices = try #require(json["choices"] as? [[String: Any]])
+    let choice = try #require(choices.first)
+    let message = try #require(choice["message"] as? [String: Any])
+    #expect(message["content"] is NSNull)
+    #expect(message["refusal"] is NSNull)
+    #expect(choice["finish_reason"] as? String == "tool_calls")
+    let calls = try #require(message["tool_calls"] as? [[String: Any]])
+    #expect(calls.map { $0["id"] as? String } == ["call_a", "call_b"])
+    #expect(calls.allSatisfy { $0["type"] as? String == "function" })
+    let firstFunction = try #require(calls[0]["function"] as? [String: Any])
+    #expect(firstFunction["name"] as? String == "weather")
+    #expect(firstFunction["arguments"] as? String == #"{"city":"Paris"}"#)
+    let usageJSON = try #require(json["usage"] as? [String: Any])
+    #expect(usageJSON["completion_tokens"] as? Int == 9)
+    #expect(usageJSON["afm_measurement"] as? String == "tokenized")
+}
+
+@Test("Unsupported forced tool choices produce a precise API error")
+func chatCompletionUnsupportedToolChoice() async throws {
+    let service = testChatService(generator: FailingGenerator(error: .unsupportedToolChoice))
+    let response = try await service.response(for: chatBody())
+    #expect(response.status == .badRequest)
+    let json = try serviceJSONObject(response.body)
+    let error = try #require(json["error"] as? [String: Any])
+    #expect(error["code"] as? String == "unsupported_tool_choice")
+    #expect(error["param"] as? String == "tool_choice")
 }
 
 @Test("Refusals remain successful completions with null content")
@@ -142,6 +193,14 @@ private struct PausingGenerator: AFMChatCompletionGenerating {
         } onCancel: {
             Task { await probe.markCancelled() }
         }
+    }
+}
+
+private struct FailingGenerator: AFMChatCompletionGenerating {
+    let error: AFMChatGenerationError
+
+    func generate(_ request: AFMChatGenerationRequest) async throws -> AFMChatGenerationResult {
+        throw error
     }
 }
 

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatRequestTests.swift
@@ -51,6 +51,137 @@ func chatRequestAppleStreamingShape() throws {
     #expect(request.streamOptions == .init(includeUsage: true))
 }
 
+@Test("Chat requests decode validated function tools and OpenAI tool choices")
+func chatRequestFunctionTools() throws {
+    let request = try decodeChatRequest(
+        #"""
+        {
+          "messages": [{"role":"user","content":"Weather?"}],
+          "tools": [{
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "description": "Get weather without executing it locally.",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "city": {"type":"string"},
+                  "days": {"type":"integer"},
+                  "units": {"type":"string","enum":["metric","imperial"]}
+                },
+                "required": ["city", "days", "units"],
+                "additionalProperties": false
+              }
+            }
+          }],
+          "tool_choice": "auto",
+          "parallel_tool_calls": true
+        }
+        """#
+    )
+
+    #expect(request.tools.count == 1)
+    #expect(request.tools[0].name == "get_weather")
+    #expect(request.tools[0].strict == true)
+    #expect(request.tools[0].parameters.required == ["city", "days", "units"])
+    #expect(request.toolChoice == .auto)
+    #expect(request.parallelToolCalls)
+}
+
+@Test("Tool choice defaults follow the OpenAI request shape")
+func chatRequestToolChoiceDefaults() throws {
+    let withoutTools = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}]}"#
+    )
+    let withTools = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{"name":"ping"}}]}"#
+    )
+    let disabled = try decodeChatRequest(
+        #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{"name":"ping"}}],"tool_choice":"none"}"#
+    )
+    let disabledParallelism = try decodeChatRequest(
+        #"""
+        {"messages":[{"role":"user","content":"Hi"}],
+         "tools":[{"type":"function","function":{"name":"ping"}}],
+         "tool_choice":"none","parallel_tool_calls":false}
+        """#
+    )
+
+    #expect(withoutTools.toolChoice == .none)
+    #expect(withTools.toolChoice == .auto)
+    #expect(disabled.toolChoice == .none)
+    #expect(disabled.tools.count == 1)
+    #expect(!disabledParallelism.parallelToolCalls)
+}
+
+#if compiler(>=6.4)
+@Test("Named tool choices decode when the public OS 27 required mode is available")
+func chatRequestNamedToolChoiceOnOS27() throws {
+    guard #available(macOS 27.0, *) else { return }
+    let request = try decodeChatRequest(
+        #"""
+        {"messages":[{"role":"user","content":"Hi"}],
+         "tools":[{"type":"function","function":{"name":"ping"}}],
+         "tool_choice":{"type":"function","function":{"name":"ping"}}}
+        """#
+    )
+    #expect(request.toolChoice == .function(name: "ping"))
+}
+#endif
+
+@Test(
+    "Strict tool schemas require closed objects and required properties recursively",
+    arguments: [
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{
+              "name":"ping","strict":true,
+              "parameters":{"type":"object","properties":{},"required":[]}
+            }}]}
+            """#,
+            "tools[0].function.parameters.additionalProperties"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{
+              "name":"ping","strict":true,
+              "parameters":{"type":"object","properties":{"value":{"type":"string"}},
+              "required":[],"additionalProperties":false}
+            }}]}
+            """#,
+            "tools[0].function.parameters.required"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{
+              "name":"ping","strict":true,
+              "parameters":{"type":"object","properties":{"nested":{"type":"object","properties":{},"required":[]}},
+              "required":["nested"],"additionalProperties":false}
+            }}]}
+            """#,
+            "tools[0].function.parameters.properties.nested.additionalProperties"
+        )
+    ]
+)
+func chatRequestStrictToolSchemas(json: String, parameter: String) {
+    expectChatValidationError(json, parameter: parameter, code: "invalid_tool_schema")
+}
+
+@Test("Non-strict tools may use optional properties from the supported schema subset")
+func chatRequestNonStrictOptionalProperties() throws {
+    let request = try decodeChatRequest(
+        #"""
+        {"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{
+          "name":"ping","strict":false,
+          "parameters":{"type":"object","properties":{"value":{"type":"string"}}}
+        }}]}
+        """#
+    )
+    #expect(request.tools[0].strict == false)
+    #expect(request.tools[0].parameters.required == nil)
+}
+
 @Test("Chat requests accept omitted and null tool sentinels")
 func chatRequestNullToolSentinels() throws {
     let omitted = try decodeChatRequest(
@@ -80,13 +211,13 @@ func chatRequestToolHistory() throws {
     arguments: [
         (
             #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function"}]}"#,
-            "tools",
-            "unsupported_field"
+            "tools[0].function",
+            "missing_field"
         ),
         (
             #"{"messages":[{"role":"user","content":"Hi"}],"tool_choice":"required"}"#,
             "tool_choice",
-            "unsupported_field"
+            "invalid_field"
         ),
         (
             #"{"messages":[{"role":"user","content":"Hi"}],"stream_options":{"include_usage":true}}"#,
@@ -109,6 +240,100 @@ func chatRequestToolHistory() throws {
 )
 func chatRequestRejectedFields(json: String, parameter: String, code: String) {
     expectChatValidationError(json, parameter: parameter, code: code)
+}
+
+@Test(
+    "Invalid tool declarations return precise field and schema errors",
+    arguments: [
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"computer","function":{"name":"ping"}}]}"#,
+            "tools[0].type",
+            "invalid_field"
+        ),
+        (
+            #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{"name":"bad name"}}]}"#,
+            "tools[0].function.name",
+            "invalid_field"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[{
+              "type":"function","function":{"name":"ping","parameters":{"type":"object","patternProperties":{}}}
+            }]}
+            """#,
+            "tools[0].function.parameters.patternProperties",
+            "unsupported_schema_keyword"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[{
+              "type":"function","function":{"name":"ping","parameters":{"type":"array","items":{"type":"string"}}}
+            }]}
+            """#,
+            "tools[0].function.parameters.type",
+            "invalid_tool_schema"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[{
+              "type":"function","function":{"name":"ping","parameters":{"type":"object","additionalProperties":true}}
+            }]}
+            """#,
+            "tools[0].function.parameters.additionalProperties",
+            "invalid_tool_schema"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],"tools":[
+              {"type":"function","function":{"name":"ping"}},
+              {"type":"function","function":{"name":"ping"}}
+            ]}
+            """#,
+            "tools[1].function.name",
+            "invalid_field"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],
+             "tools":[{"type":"function","function":{"name":"ping"}}],
+             "tool_choice":{"type":"function","function":{"name":"missing"}}}
+            """#,
+            "tool_choice.function.name",
+            "invalid_field"
+        ),
+        (
+            #"""
+            {"messages":[{"role":"user","content":"Hi"}],
+             "tools":[{"type":"function","function":{"name":"ping"}}],
+             "parallel_tool_calls":false}
+            """#,
+            "parallel_tool_calls",
+            "unsupported_field"
+        )
+    ]
+)
+func chatRequestInvalidTools(json: String, parameter: String, code: String) {
+    expectChatValidationError(json, parameter: parameter, code: code)
+}
+
+@Test("Tool definition and schema limits fail before generation")
+func chatRequestToolLimits() throws {
+    let tools = (0...AFMChatToolLimits.maximumDefinitions).map { index in
+        #"{"type":"function","function":{"name":"tool_\#(index)"}}"#
+    }.joined(separator: ",")
+    expectChatValidationError(
+        #"{"messages":[{"role":"user","content":"Hi"}],"tools":[\#(tools)]}"#,
+        parameter: "tools",
+        code: "invalid_field"
+    )
+
+    let oversizedDescription = String(repeating: "x", count: AFMChatToolLimits.maximumSchemaBytes)
+    let schema = ##"{"type":"object","description":"\##(oversizedDescription)"}"##
+    expectChatValidationError(
+        #"{"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{"name":"ping","parameters":\#(schema)}}]}"#,
+        parameter: "tools[0].function.parameters",
+        code: "invalid_field"
+    )
 }
 
 @Test("Chat option conflicts and invalid ranges fail before generation")

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatStreamingServiceTests.swift
@@ -188,8 +188,104 @@ struct AFMChatStreamingServiceTests {
         #expect(response.status == .badRequest)
         let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
         let error = try #require(json["error"] as? [String: Any])
-        #expect(error["code"] as? String == "unsupported_field")
-        #expect(error["param"] as? String == "tools")
+        #expect(error["code"] as? String == "missing_field")
+        #expect(error["param"] as? String == "tools[0].type")
+    }
+
+    @Test("Unsupported forced tool choices fail before the SSE response starts")
+    func streamForcedToolChoiceValidation() async throws {
+        #if compiler(>=6.4)
+        if #available(macOS 27.0, *) { return }
+        #endif
+        let generator = StreamingGenerator(deltas: [], result: Self.standardResult())
+        let body = Data(
+            #"""
+            {"messages":[{"role":"user","content":"Call ping"}],"stream":true,
+             "tools":[{"type":"function","function":{"name":"ping"}}],
+             "tool_choice":"required"}
+            """#.utf8
+        )
+        let emissions = try await Self.collect(Self.service(generator: generator), body: body)
+
+        #expect(emissions.count == 1)
+        guard case .fixed(let response) = try #require(emissions.first) else {
+            Issue.record("Expected a fixed JSON validation response")
+            return
+        }
+        #expect(response.status == .badRequest)
+        let json = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        let error = try #require(json["error"] as? [String: Any])
+        #expect(error["code"] as? String == "unsupported_tool_choice")
+        #expect(error["param"] as? String == "tool_choice")
+    }
+}
+
+extension AFMChatStreamingServiceTests {
+    @Test("Streaming tool calls emit canonical deltas, finish, usage, and DONE")
+    func streamToolCalls() async throws {
+        let generator = StreamingGenerator(
+            deltas: ["<start_of_turn>", "model:internal-base64"],
+            result: .init(
+                content: nil,
+                finishReason: .toolCalls,
+                usage: .init(
+                    input: .init(totalTokenCount: 8),
+                    output: .init(totalTokenCount: 5),
+                    measurement: .tokenized,
+                    scope: .response
+                ),
+                toolCalls: [
+                    .init(id: "call_1", name: "weather", arguments: #"{"city":"Paris"}"#),
+                    .init(id: "call_2", name: "weather", arguments: #"{"city":"Tokyo"}"#)
+                ]
+            )
+        )
+        let emissions = try await Self.collect(
+            Self.service(generator: generator),
+            body: Self.toolStreamBody(includeUsage: true)
+        )
+        let bodies = Self.streamBodies(emissions)
+        #expect(bodies.last == "data: [DONE]\n\n")
+        let chunks = try bodies.dropLast().map(Self.eventObject)
+        #expect(chunks.count == 4)
+        #expect(!bodies.contains { $0.contains("start_of_turn") || $0.contains("internal-base64") })
+
+        let callChoice = try Self.choice(in: chunks[1])
+        #expect(callChoice["finish_reason"] is NSNull)
+        let delta = try #require(callChoice["delta"] as? [String: Any])
+        #expect(delta["content"] == nil)
+        let calls = try #require(delta["tool_calls"] as? [[String: Any]])
+        #expect(calls.map { $0["index"] as? Int } == [0, 1])
+        #expect(calls.map { $0["id"] as? String } == ["call_1", "call_2"])
+        #expect(calls.allSatisfy { $0["type"] as? String == "function" })
+        let secondFunction = try #require(calls[1]["function"] as? [String: Any])
+        #expect(secondFunction["name"] as? String == "weather")
+        #expect(secondFunction["arguments"] as? String == #"{"city":"Tokyo"}"#)
+
+        #expect(try Self.choice(in: chunks[2])["finish_reason"] as? String == "tool_calls")
+        #expect((chunks[3]["choices"] as? [Any])?.isEmpty == true)
+        let usage = try #require(chunks[3]["usage"] as? [String: Any])
+        #expect(usage["prompt_tokens"] as? Int == 8)
+        #expect(usage["completion_tokens"] as? Int == 5)
+        #expect(usage["afm_measurement"] as? String == "tokenized")
+    }
+
+    @Test("Tool-enabled streams release buffered content after a normal answer")
+    func streamToolEnabledContent() async throws {
+        let generator = StreamingGenerator(
+            deltas: ["No tool", " needed"],
+            result: .init(content: "No tool needed", usage: Self.standardUsage())
+        )
+        let emissions = try await Self.collect(
+            Self.service(generator: generator),
+            body: Self.toolStreamBody()
+        )
+        let chunks = try Self.streamBodies(emissions).dropLast().map(Self.eventObject)
+
+        #expect(chunks.count == 4)
+        #expect(try Self.content(in: chunks[1]) == "No tool")
+        #expect(try Self.content(in: chunks[2]) == " needed")
+        #expect(try Self.choice(in: chunks[3])["finish_reason"] as? String == "stop")
     }
 }
 
@@ -347,6 +443,20 @@ private extension AFMChatStreamingServiceTests {
         return Data(
             #"{"model":"system","messages":[{"role":"user","content":"Hi"}],"stream":true\#(options)}"#.utf8
         )
+    }
+
+    static func toolStreamBody(includeUsage: Bool = false) -> Data {
+        let options = includeUsage ? #", "stream_options":{"include_usage":true}"# : ""
+        let body = """
+        {
+          "model":"system",
+          "messages":[{"role":"user","content":"Call ping"}],
+          "stream":true,
+          "tools":[{"type":"function","function":{"name":"ping"}}],
+          "tool_choice":"auto"\(options)
+        }
+        """
+        return Data(body.utf8)
     }
 
     static func streamBodies(_ emissions: [AFMHTTPEmission]) -> [String] {

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMChatToolRuntimeTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMChatToolRuntimeTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import FoundationModels
+import FoundationModelsKit
+import Testing
+@testable import AFMServer
+
+@Test("Capture tools report canonical calls in declaration order without executing a registry")
+func captureToolReportsCalls() async throws {
+    let request = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Use both tools"])],
+        tools: [
+            toolDefinition(name: "first_tool"),
+            toolDefinition(name: "second_tool")
+        ]
+    )
+    let runtime = try AFMChatToolRuntime(request: request)
+    let first = try #require(runtime.tools[0] as? AFMChatCaptureTool)
+    let second = try #require(runtime.tools[1] as? AFMChatCaptureTool)
+
+    await invoke(second, arguments: #"{"z":2,"a":"second"}"#)
+    await invoke(first, arguments: #"{"z":1,"a":"first"}"#)
+
+    let calls = try await runtime.capturedCalls()
+    #expect(calls.map(\.name) == ["first_tool", "second_tool"])
+    #expect(calls.map(\.arguments) == [
+        #"{"a":"first","z":1}"#,
+        #"{"a":"second","z":2}"#
+    ])
+    #expect(Set(calls.map(\.id)).count == 2)
+    #expect(calls.allSatisfy { $0.id.hasPrefix("call_") })
+}
+
+@Test("Tool call capture enforces its hard count limit")
+func captureToolCallLimit() async throws {
+    let request = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Use a tool"])],
+        tools: [toolDefinition(name: "ping")]
+    )
+    let runtime = try AFMChatToolRuntime(request: request)
+    let tool = try #require(runtime.tools[0] as? AFMChatCaptureTool)
+
+    for index in 0...AFMChatToolLimits.maximumCapturedCalls {
+        await invoke(tool, arguments: #"{"value":\#(index)}"#)
+    }
+
+    do {
+        _ = try await runtime.capturedCalls()
+        Issue.record("Expected the captured-call limit to fail")
+    } catch let error as AFMChatGenerationError {
+        #expect(error == .toolCallLimitExceeded)
+    }
+}
+
+@Test("Input token accounting includes active tool definitions only")
+func toolDefinitionsInInputTranscript() throws {
+    let enabled = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Hello"])],
+        tools: [toolDefinition(name: "ping")]
+    )
+    let enabledRuntime = try AFMChatToolRuntime(request: enabled)
+    let enabledPrepared = try AFMChatTranscriptBuilder.prepare(
+        enabled,
+        toolDefinitions: enabledRuntime.transcriptDefinitions
+    )
+
+    guard case .instructions(let instructions) = Array(enabledPrepared.inputTranscript).first else {
+        Issue.record("Expected synthetic tool instructions in counted input")
+        return
+    }
+    #expect(instructions.toolDefinitions.map(\.name) == ["ping"])
+    #expect(Array(enabledPrepared.transcript).isEmpty)
+
+    let disabled = AFMChatGenerationRequest(
+        messages: enabled.messages,
+        tools: enabled.tools,
+        toolChoice: .none
+    )
+    let disabledRuntime = try AFMChatToolRuntime(request: disabled)
+    let disabledPrepared = try AFMChatTranscriptBuilder.prepare(
+        disabled,
+        toolDefinitions: disabledRuntime.transcriptDefinitions
+    )
+    guard case .prompt = Array(disabledPrepared.inputTranscript).first else {
+        Issue.record("Disabled tools must not contribute counted definitions")
+        return
+    }
+    #expect(disabledRuntime.tools.isEmpty)
+}
+
+private func toolDefinition(name: String) -> AFMChatToolDefinition {
+    .init(
+        name: name,
+        description: "Report arguments only.",
+        parameters: .init(
+            type: "object",
+            properties: [
+                "a": .init(type: "string"),
+                "z": .init(type: "integer")
+            ],
+            additionalProperties: false
+        )
+    )
+}
+
+private func invoke(_ tool: AFMChatCaptureTool, arguments: String) async {
+    do {
+        _ = try await tool.call(arguments: try GeneratedContent(json: arguments))
+        Issue.record("Capture tools must stop generation instead of returning output")
+    } catch {
+        // The capture sentinel is the expected stop boundary.
+    }
+}

--- a/Packages/AFMServer/Tests/AFMServerTests/AFMFoundationModelsChatGeneratorTests.swift
+++ b/Packages/AFMServer/Tests/AFMServerTests/AFMFoundationModelsChatGeneratorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FoundationModels
+import FoundationModelsKit
 import Testing
 @testable import AFMServer
 
@@ -20,6 +21,82 @@ func foundationModelsGeneratorForwardsRequestedModel() async throws {
     }
     #expect(probe.modelIdentifier == "pcc")
 }
+
+@Test("Foundation Models generator passes validated capture tools to tool-aware builders")
+func foundationModelsGeneratorForwardsCaptureTools() async throws {
+    let probe = AFMSessionBuilderProbe()
+    let generator = AFMFoundationModelsChatGenerator(
+        toolSessionBuilder: { modelIdentifier, tools, _ in
+            probe.record("\(modelIdentifier):\(tools.count):\(tools.first?.name ?? "missing")")
+            throw AFMSessionBuilderTestError.expected
+        }
+    )
+    let request = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Call ping"])],
+        tools: [
+            .init(
+                name: "ping",
+                parameters: .init(type: "object", additionalProperties: false)
+            )
+        ]
+    )
+
+    await #expect(throws: AFMSessionBuilderTestError.expected) {
+        try await generator.generate(request)
+    }
+    #expect(probe.modelIdentifier == "system:1:ping")
+}
+
+@Test("Tool choice none does not register caller-declared tools")
+func foundationModelsGeneratorOmitsDisabledTools() async throws {
+    let probe = AFMSessionBuilderProbe()
+    let generator = AFMFoundationModelsChatGenerator(
+        toolSessionBuilder: { modelIdentifier, tools, _ in
+            probe.record("\(modelIdentifier):\(tools.count)")
+            throw AFMSessionBuilderTestError.expected
+        }
+    )
+    let request = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Do not call ping"])],
+        tools: [.init(name: "ping")],
+        toolChoice: .none
+    )
+
+    await #expect(throws: AFMSessionBuilderTestError.expected) {
+        try await generator.generate(request)
+    }
+    #expect(probe.modelIdentifier == "system:0")
+}
+
+#if compiler(<6.4)
+@Test("Forced tool choices reject precisely when the compiler lacks a public required mode")
+func foundationModelsGeneratorRejectsForcedToolsOnXcode26() throws {
+    let request = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Call ping"])],
+        tools: [.init(name: "ping")],
+        toolChoice: .required
+    )
+
+    #expect(throws: AFMChatGenerationError.unsupportedToolChoice) {
+        try AFMChatTranscriptBuilder.prepare(request)
+    }
+}
+#endif
+
+#if compiler(>=6.4)
+@Test("Forced tool choices use the public OS 27 required mode")
+func foundationModelsGeneratorRequiresToolsOnOS27() throws {
+    guard #available(macOS 27.0, *) else { return }
+    let request = AFMChatGenerationRequest(
+        messages: [.init(role: .user, contentSegments: ["Call ping"])],
+        tools: [.init(name: "ping")],
+        toolChoice: .required
+    )
+
+    let prepared = try AFMChatTranscriptBuilder.prepare(request)
+    #expect(prepared.options.toolCallingMode?.kind == .required)
+}
+#endif
 
 private final class AFMSessionBuilderProbe: @unchecked Sendable {
     private let lock = NSLock()

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -193,6 +193,9 @@ curl http://127.0.0.1:1976/v1/chat/completions \
 curl -N http://127.0.0.1:1976/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"system","messages":[{"role":"user","content":"Hello"}],"stream":true,"stream_options":{"include_usage":true},"tools":[],"tool_choice":"auto"}'
+curl http://127.0.0.1:1976/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"system","messages":[{"role":"user","content":"What is the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Report a weather lookup request.","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"],"additionalProperties":false}}}],"tool_choice":"auto"}'
 ```
 
 Chat requests are stateless: send the complete system, developer, user,
@@ -200,12 +203,37 @@ assistant, and tool history each time. String content and typed text parts are
 supported, along with `temperature`, `top_p`, `max_completion_tokens`, and the
 legacy `max_tokens` alias. Streaming emits assistant role and content deltas,
 a terminal finish reason, and `[DONE]`. Set `stream_options.include_usage` to
-receive a final empty-choices usage chunk. The empty `tools: []` and
-`tool_choice: "auto"` sentinels used by Apple's client are accepted; client-defined
-tools, image parts, and response formats return a precise `400` until their
-dedicated endpoints are implemented. Responses include input/output usage plus an `afm_measurement`
+receive a final empty-choices usage chunk.
+
+Function tools use the public Foundation Models `Tool` protocol, but the server's
+adapter only records the model's proposed name and JSON arguments. It never
+looks up or executes a caller-supplied function. The response finishes with
+`tool_calls`; execute any action in your own process, then send the matching
+assistant and tool messages in the next stateless request. `tool_choice: "auto"`
+and `"none"` work on OS 26. Forced `"required"` and named-function choices use
+the public OS 27 required mode and return `unsupported_tool_choice` on older
+runtimes instead of silently behaving like `auto`. `parallel_tool_calls: false`
+is accepted with `tool_choice: "none"`; it is rejected for enabled tools because
+Foundation Models has no public serial-call mode.
+
+Tool parameter schemas accept the shared dynamic-schema subset: closed objects,
+optional or required properties, nested objects, arrays, strings, string enums,
+integers, numbers, and booleans. Unsupported JSON Schema keywords receive a
+field-specific `400`. `strict: true` additionally requires every object to set
+`additionalProperties: false` and list every property as required, recursively.
+Requests are capped at 16 definitions, 64 KiB per schema,
+and 128 KiB combined; one response may report at most 32 calls. Tool-enabled
+streams are buffered until the runtime either finishes normally or reports tool
+calls, preventing Foundation Models' internal tool representation from appearing
+as content deltas.
+
+Image parts and unsupported response formats return a precise `400`. Responses
+include input/output usage plus an `afm_measurement`
 value of `observed`, `tokenized`, or `estimated` so fallback counts are never
-presented as runtime observation.
+presented as runtime observation. Sentinel-stopped tool calls are counted from
+the input transcript (including active definitions) and a synthetic tool-call
+output entry, so they are reported as `tokenized` or `estimated`, never
+`observed`.
 
 Generation concurrency defaults to one and excess requests receive `429`
 without being queued. Configure it with `--max-concurrent-generations`; use


### PR DESCRIPTION
## Summary

- accept OpenAI-compatible function definitions and translate their supported JSON Schema subset through FoundationModelsKit
- use a dedicated capture-only Foundation Models Tool that records proposed calls and never dispatches caller names to app or package tools
- return canonical non-streaming tool_calls and buffered SSE tool-call deltas with finish_reason=tool_calls
- suppress Foundation Models internal tool markers and encoded payloads from streamed content
- support auto and none on OS 26 and 27; support required and named choices only through the public OS 27 required mode
- return unsupported_tool_choice before the SSE head on older runtimes instead of silently degrading
- enforce strict tool schemas recursively and reject unsupported keywords, serial-call claims, oversized definitions, and oversized captured arguments
- count active tool definitions and synthetic tool-call output with tokenized or estimated provenance; never label sentinel-stopped calls as observed

## Safety boundary

This endpoint reports model-proposed function names and JSON arguments only. It does not execute a built-in tool, shell command, network request, permission request, or side effect. The client must execute or confirm any action in its own process and send the resulting tool message in a later stateless request.

## Native comparison

- identical live request: native fm and afm both counted 142 prompt tokens
- afm returned canonical tool_calls with explicit tokenized usage
- afm honored tool_choice=none; native fm still called a tool
- Xcode 26 afm rejected required with a precise 400; native fm accepted it but silently returned prose
- tool-enabled afm streams are buffered, avoiding native fm internal/base64 delta leakage

## Verification

- AFMServer: 98 tests on Xcode 26.6 and 99 tests on Xcode 27
- exact CI lint configs: zero violations across 250 core/CLI/server files and 32 FoundationModelsKit files
- repeated real capture probes verified concurrent two-tool calls on both public toolchains
- live non-TTY afm serve exercised auto, none, required fallback, response shape, and usage
- generic app build matrix is running on both compilers

## Stack

Base: #179 shared schema conversion. This is a sibling of #180 response_format so the two endpoint capabilities remain reviewable independently.