### PR TITLE
[codex] Build live Spotlight RAG lab

### DIFF
--- a/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
+++ b/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
@@ -73,7 +73,9 @@ final class SpotlightRAGViewModel {
 
     func indexSamples() async {
         guard !isIndexing else { return }
+        cancelRun()
         isIndexing = true
+        hasIndexedSamples = false
         errorMessage = nil
 
         defer { isIndexing = false }

--- a/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
+++ b/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
@@ -168,6 +168,7 @@ private extension SpotlightRAGViewModel {
         }
 
         guard SystemLanguageModel.default.isAvailable else {
+            guard activeRunID == id else { return }
             errorMessage = String(localized: "The on-device system language model is unavailable.")
             return
         }

--- a/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
+++ b/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
@@ -1,0 +1,377 @@
+//
+//  SpotlightRAGViewModel.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4) && arch(arm64)
+import CoreSpotlight
+import Foundation
+import FoundationModels
+import Observation
+import UniformTypeIdentifiers
+import _CoreSpotlight_FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+@Observable
+final class SpotlightRAGViewModel {
+    static let defaultPrompt = "What did I decide about the Kyoto itinerary?"
+    static let domainIdentifier = "com.rudrankriyam.FoundationLab.spotlight-rag"
+
+    var prompt = defaultPrompt
+    var answer = ""
+    var errorMessage: String?
+    var events: [SpotlightRAGSearchEvent] = []
+    var matchedDocuments: [SpotlightRAGDocument] = []
+    var guidance = SpotlightRAGGuidance.dynamic
+    var usesCompactFormat = true
+    var isIndexing = false
+    var isRunning = false
+    var hasIndexedSamples = false
+
+    let sampleDocuments = SpotlightRAGDocument.samples
+
+    private var runTask: Task<Void, Never>?
+    private var activeRunID: UUID?
+
+    var canRun: Bool {
+        hasIndexedSamples
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isIndexing
+            && !isRunning
+    }
+
+    func indexSamples() async {
+        guard !isIndexing else { return }
+        isIndexing = true
+        errorMessage = nil
+
+        defer { isIndexing = false }
+
+        do {
+            let index = CSSearchableIndex.default()
+            try await index.deleteSearchableItems(withDomainIdentifiers: [Self.domainIdentifier])
+            try await index.indexSearchableItems(sampleDocuments.map(Self.searchableItem))
+            hasIndexedSamples = true
+            answer = ""
+            events = []
+            matchedDocuments = []
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func startRun() {
+        guard canRun else { return }
+        cancelRun()
+
+        let prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let runID = UUID()
+        activeRunID = runID
+        isRunning = true
+        answer = ""
+        errorMessage = nil
+        events = []
+        matchedDocuments = []
+
+        runTask = Task { @MainActor [weak self] in
+            await self?.performRun(prompt: prompt, id: runID)
+        }
+    }
+
+    func cancelRun() {
+        activeRunID = nil
+        runTask?.cancel()
+        runTask = nil
+        isRunning = false
+    }
+
+    func reset() {
+        cancelRun()
+        prompt = Self.defaultPrompt
+        answer = ""
+        errorMessage = nil
+        events = []
+        matchedDocuments = []
+        guidance = .dynamic
+        usesCompactFormat = true
+    }
+
+    func clearIndex() async {
+        cancelRun()
+        isIndexing = true
+        errorMessage = nil
+
+        defer { isIndexing = false }
+
+        do {
+            try await CSSearchableIndex.default().deleteSearchableItems(
+                withDomainIdentifiers: [Self.domainIdentifier]
+            )
+            hasIndexedSamples = false
+            answer = ""
+            events = []
+            matchedDocuments = []
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension SpotlightRAGViewModel {
+    func performRun(prompt: String, id: UUID) async {
+        defer {
+            if activeRunID == id {
+                activeRunID = nil
+                runTask = nil
+                isRunning = false
+            }
+        }
+
+        guard SystemLanguageModel.default.isAvailable else {
+            errorMessage = String(localized: "The on-device system language model is unavailable.")
+            return
+        }
+
+        let tool = makeTool()
+        let monitor = Task { @MainActor [weak self] in
+            await self?.monitor(tool: tool, runID: id)
+        }
+        defer { monitor.cancel() }
+
+        do {
+            let session = LanguageModelSession(
+                tools: [tool],
+                instructions: """
+                Answer questions using the app's Spotlight index. Cite the titles of the indexed items you rely on. If the index \
+                doesn't contain enough evidence, say that plainly instead of guessing.
+                """
+            )
+            let response = try await session.respond(to: prompt)
+            try Task.checkCancellation()
+            guard activeRunID == id else { return }
+            answer = response.content
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeRunID == id else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func makeTool() -> SpotlightSearchTool {
+        let attributes: [SearchableItemAttribute] = [
+            .title,
+            .textContent,
+            .contentDescription,
+            .keywords,
+            .contentModificationDate
+        ]
+        var source = CoreSpotlightSource(fetchAttributes: attributes)
+        source.maximumResultCount = 8
+
+        let level: SpotlightSearchTool.GuidanceLevel
+        switch guidance {
+        case .focused:
+            level = .focused(.items)
+        case .dynamic:
+            level = .dynamic(
+                .init(
+                    textMatch: true,
+                    similarityMatch: true,
+                    numericMatch: false,
+                    dates: true,
+                    people: false,
+                    contentType: true,
+                    attributes: attributes
+                )
+            )
+        case .complete:
+            level = .complete
+        }
+
+        let guide = SpotlightSearchTool.Guide(
+            level: level,
+            format: usesCompactFormat ? .compact : .structured
+        )
+        return SpotlightSearchTool(
+            configuration: .init(
+                sources: [.coreSpotlight(source)],
+                guide: guide
+            )
+        )
+    }
+
+    func monitor(tool: SpotlightSearchTool, runID: UUID) async {
+        var queryNumbers: [SpotlightSearchTool.SearchReply.QueryToken: Int] = [:]
+
+        for await reply in tool.searchResults {
+            guard !Task.isCancelled, activeRunID == runID else { return }
+            let queryNumber: Int
+            if let existing = queryNumbers[reply.queryToken] {
+                queryNumber = existing
+            } else {
+                queryNumber = queryNumbers.count + 1
+                queryNumbers[reply.queryToken] = queryNumber
+            }
+
+            let event = makeEvent(from: reply, queryNumber: queryNumber)
+            events.append(event)
+        }
+    }
+
+    func makeEvent(
+        from reply: SpotlightSearchTool.SearchReply,
+        queryNumber: Int
+    ) -> SpotlightRAGSearchEvent {
+        let statusIsComplete = reply.status == .complete
+        let label = reply.label ?? String(localized: "Search stage")
+
+        switch reply.content {
+        case .items(let items):
+            capture(items)
+            return event(queryNumber, label, itemSummary(items), .items, statusIsComplete)
+        case .scoredItems(let scoredItems):
+            return scoredEvent(scoredItems, queryNumber, label, statusIsComplete)
+        case .groupedItems(let groups):
+            return groupedEvent(groups, queryNumber, label, statusIsComplete)
+        case .count(let count):
+            return event(
+                queryNumber,
+                count.header ?? label,
+                String(localized: "\(count.value) results"),
+                .count,
+                statusIsComplete
+            )
+        case .table(let table):
+            return event(
+                queryNumber,
+                table.header ?? label,
+                String(localized: "\(table.rows.count) rows · \(table.columns.count) columns"),
+                .table,
+                statusIsComplete
+            )
+        case .statistic(let statistic):
+            return event(
+                queryNumber,
+                statistic.header ?? label,
+                String(localized: "\(statistic.name): \(statistic.value.formatted())"),
+                .statistic,
+                statusIsComplete
+            )
+        case .text(let text):
+            return event(queryNumber, text.header ?? label, text.body, .text, statusIsComplete)
+        @unknown default:
+            return event(
+                queryNumber,
+                label,
+                String(localized: "A newer Spotlight result type was returned."),
+                .text,
+                statusIsComplete
+            )
+        }
+    }
+
+    func scoredEvent(
+        _ scoredItems: [ScoredSearchableItem],
+        _ queryNumber: Int,
+        _ label: String,
+        _ isComplete: Bool
+    ) -> SpotlightRAGSearchEvent {
+        let items = scoredItems.map(\.item)
+        capture(items)
+        let scoreDetail = scoredItems.map(\.score).max().map {
+            String(localized: "Top score: \($0.formatted(.number.precision(.fractionLength(2))))")
+        }
+        return event(
+            queryNumber,
+            label,
+            [itemSummary(items), scoreDetail].compactMap(\.self).joined(separator: " · "),
+            .scoredItems,
+            isComplete
+        )
+    }
+
+    func groupedEvent(
+        _ groups: [SearchableItemAttribute: [CSSearchableItem]],
+        _ queryNumber: Int,
+        _ label: String,
+        _ isComplete: Bool
+    ) -> SpotlightRAGSearchEvent {
+        let items = groups.values.flatMap(\.self)
+        capture(items)
+        return event(
+            queryNumber,
+            label,
+            String(localized: "\(groups.count) groups · \(items.count) items"),
+            .groupedItems,
+            isComplete
+        )
+    }
+
+    func event(
+        _ queryNumber: Int,
+        _ label: String,
+        _ detail: String,
+        _ kind: SpotlightRAGSearchEvent.Kind,
+        _ isComplete: Bool
+    ) -> SpotlightRAGSearchEvent {
+        SpotlightRAGSearchEvent(
+            queryNumber: queryNumber,
+            label: label,
+            detail: detail,
+            kind: kind,
+            isComplete: isComplete
+        )
+    }
+
+    func capture(_ items: [CSSearchableItem]) {
+        let existingIDs = Set(matchedDocuments.map(\.id))
+        let additions = items.compactMap(Self.document).filter { !existingIDs.contains($0.id) }
+        matchedDocuments.append(contentsOf: additions)
+    }
+
+    func itemSummary(_ items: [CSSearchableItem]) -> String {
+        let titles = items.compactMap(\.attributeSet.title)
+        guard !titles.isEmpty else { return String(localized: "\(items.count) items") }
+        return titles.joined(separator: ", ")
+    }
+
+    static func searchableItem(for document: SpotlightRAGDocument) -> CSSearchableItem {
+        let attributes = CSSearchableItemAttributeSet(contentType: .text)
+        attributes.title = document.title
+        attributes.textContent = document.body
+        attributes.contentDescription = document.body
+        attributes.keywords = document.keywords
+        attributes.contentModificationDate = document.modifiedAt
+        attributes.userCreated = true
+        attributes.userOwned = true
+
+        return CSSearchableItem(
+            uniqueIdentifier: document.id,
+            domainIdentifier: domainIdentifier,
+            attributeSet: attributes
+        )
+    }
+
+    static func document(from item: CSSearchableItem) -> SpotlightRAGDocument? {
+        guard let title = item.attributeSet.title else { return nil }
+        return SpotlightRAGDocument(
+            id: item.uniqueIdentifier,
+            title: title,
+            body: item.attributeSet.textContent ?? item.attributeSet.contentDescription ?? "",
+            keywords: item.attributeSet.keywords ?? [],
+            modifiedAt: item.attributeSet.contentModificationDate ?? .distantPast
+        )
+    }
+}
+#endif

--- a/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
+++ b/Foundation Lab/ViewModels/SpotlightRAGViewModel.swift
@@ -14,6 +14,34 @@ import _CoreSpotlight_FoundationModels
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+extension SessionPropertyValues {
+    @SessionPropertyEntry
+    var spotlightRAGToolCallCount = 0
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private struct SpotlightRAGProfile: LanguageModelSession.DynamicProfile {
+    let tool: SpotlightSearchTool
+
+    @SessionProperty(\.spotlightRAGToolCallCount)
+    private var toolCallCount
+
+    var body: some LanguageModelSession.DynamicProfile {
+        LanguageModelSession.Profile {
+            tool
+        }
+        .toolCallingMode(toolCallCount == 0 ? .required : .allowed)
+        .onToolCall {
+            toolCallCount += 1
+        }
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
 @MainActor
 @Observable
 final class SpotlightRAGViewModel {
@@ -25,7 +53,7 @@ final class SpotlightRAGViewModel {
     var errorMessage: String?
     var events: [SpotlightRAGSearchEvent] = []
     var matchedDocuments: [SpotlightRAGDocument] = []
-    var guidance = SpotlightRAGGuidance.dynamic
+    var guidance = SpotlightRAGGuidance.focused
     var usesCompactFormat = true
     var isIndexing = false
     var isRunning = false
@@ -97,7 +125,7 @@ final class SpotlightRAGViewModel {
         errorMessage = nil
         events = []
         matchedDocuments = []
-        guidance = .dynamic
+        guidance = .focused
         usesCompactFormat = true
     }
 
@@ -149,14 +177,14 @@ private extension SpotlightRAGViewModel {
         defer { monitor.cancel() }
 
         do {
-            let session = LanguageModelSession(
-                tools: [tool],
-                instructions: """
-                Answer questions using the app's Spotlight index. Cite the titles of the indexed items you rely on. If the index \
-                doesn't contain enough evidence, say that plainly instead of guessing.
-                """
-            )
-            let response = try await session.respond(to: prompt)
+            let session = LanguageModelSession(profile: SpotlightRAGProfile(tool: tool))
+            let groundedPrompt = """
+            Search the app's Spotlight index before answering. Cite the titles of the indexed items you rely on. If the index \
+            doesn't contain enough evidence, say that plainly instead of guessing.
+
+            Question: \(prompt)
+            """
+            let response = try await session.respond(to: groundedPrompt)
             try Task.checkCancellation()
             guard activeRunID == id else { return }
             answer = response.content

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGConfigurationSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGConfigurationSection.swift
@@ -12,8 +12,10 @@ import SwiftUI
 struct SpotlightRAGConfigurationSection: View {
     @Bindable var model: SpotlightRAGViewModel
 
+    @State private var showsSettings = false
+
     var body: some View {
-        Xcode27Section(String(localized: "Tool Configuration")) {
+        DisclosureGroup(isExpanded: $showsSettings) {
             VStack(alignment: .leading, spacing: Spacing.medium) {
                 Picker("Search guidance", selection: $model.guidance) {
                     ForEach(SpotlightRAGGuidance.allCases) { guidance in
@@ -24,18 +26,23 @@ struct SpotlightRAGConfigurationSection: View {
 
                 Toggle("Use compact result formatting", isOn: $model.usesCompactFormat)
 
-                Text(
-                    """
-                    Dynamic guidance enables text, semantic, date, and content-type search while excluding irrelevant people and \
-                    numeric operators. Compact formatting preserves more of the model's context window.
-                    """
-                )
-                    .font(.callout)
+                Text(model.guidance.explanation)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .disabled(model.isRunning)
+            .padding(.top, Spacing.small)
+        } label: {
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text("Search Settings")
+                    .font(.headline)
+                Text("\(model.guidance.title) guidance · \(model.usesCompactFormat ? "Compact" : "Structured") output")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
+        .padding(.vertical, Spacing.small)
     }
 }
 #endif

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGConfigurationSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGConfigurationSection.swift
@@ -1,0 +1,41 @@
+//
+//  SpotlightRAGConfigurationSection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4) && arch(arm64)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct SpotlightRAGConfigurationSection: View {
+    @Bindable var model: SpotlightRAGViewModel
+
+    var body: some View {
+        Xcode27Section(String(localized: "Tool Configuration")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                Picker("Search guidance", selection: $model.guidance) {
+                    ForEach(SpotlightRAGGuidance.allCases) { guidance in
+                        Text(guidance.title).tag(guidance)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Toggle("Use compact result formatting", isOn: $model.usesCompactFormat)
+
+                Text(
+                    """
+                    Dynamic guidance enables text, semantic, date, and content-type search while excluding irrelevant people and \
+                    numeric operators. Compact formatting preserves more of the model's context window.
+                    """
+                )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .disabled(model.isRunning)
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGDocument.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGDocument.swift
@@ -1,0 +1,45 @@
+//
+//  SpotlightRAGDocument.swift
+//  FoundationLab
+//
+
+import Foundation
+
+struct SpotlightRAGDocument: Identifiable, Sendable {
+    let id: String
+    let title: String
+    let body: String
+    let keywords: [String]
+    let modifiedAt: Date
+
+    static let samples = [
+        SpotlightRAGDocument(
+            id: "kyoto-itinerary",
+            title: "Kyoto itinerary",
+            body: "Book dinner in Gion for Friday. Visit Fushimi Inari before 7 AM on Saturday to avoid the crowds.",
+            keywords: ["Kyoto", "Gion", "Fushimi Inari", "travel"],
+            modifiedAt: Date(timeIntervalSince1970: 1_772_323_200)
+        ),
+        SpotlightRAGDocument(
+            id: "foundation-lab-release",
+            title: "Foundation Lab release checklist",
+            body: "Run SwiftLint, Swift package tests, and both macOS and iOS Simulator builds before opening the pull request.",
+            keywords: ["Foundation Lab", "release", "testing"],
+            modifiedAt: Date(timeIntervalSince1970: 1_781_740_800)
+        ),
+        SpotlightRAGDocument(
+            id: "hike-notes",
+            title: "Monsoon hike notes",
+            body: "The lakeside route was quiet after the rain. Pack a shell and use the eastern trail when the lower path is muddy.",
+            keywords: ["hike", "water", "rain", "trail"],
+            modifiedAt: Date(timeIntervalSince1970: 1_775_088_000)
+        ),
+        SpotlightRAGDocument(
+            id: "design-review",
+            title: "Developer tool design review",
+            body: "Keep the interface quiet and evidence-led. Show retrieved sources separately from the generated answer.",
+            keywords: ["design", "developer tools", "retrieval", "sources"],
+            modifiedAt: Date(timeIntervalSince1970: 1_779_235_200)
+        )
+    ]
+}

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGExplorerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGExplorerView.swift
@@ -8,213 +8,24 @@
 import SwiftUI
 
 struct SpotlightRAGExplorerView: View {
-    @State private var selectedStage = SpotlightRAGStage.index
-
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.large) {
-                Label {
-                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                        Text("Architecture walkthrough")
-                            .bold()
-                        Text(
-                            String(
-                                localized: """
-                                This screen does not query Spotlight or a language model. It explains how SpotlightSearchTool grounds \
-                                a real session in content your app has indexed.
-                                """
-                            )
-                        )
-                            .foregroundStyle(.secondary)
-                    }
-                } icon: {
-                    Image(systemName: "book.pages")
-                        .foregroundStyle(.blue)
-                }
-                .font(.callout)
-                .padding(Spacing.medium)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.blue.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
-
-                Xcode27Section(String(localized: "Example Question")) {
-                    Text("“What did I decide about the Kyoto itinerary?”")
-                        .font(.callout)
-                        .textSelection(.enabled)
-                }
-
-                Xcode27Section(String(localized: "Pipeline")) {
-                    VStack(spacing: 0) {
-                        ForEach(SpotlightRAGStage.allCases) { stage in
-                            Button {
-                                select(stage)
-                            } label: {
-                                HStack {
-                                    Xcode27InfoRow(
-                                        title: stage.title,
-                                        detail: stage.detail,
-                                        systemImage: stage.icon,
-                                        tint: stage == selectedStage ? .blue : .secondary
-                                    )
-
-                                    if stage == selectedStage {
-                                        Image(systemName: "checkmark")
-                                            .foregroundStyle(.blue)
-                                            .accessibilityHidden(true)
-                                    }
-                                }
-                                .frame(minHeight: 44)
-                                .contentShape(.rect)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityAddTraits(stage == selectedStage ? .isSelected : [])
-
-                            if stage != SpotlightRAGStage.allCases.last {
-                                Divider()
-                            }
-                        }
-                    }
-                }
-
-                Xcode27Section(selectedStage.title) {
-                    VStack(alignment: .leading, spacing: Spacing.medium) {
-                        Text(selectedStage.explanation)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-
-                        Button("Inspect Next Stage", systemImage: "arrow.down", action: nextStage)
-                            .buttonStyle(.glassProminent)
-                    }
-                }
-
-                CodeDisclosure(code: selectedStage.code)
-            }
-            .padding(.horizontal, Spacing.medium)
-            .padding(.vertical, Spacing.large)
+        #if compiler(>=6.4) && arch(arm64)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            SpotlightRAGLiveView()
+        } else {
+            SpotlightRAGUnavailableView(
+                message: String(localized: "The live Spotlight RAG lab requires an OS 27 runtime.")
+            )
         }
-        .navigationTitle("Spotlight RAG")
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.large)
-        .navigationSubtitle("Ground a session in your app's indexed content")
+        #elseif compiler(>=6.4)
+        SpotlightRAGUnavailableView(
+            message: String(localized: "The live Spotlight RAG lab requires Apple silicon.")
+        )
+        #else
+        SpotlightRAGUnavailableView(
+            message: String(localized: "The live Spotlight RAG lab requires the Xcode 27 SDK.")
+        )
         #endif
-    }
-
-    private func nextStage() {
-        let cases = SpotlightRAGStage.allCases
-        guard let index = cases.firstIndex(of: selectedStage) else { return }
-        selectedStage = cases[(index + 1) % cases.count]
-    }
-
-    private func select(_ stage: SpotlightRAGStage) {
-        selectedStage = stage
-    }
-}
-
-private enum SpotlightRAGStage: String, CaseIterable, Identifiable {
-    case index
-    case tool
-    case prompt
-    case evaluate
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .index: return String(localized: "Index Content")
-        case .tool: return String(localized: "Add Search Tool")
-        case .prompt: return String(localized: "Prompt Session")
-        case .evaluate: return String(localized: "Evaluate")
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .index: return String(localized: "Maintain a Core Spotlight index for your app's content.")
-        case .tool: return String(localized: "Make that index available to LanguageModelSession.")
-        case .prompt: return String(localized: "Ask a question that requires indexed knowledge.")
-        case .evaluate: return String(localized: "Test retrieval relevance and answer quality.")
-        }
-    }
-
-    var explanation: String {
-        switch self {
-        case .index:
-            return String(
-                localized: """
-                SpotlightSearchTool searches content already indexed by your app. Index useful metadata and keep the index \
-                synchronized as content changes.
-                """
-            )
-        case .tool:
-            return String(
-                localized: """
-                Add SpotlightSearchTool to the tools passed to LanguageModelSession. The model can then search the local index when a \
-                prompt requires app-specific knowledge.
-                """
-            )
-        case .prompt:
-            return String(
-                localized: """
-                Call respond on the session as usual. Tool calling lets the model retrieve relevant indexed content and use it as \
-                additional context for the answer.
-                """
-            )
-        case .evaluate:
-            return String(
-                localized: """
-                Use representative questions and verify retrieval relevance, honest handling of missing evidence, and answers that \
-                stay grounded in the index.
-                """
-            )
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .index: return "square.stack.3d.up"
-        case .tool: return "wrench.and.screwdriver"
-        case .prompt: return "text.bubble"
-        case .evaluate: return "checklist.checked"
-        }
-    }
-
-    var code: String {
-        switch self {
-        case .index:
-            return """
-            import CoreSpotlight
-            import UniformTypeIdentifiers
-
-            let attributes = CSSearchableItemAttributeSet(contentType: .text)
-            attributes.title = "Kyoto itinerary"
-            attributes.contentDescription = "Dinner in Gion on Friday."
-
-            let item = CSSearchableItem(
-                uniqueIdentifier: "trip.kyoto",
-                domainIdentifier: "travel",
-                attributeSet: attributes
-            )
-            try await CSSearchableIndex.default().indexSearchableItems([item])
-            """
-        case .tool, .prompt:
-            return """
-            import CoreSpotlight
-            import FoundationModels
-
-            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
-                let tool = SpotlightSearchTool()
-                let session = LanguageModelSession(tools: [tool])
-                let response = try await session.respond(
-                    to: "What did I decide about the Kyoto itinerary?"
-                )
-            }
-            """
-        case .evaluate:
-            return """
-            // Exercise questions with relevant, missing, and ambiguous evidence.
-            // Inspect retrieval and final-answer quality with Instruments
-            // and your evaluation suite.
-            """
-        }
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGGuidance.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGGuidance.swift
@@ -1,0 +1,22 @@
+//
+//  SpotlightRAGGuidance.swift
+//  FoundationLab
+//
+
+import Foundation
+
+enum SpotlightRAGGuidance: String, CaseIterable, Identifiable, Sendable {
+    case focused
+    case dynamic
+    case complete
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .focused: String(localized: "Focused")
+        case .dynamic: String(localized: "Dynamic")
+        case .complete: String(localized: "Complete")
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGGuidance.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGGuidance.swift
@@ -19,4 +19,15 @@ enum SpotlightRAGGuidance: String, CaseIterable, Identifiable, Sendable {
         case .complete: String(localized: "Complete")
         }
     }
+
+    var explanation: String {
+        switch self {
+        case .focused:
+            String(localized: "Focused guidance asks Spotlight for the most relevant matching items.")
+        case .dynamic:
+            String(localized: "Dynamic guidance lets the model combine keyword, semantic, date, and content-type queries.")
+        case .complete:
+            String(localized: "Complete guidance exposes the full Spotlight query surface to the model.")
+        }
+    }
 }

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGIndexSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGIndexSection.swift
@@ -12,50 +12,62 @@ import SwiftUI
 struct SpotlightRAGIndexSection: View {
     let model: SpotlightRAGViewModel
 
+    @State private var showsSamples = false
+
     var body: some View {
         Xcode27Section(String(localized: "Local Spotlight Index")) {
             VStack(alignment: .leading, spacing: Spacing.medium) {
-                ForEach(model.sampleDocuments) { document in
-                    Label {
-                        VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                            Text(document.title)
-                                .bold()
-                            Text(document.body)
-                                .font(.callout)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
+                if model.isIndexing {
+                    ProgressView("Indexing four sample notes…")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else if model.hasIndexedSamples {
+                    HStack(spacing: Spacing.small) {
+                        Label("Four sample notes are ready", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+
+                        Spacer()
+
+                        Menu("Index actions", systemImage: "ellipsis.circle") {
+                            Button("Reindex Samples", systemImage: "arrow.clockwise", action: indexSamples)
+                            Button("Clear Index", systemImage: "trash", role: .destructive, action: clearIndex)
                         }
-                    } icon: {
-                        Image(systemName: "doc.text")
-                            .foregroundStyle(.blue)
+                        .labelStyle(.iconOnly)
+                        .frame(minWidth: 44, minHeight: 44)
                     }
-
-                    if document.id != model.sampleDocuments.last?.id {
-                        Divider()
-                    }
-                }
-
-                HStack(spacing: Spacing.small) {
-                    Button("Clear Index", systemImage: "trash", action: clearIndex)
-                        .buttonStyle(.glass)
-                        .disabled(model.isIndexing || !model.hasIndexedSamples)
-
+                } else {
                     Button(
-                        model.hasIndexedSamples ? "Reindex Samples" : "Index Samples",
+                        "Index Four Sample Notes",
                         systemImage: "square.stack.3d.up.badge.a",
                         action: indexSamples
                     )
                     .buttonStyle(.glassProminent)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
                     .disabled(model.isIndexing || model.isRunning)
                 }
-                .controlSize(.large)
 
-                Label(
-                    model.hasIndexedSamples ? "Sample index is ready" : "Index the samples before asking a question",
-                    systemImage: model.hasIndexedSamples ? "checkmark.circle.fill" : "circle.dashed"
-                )
+                DisclosureGroup(isExpanded: $showsSamples) {
+                    VStack(alignment: .leading, spacing: Spacing.small) {
+                        ForEach(model.sampleDocuments) { document in
+                            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                                Text(document.title)
+                                    .bold()
+                                Text(document.body)
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if document.id != model.sampleDocuments.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                    .padding(.top, Spacing.small)
+                } label: {
+                    Text("Preview sample notes")
+                        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                }
                 .font(.callout)
-                .foregroundStyle(model.hasIndexedSamples ? .green : .secondary)
             }
         }
     }

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGIndexSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGIndexSection.swift
@@ -1,0 +1,71 @@
+//
+//  SpotlightRAGIndexSection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4) && arch(arm64)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct SpotlightRAGIndexSection: View {
+    let model: SpotlightRAGViewModel
+
+    var body: some View {
+        Xcode27Section(String(localized: "Local Spotlight Index")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                ForEach(model.sampleDocuments) { document in
+                    Label {
+                        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                            Text(document.title)
+                                .bold()
+                            Text(document.body)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    } icon: {
+                        Image(systemName: "doc.text")
+                            .foregroundStyle(.blue)
+                    }
+
+                    if document.id != model.sampleDocuments.last?.id {
+                        Divider()
+                    }
+                }
+
+                HStack(spacing: Spacing.small) {
+                    Button("Clear Index", systemImage: "trash", action: clearIndex)
+                        .buttonStyle(.glass)
+                        .disabled(model.isIndexing || !model.hasIndexedSamples)
+
+                    Button(
+                        model.hasIndexedSamples ? "Reindex Samples" : "Index Samples",
+                        systemImage: "square.stack.3d.up.badge.a",
+                        action: indexSamples
+                    )
+                    .buttonStyle(.glassProminent)
+                    .disabled(model.isIndexing || model.isRunning)
+                }
+                .controlSize(.large)
+
+                Label(
+                    model.hasIndexedSamples ? "Sample index is ready" : "Index the samples before asking a question",
+                    systemImage: model.hasIndexedSamples ? "checkmark.circle.fill" : "circle.dashed"
+                )
+                .font(.callout)
+                .foregroundStyle(model.hasIndexedSamples ? .green : .secondary)
+            }
+        }
+    }
+
+    private func indexSamples() {
+        Task { await model.indexSamples() }
+    }
+
+    private func clearIndex() {
+        Task { await model.clearIndex() }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGLiveView.swift
@@ -16,27 +16,14 @@ struct SpotlightRAGLiveView: View {
         @Bindable var model = model
 
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: Spacing.large) {
-                Label {
-                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                        Text("Live retrieval experiment")
-                            .bold()
-                        Text(
-                            """
-                            Index local sample notes, inspect every Spotlight search stage, and compare the evidence with the \
-                            model's answer.
-                            """
-                        )
-                            .foregroundStyle(.secondary)
-                    }
-                } icon: {
-                    Image(systemName: "sparkle.magnifyingglass")
-                        .foregroundStyle(.blue)
+            LazyVStack(alignment: .leading, spacing: Spacing.xLarge) {
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Ask your Spotlight index")
+                        .font(.title2.bold())
+                    Text("Index four notes, ask one question, then inspect the evidence behind the answer.")
+                        .foregroundStyle(.secondary)
                 }
-                .font(.callout)
-                .padding(Spacing.medium)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.blue.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
 
                 SpotlightRAGIndexSection(model: model)
                 SpotlightRAGConfigurationSection(model: model)
@@ -48,30 +35,31 @@ struct SpotlightRAGLiveView: View {
                             .textFieldStyle(.roundedBorder)
                             .accessibilityHint("The model searches only the sample notes indexed by this lab")
 
-                        PromptSuggestions(
-                            suggestions: [
-                                String(localized: "What did I decide about Kyoto?"),
-                                String(localized: "How should I validate a Foundation Lab release?"),
-                                String(localized: "Which hike advice mentions rain?"),
-                                String(localized: "What does the index not know about Tokyo?")
-                            ],
-                            onSelect: selectPrompt
-                        )
+                        HStack {
+                            Menu("Example Questions", systemImage: "text.bubble") {
+                                ForEach(examplePrompts, id: \.self) { prompt in
+                                    Button(prompt) { selectPrompt(prompt) }
+                                }
+                            }
+                            .padding(.vertical, Spacing.medium)
+                            .contentShape(.rect)
 
-                        HStack(spacing: Spacing.small) {
+                            Spacer()
+
                             Button("Reset", systemImage: "arrow.counterclockwise", action: model.reset)
-                                .buttonStyle(.glass)
-                                .frame(maxWidth: .infinity)
-
-                            Button(
-                                model.isRunning ? "Stop" : "Search and Answer",
-                                systemImage: model.isRunning ? "stop.fill" : "sparkle.magnifyingglass",
-                                action: toggleRun
-                            )
-                            .buttonStyle(.glassProminent)
-                            .frame(maxWidth: .infinity)
-                            .disabled(!model.isRunning && !model.canRun)
+                                .buttonStyle(.borderless)
+                                .padding(.vertical, Spacing.medium)
+                                .contentShape(.rect)
                         }
+
+                        Button(
+                            model.isRunning ? "Stop" : "Search Spotlight and Answer",
+                            systemImage: model.isRunning ? "stop.fill" : "sparkle.magnifyingglass",
+                            action: toggleRun
+                        )
+                        .buttonStyle(.glassProminent)
+                        .frame(maxWidth: .infinity)
+                        .disabled(!model.isRunning && !model.canRun)
                         .controlSize(.large)
                     }
                 }
@@ -102,7 +90,9 @@ struct SpotlightRAGLiveView: View {
         .navigationSubtitle("Ground answers in your app's indexed content")
         #endif
         .onDisappear(perform: model.cancelRun)
-        .sensoryFeedback(.success, trigger: model.hasIndexedSamples)
+        .sensoryFeedback(.success, trigger: model.hasIndexedSamples) { _, isReady in
+            isReady
+        }
     }
 
     private func selectPrompt(_ prompt: String) {
@@ -117,6 +107,15 @@ struct SpotlightRAGLiveView: View {
         }
     }
 
+    private var examplePrompts: [String] {
+        [
+            String(localized: "What did I decide about Kyoto?"),
+            String(localized: "How should I validate a Foundation Lab release?"),
+            String(localized: "Which hike advice mentions rain?"),
+            String(localized: "What does the index not know about Tokyo?")
+        ]
+    }
+
     private var codeExample: String {
         """
         import CoreSpotlight
@@ -127,11 +126,7 @@ struct SpotlightRAGLiveView: View {
         ]
         let source = CoreSpotlightSource(fetchAttributes: attributes)
         let guide = SpotlightSearchTool.Guide(
-            level: .dynamic(.init(
-                textMatch: true,
-                similarityMatch: true,
-                attributes: attributes
-            )),
+            level: .focused(.items),
             format: .compact
         )
         let tool = SpotlightSearchTool(configuration: .init(
@@ -145,7 +140,8 @@ struct SpotlightRAGLiveView: View {
             }
         }
 
-        let session = LanguageModelSession(tools: [tool])
+        // Require retrieval once, then switch to allowed so the model can answer.
+        let session = LanguageModelSession(profile: SpotlightRAGProfile(tool: tool))
         let response = try await session.respond(to: prompt)
         """
     }

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGLiveView.swift
@@ -1,0 +1,153 @@
+//
+//  SpotlightRAGLiveView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4) && arch(arm64)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct SpotlightRAGLiveView: View {
+    @State private var model = SpotlightRAGViewModel()
+
+    var body: some View {
+        @Bindable var model = model
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.large) {
+                Label {
+                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                        Text("Live retrieval experiment")
+                            .bold()
+                        Text(
+                            """
+                            Index local sample notes, inspect every Spotlight search stage, and compare the evidence with the \
+                            model's answer.
+                            """
+                        )
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "sparkle.magnifyingglass")
+                        .foregroundStyle(.blue)
+                }
+                .font(.callout)
+                .padding(Spacing.medium)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.blue.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+
+                SpotlightRAGIndexSection(model: model)
+                SpotlightRAGConfigurationSection(model: model)
+
+                Xcode27Section(String(localized: "Ask the Index")) {
+                    VStack(alignment: .leading, spacing: Spacing.medium) {
+                        TextField("Ask about the indexed notes", text: $model.prompt, axis: .vertical)
+                            .lineLimit(3...6)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityHint("The model searches only the sample notes indexed by this lab")
+
+                        PromptSuggestions(
+                            suggestions: [
+                                String(localized: "What did I decide about Kyoto?"),
+                                String(localized: "How should I validate a Foundation Lab release?"),
+                                String(localized: "Which hike advice mentions rain?"),
+                                String(localized: "What does the index not know about Tokyo?")
+                            ],
+                            onSelect: selectPrompt
+                        )
+
+                        HStack(spacing: Spacing.small) {
+                            Button("Reset", systemImage: "arrow.counterclockwise", action: model.reset)
+                                .buttonStyle(.glass)
+                                .frame(maxWidth: .infinity)
+
+                            Button(
+                                model.isRunning ? "Stop" : "Search and Answer",
+                                systemImage: model.isRunning ? "stop.fill" : "sparkle.magnifyingglass",
+                                action: toggleRun
+                            )
+                            .buttonStyle(.glassProminent)
+                            .frame(maxWidth: .infinity)
+                            .disabled(!model.isRunning && !model.canRun)
+                        }
+                        .controlSize(.large)
+                    }
+                }
+
+                if let errorMessage = model.errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .padding(Spacing.medium)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.red.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+                }
+
+                SpotlightRAGResultsSection(model: model)
+                CodeDisclosure(code: codeExample)
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+            .frame(maxWidth: .infinity)
+        }
+        #if os(iOS)
+        .scrollDismissesKeyboard(.interactively)
+        #endif
+        .navigationTitle("Spotlight RAG")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Ground answers in your app's indexed content")
+        #endif
+        .onDisappear(perform: model.cancelRun)
+        .sensoryFeedback(.success, trigger: model.hasIndexedSamples)
+    }
+
+    private func selectPrompt(_ prompt: String) {
+        model.prompt = prompt
+    }
+
+    private func toggleRun() {
+        if model.isRunning {
+            model.cancelRun()
+        } else {
+            model.startRun()
+        }
+    }
+
+    private var codeExample: String {
+        """
+        import CoreSpotlight
+        import FoundationModels
+
+        let attributes: [SearchableItemAttribute] = [
+            .title, .textContent, .contentDescription, .keywords
+        ]
+        let source = CoreSpotlightSource(fetchAttributes: attributes)
+        let guide = SpotlightSearchTool.Guide(
+            level: .dynamic(.init(
+                textMatch: true,
+                similarityMatch: true,
+                attributes: attributes
+            )),
+            format: .compact
+        )
+        let tool = SpotlightSearchTool(configuration: .init(
+            sources: [.coreSpotlight(source)],
+            guide: guide
+        ))
+
+        Task {
+            for await reply in tool.searchResults {
+                inspect(reply.content)
+            }
+        }
+
+        let session = LanguageModelSession(tools: [tool])
+        let response = try await session.respond(to: prompt)
+        """
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGResultsSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGResultsSection.swift
@@ -1,0 +1,100 @@
+//
+//  SpotlightRAGResultsSection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4) && arch(arm64)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct SpotlightRAGResultsSection: View {
+    let model: SpotlightRAGViewModel
+
+    var body: some View {
+        Xcode27Section(String(localized: "Retrieval Trajectory")) {
+            if model.events.isEmpty {
+                ContentUnavailableView {
+                    Label("No Search Events", systemImage: "point.3.connected.trianglepath.dotted")
+                } description: {
+                    Text("Run a grounded question to watch the model build and execute Spotlight search stages.")
+                }
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(model.events) { event in
+                        Label {
+                            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                                HStack {
+                                    Text("Query \(event.queryNumber): \(event.label)")
+                                        .bold()
+                                    Spacer()
+                                    Text(event.isComplete ? "Complete" : "Partial")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(event.detail)
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                        } icon: {
+                            Image(systemName: event.kind.systemImage)
+                                .foregroundStyle(event.isComplete ? .green : .blue)
+                        }
+                        .padding(.vertical, Spacing.small)
+
+                        if event.id != model.events.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+
+        Xcode27Section(String(localized: "Retrieved Evidence")) {
+            if model.matchedDocuments.isEmpty {
+                ContentUnavailableView {
+                    Label("No Evidence Retrieved", systemImage: "doc.text.magnifyingglass")
+                } description: {
+                    Text("Matched items appear here separately from the generated answer.")
+                }
+            } else {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
+                    ForEach(model.matchedDocuments) { document in
+                        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                            Text(document.title)
+                                .bold()
+                            Text(document.body)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                            Text(document.modifiedAt, format: .dateTime.day().month().year())
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        if document.id != model.matchedDocuments.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+
+        Xcode27Section(String(localized: "Grounded Answer")) {
+            if model.answer.isEmpty {
+                ContentUnavailableView {
+                    Label("No Answer Yet", systemImage: "text.bubble")
+                } description: {
+                    Text("The final model response appears here after retrieval completes.")
+                }
+            } else {
+                Text(model.answer)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGResultsSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGResultsSection.swift
@@ -13,14 +13,13 @@ struct SpotlightRAGResultsSection: View {
     let model: SpotlightRAGViewModel
 
     var body: some View {
-        Xcode27Section(String(localized: "Retrieval Trajectory")) {
-            if model.events.isEmpty {
-                ContentUnavailableView {
-                    Label("No Search Events", systemImage: "point.3.connected.trianglepath.dotted")
-                } description: {
-                    Text("Run a grounded question to watch the model build and execute Spotlight search stages.")
-                }
-            } else {
+        if model.isRunning && model.events.isEmpty {
+            ProgressView("Searching Spotlight…")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        if !model.events.isEmpty {
+            Xcode27Section(String(localized: "Retrieval Trajectory")) {
                 VStack(spacing: 0) {
                     ForEach(model.events) { event in
                         Label {
@@ -52,14 +51,8 @@ struct SpotlightRAGResultsSection: View {
             }
         }
 
-        Xcode27Section(String(localized: "Retrieved Evidence")) {
-            if model.matchedDocuments.isEmpty {
-                ContentUnavailableView {
-                    Label("No Evidence Retrieved", systemImage: "doc.text.magnifyingglass")
-                } description: {
-                    Text("Matched items appear here separately from the generated answer.")
-                }
-            } else {
+        if !model.matchedDocuments.isEmpty {
+            Xcode27Section(String(localized: "Retrieved Evidence")) {
                 VStack(alignment: .leading, spacing: Spacing.medium) {
                     ForEach(model.matchedDocuments) { document in
                         VStack(alignment: .leading, spacing: Spacing.xSmall) {
@@ -82,19 +75,17 @@ struct SpotlightRAGResultsSection: View {
             }
         }
 
-        Xcode27Section(String(localized: "Grounded Answer")) {
-            if model.answer.isEmpty {
-                ContentUnavailableView {
-                    Label("No Answer Yet", systemImage: "text.bubble")
-                } description: {
-                    Text("The final model response appears here after retrieval completes.")
-                }
-            } else {
-                Text(model.answer)
+        if !model.answer.isEmpty {
+            Xcode27Section(String(localized: "Grounded Answer")) {
+                Text(formattedAnswer)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .textSelection(.enabled)
             }
         }
+    }
+
+    private var formattedAnswer: AttributedString {
+        (try? AttributedString(markdown: model.answer)) ?? AttributedString(model.answer)
     }
 }
 #endif

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGSearchEvent.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGSearchEvent.swift
@@ -1,0 +1,36 @@
+//
+//  SpotlightRAGSearchEvent.swift
+//  FoundationLab
+//
+
+import Foundation
+
+struct SpotlightRAGSearchEvent: Identifiable, Sendable {
+    enum Kind: String, Sendable {
+        case items
+        case scoredItems
+        case groupedItems
+        case count
+        case table
+        case statistic
+        case text
+
+        var systemImage: String {
+            switch self {
+            case .items, .scoredItems: "doc.text.magnifyingglass"
+            case .groupedItems: "square.stack.3d.up"
+            case .count: "number"
+            case .table: "tablecells"
+            case .statistic: "chart.bar"
+            case .text: "text.quote"
+            }
+        }
+    }
+
+    let id = UUID()
+    let queryNumber: Int
+    let label: String
+    let detail: String
+    let kind: Kind
+    let isComplete: Bool
+}

--- a/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGUnavailableView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SpotlightRAGUnavailableView.swift
@@ -1,0 +1,19 @@
+//
+//  SpotlightRAGUnavailableView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct SpotlightRAGUnavailableView: View {
+    let message: String
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Spotlight RAG Unavailable", systemImage: "magnifyingglass.circle")
+        } description: {
+            Text(message)
+        }
+        .navigationTitle("Spotlight RAG")
+    }
+}


### PR DESCRIPTION
## Summary

- replace the static Spotlight RAG walkthrough with a runnable Core Spotlight + Foundation Models experiment
- distill the primary flow to index four notes, ask one question, and inspect retrieval evidence
- keep sample previews, search guidance, result formatting, reindexing, and clearing behind progressive disclosure
- expose real search stages, retrieved items, and the Markdown-rendered grounded answer separately
- require one Spotlight tool call before allowing the model to answer, with focused item retrieval as the reliable default
- add cancellation, loading, model/index/error states, source disclosure, and truthful fallbacks for unsupported SDKs, OS versions, and Intel builds

## Implementation notes

- The Xcode 27 Beta 2 SDK exposes `SpotlightSearchTool` only in Apple-silicon framework interfaces, so the live surface is compiled for `arch(arm64)`; Intel builds receive an explicit availability view.
- The sample index is isolated under `com.rudrankriyam.FoundationLab.spotlight-rag` and can be removed from the lab.
- The required-tool dynamic profile switches to `.allowed` after the first call so the model can complete its answer.

## Impeccable interaction audit

The first runtime pass caught issues that compile tests did not:

- the original surface showed four source rows, configuration, prompt chips, and three empty result panels at once
- prompt chips exposed 33-point accessibility frames
- instructions alone did not make the model call Spotlight
- dynamic guidance returned an unsupported query / zero items for the default question in Beta 2

The revised flow uses progressive disclosure, 44-point controls, a single primary action, conditional result sections, required-once tool calling, and focused item guidance. The final end-to-end run retrieved **Kyoto itinerary**, displayed it as evidence, and grounded the answer in that item.

Audit score after fixes: **19/20**. No AI-pattern or theming findings; remaining minor debt is localization coverage for the newly added strings.

## Validation

- `swiftlint lint --strict --config .swiftlint.yml`
- `swift test`
- Xcode 27 Beta 2 (`27A5209h`): macOS generic build
- Xcode 27 Beta 2 (`27A5209h`): iOS Simulator generic build
- Xcode 27 Beta 2 runtime (`24A5370g`): fresh-device install and launch
- accessibility-tree audit of controls and touch frames
- end-to-end runtime flow: index → forced Spotlight search → retrieved evidence → grounded answer
- Xcode 26.6 RC 2: macOS generic build
- Xcode 26.6 RC 2: iOS Simulator generic build

Beta 2 emits an existing deprecation warning in `GeminiDeveloperVideoLanguageModel.swift`; both builds complete successfully.