### PR TITLE
[codex] Fix Xcode 27 beta 2 test compilation

### DIFF
--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabModelErrorProjectionModernTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabModelErrorProjectionModernTests.swift
@@ -54,7 +54,11 @@ final class FoundationLabModelErrorProjectionModernTests: XCTestCase {
             .init(debugDescription: "Modern guardrail", metadata: ["policy": "safety"])
         )
         let refusal = FoundationModels.LanguageModelError.refusal(
-            .init(debugDescription: "Modern refusal", metadata: ["reason": "policy"])
+            .init(
+                explanation: "The request could not be completed.",
+                debugDescription: "Modern refusal",
+                metadata: ["reason": "policy"]
+            )
         )
         let unsupportedCapability = FoundationModels.LanguageModelError.unsupportedCapability(
             .init(


### PR DESCRIPTION
## Summary
- update the modern refusal fixture for the Xcode 27 beta 2 `explanation` requirement
- keep the stable error-projection assertion unchanged

## Validation
- `swiftlint lint --strict --config .swiftlint.yml`
- Xcode 27 beta 2: `swift build --build-tests`
- Xcode 26.6 RC 2: full `swift test` suite with the matching AFM binary (48 XCTest + 197 Swift Testing tests)

## Runtime note
Running Xcode 27 beta 2-built SwiftPM tests on the current macOS 27 beta 1 host still hits an Apple framework ABI mismatch (`Generable.promptRepresentation`). This PR fixes the repository compile break; executing those beta 2-linked bundles requires a matching OS runtime.