### PR TITLE
Prepare Foundation Lab 1.1.0

### DIFF
--- a/FoundationLab.xcodeproj/project.pbxproj
+++ b/FoundationLab.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rudrankriyam.foundationlab${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -446,7 +446,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rudrankriyam.foundationlab${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- bump Foundation Lab's marketing version from 1.0 to 1.1 for the 1.1.0 product release
- keep the independent `afm-vx.y.z` CLI release channel unchanged

## Release shape

- tag and release title: `1.1.0`
- lightweight tag on the exact validated `main` merge commit
- curated release notes following the 1.0.0 release format
- no uploaded assets, matching previous product releases

## Verification

- project file contains `MARKETING_VERSION = 1.1` in both build configurations
- Xcode 26.6 macOS and iOS Simulator builds succeeded; the checked-in app bundles report version 1.1
- Xcode 27 macOS and iOS Simulator builds verify the same release setting before merge
