### PR TITLE
Build a live image input lab

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -161,7 +161,7 @@ extension ExampleType {
         case .privateCloudCompute:
             return "Probe PCC availability, quota, and context size"
         case .imageInputPlayground:
-            return "Explore image attachments and resolution boundaries"
+            return "Run a live on-device image attachment request"
         case .geminiVideoInput:
             return "Analyze video with a custom LanguageModelSession"
         case .toolCallingModeLab:

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -1,0 +1,240 @@
+//
+//  ImageInputViewModel.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+import FoundationModels
+import Observation
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+@Observable
+final class ImageInputViewModel {
+    private(set) var selection: ImageInputSelection?
+    private(set) var result: ImageInputRunResult?
+    private(set) var isImporting = false
+    private(set) var isRunning = false
+    var prompt = ImageInputRecipe.altText.prompt
+    var recipe = ImageInputRecipe.altText
+    var errorMessage: String?
+
+    private let importer = ImageInputImporter()
+    private var importTask: Task<Void, Never>?
+    private var runTask: Task<Void, Never>?
+    private var activeImportID: UUID?
+    private var activeRunID: UUID?
+
+    var canRun: Bool {
+        selection != nil
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && readinessMessage == nil
+            && !isImporting
+            && !isRunning
+    }
+
+    var readinessMessage: String? {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            if SystemLanguageModel.default.capabilities.contains(.vision) {
+                nil
+            } else {
+                String(localized: "The active system model does not support image input on this device.")
+            }
+        case .unavailable(.deviceNotEligible):
+            String(localized: "This device does not support Apple Intelligence.")
+        case .unavailable(.appleIntelligenceNotEnabled):
+            String(localized: "Turn on Apple Intelligence in Settings, then return to run the lab.")
+        case .unavailable(.modelNotReady):
+            String(localized: "The on-device model is still preparing. Try again when Apple Intelligence is ready.")
+        @unknown default:
+            String(localized: "The on-device system language model is currently unavailable.")
+        }
+    }
+
+    func chooseRecipe(_ recipe: ImageInputRecipe) {
+        self.recipe = recipe
+        prompt = recipe.prompt
+        errorMessage = nil
+    }
+
+    func importImage(from result: Result<URL, any Error>) {
+        cancelImport()
+        cancelRun()
+
+        switch result {
+        case .success(let url):
+            let importID = UUID()
+            activeImportID = importID
+            isImporting = true
+            errorMessage = nil
+
+            importTask = Task { @MainActor [weak self] in
+                await self?.performImport(url: url, id: importID)
+            }
+        case .failure(let error):
+            if (error as? CocoaError)?.code == .userCancelled {
+                return
+            }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func removeImage() {
+        cancelImport()
+        cancelRun()
+        selection = nil
+        result = nil
+        errorMessage = nil
+    }
+
+    func startRun() {
+        guard canRun, let selection else { return }
+        cancelRun()
+
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let runID = UUID()
+        activeRunID = runID
+        isRunning = true
+        result = nil
+        errorMessage = nil
+
+        runTask = Task { @MainActor [weak self] in
+            await self?.performRun(prompt: trimmedPrompt, selection: selection, id: runID)
+        }
+    }
+
+    func cancelRun() {
+        activeRunID = nil
+        runTask?.cancel()
+        runTask = nil
+        isRunning = false
+    }
+
+    func reset() {
+        cancelImport()
+        cancelRun()
+        selection = nil
+        result = nil
+        recipe = .altText
+        prompt = ImageInputRecipe.altText.prompt
+        errorMessage = nil
+    }
+
+    func cancelAll() {
+        cancelImport()
+        cancelRun()
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+private extension ImageInputViewModel {
+    func cancelImport() {
+        activeImportID = nil
+        importTask?.cancel()
+        importTask = nil
+        isImporting = false
+    }
+
+    func performImport(url: URL, id: UUID) async {
+        defer {
+            if activeImportID == id {
+                activeImportID = nil
+                importTask = nil
+                isImporting = false
+            }
+        }
+
+        do {
+            let importedSelection = try await importer.load(url)
+            try Task.checkCancellation()
+            guard activeImportID == id else { return }
+            selection = importedSelection
+            result = nil
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeImportID == id else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func performRun(prompt: String, selection: ImageInputSelection, id: UUID) async {
+        defer {
+            if activeRunID == id {
+                activeRunID = nil
+                runTask = nil
+                isRunning = false
+            }
+        }
+
+        guard SystemLanguageModel.default.isAvailable else {
+            guard activeRunID == id else { return }
+            errorMessage = readinessMessage
+            return
+        }
+        guard SystemLanguageModel.default.capabilities.contains(.vision) else {
+            guard activeRunID == id else { return }
+            errorMessage = String(localized: "The active system model does not support image input on this device.")
+            return
+        }
+
+        do {
+            let cgImage = try await importer.fullResolutionImage(from: selection.data)
+            try Task.checkCancellation()
+
+            let attachment = Attachment<ImageAttachmentContent>(
+                cgImage,
+                orientation: selection.orientation
+            )
+            .label("selected-image")
+            let session = LanguageModelSession()
+            let clock = ContinuousClock()
+            let startedAt = clock.now
+            let response = try await session.respond {
+                prompt
+                attachment
+            }
+            let finishedAt = clock.now
+
+            try Task.checkCancellation()
+            guard activeRunID == id, self.selection?.id == selection.id else { return }
+
+            result = ImageInputRunResult(
+                response: response.content,
+                prompt: prompt,
+                imageName: selection.fileName,
+                inputTokens: response.usage.input.totalTokenCount,
+                cachedInputTokens: response.usage.input.cachedTokenCount,
+                outputTokens: response.usage.output.totalTokenCount,
+                reasoningTokens: response.usage.output.reasoningTokenCount,
+                totalTokens: response.usage.totalTokenCount,
+                transcriptEntryCount: session.transcript.count,
+                attachmentSegmentCount: Self.attachmentSegmentCount(in: session.transcript),
+                duration: startedAt.duration(to: finishedAt)
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeRunID == id, self.selection?.id == selection.id else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    static func attachmentSegmentCount(in transcript: Transcript) -> Int {
+        var count = 0
+        for entry in transcript {
+            guard case .prompt(let prompt) = entry else { continue }
+            for segment in prompt.segments {
+                if case .attachment = segment {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+}
+#endif

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -117,7 +117,6 @@ final class ImageInputViewModel {
         let runID = UUID()
         activeRunID = runID
         isRunning = true
-        result = nil
         errorMessage = nil
 
         runTask = Task { @MainActor [weak self] in

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -66,6 +66,7 @@ final class ImageInputViewModel {
         case .success(let url):
             cancelImport()
             cancelRun()
+            self.result = nil
 
             let importID = UUID()
             activeImportID = importID

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -18,8 +18,22 @@ final class ImageInputViewModel {
     private(set) var result: ImageInputRunResult?
     private(set) var isImporting = false
     private(set) var isRunning = false
-    var prompt = ImageInputRecipe.altText.prompt
-    var recipe = ImageInputRecipe.altText
+    var prompt = ImageInputRecipe.altText.prompt {
+        didSet {
+            if prompt != oldValue {
+                result = nil
+                errorMessage = nil
+            }
+        }
+    }
+    var recipe = ImageInputRecipe.altText {
+        didSet {
+            if recipe != oldValue {
+                result = nil
+                errorMessage = nil
+            }
+        }
+    }
     var errorMessage: String?
 
     private let importer = ImageInputImporter()
@@ -64,8 +78,12 @@ final class ImageInputViewModel {
     func importImage(from result: Result<URL, any Error>) {
         switch result {
         case .success(let url):
+            guard !isRunning else {
+                errorMessage = String(localized: "Stop the current analysis before replacing the image.")
+                return
+            }
+
             cancelImport()
-            cancelRun()
             self.result = nil
 
             let importID = UUID()
@@ -80,13 +98,13 @@ final class ImageInputViewModel {
             if (error as? CocoaError)?.code == .userCancelled {
                 return
             }
-            errorMessage = error.localizedDescription
+            errorMessage = importFailureMessage(for: error)
         }
     }
 
     func removeImage() {
+        guard !isRunning else { return }
         cancelImport()
-        cancelRun()
         selection = nil
         result = nil
         errorMessage = nil
@@ -115,6 +133,13 @@ final class ImageInputViewModel {
         isRunning = false
     }
 
+    func cancelImport() {
+        activeImportID = nil
+        importTask?.cancel()
+        importTask = nil
+        isImporting = false
+    }
+
     func reset() {
         cancelImport()
         cancelRun()
@@ -133,13 +158,6 @@ final class ImageInputViewModel {
 
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 private extension ImageInputViewModel {
-    func cancelImport() {
-        activeImportID = nil
-        importTask?.cancel()
-        importTask = nil
-        isImporting = false
-    }
-
     func performImport(url: URL, id: UUID) async {
         defer {
             if activeImportID == id {
@@ -159,8 +177,21 @@ private extension ImageInputViewModel {
             return
         } catch {
             guard activeImportID == id else { return }
-            errorMessage = error.localizedDescription
+            errorMessage = importFailureMessage(for: error, attemptedFileName: url.lastPathComponent)
         }
+    }
+
+    func importFailureMessage(for error: any Error, attemptedFileName: String? = nil) -> String {
+        guard let retainedFileName = selection?.fileName else {
+            return error.localizedDescription
+        }
+
+        if let attemptedFileName {
+            return String(
+                localized: "Couldn't import \(attemptedFileName). Keeping \(retainedFileName). \(error.localizedDescription)"
+            )
+        }
+        return String(localized: "Couldn't open a replacement image. Keeping \(retainedFileName). \(error.localizedDescription)")
     }
 
     func performRun(prompt: String, selection: ImageInputSelection, id: UUID) async {

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -84,7 +84,6 @@ final class ImageInputViewModel {
             }
 
             cancelImport()
-            self.result = nil
 
             let importID = UUID()
             activeImportID = importID

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -62,11 +62,11 @@ final class ImageInputViewModel {
     }
 
     func importImage(from result: Result<URL, any Error>) {
-        cancelImport()
-        cancelRun()
-
         switch result {
         case .success(let url):
+            cancelImport()
+            cancelRun()
+
             let importID = UUID()
             activeImportID = importID
             isImporting = true

--- a/Foundation Lab/ViewModels/ImageInputViewModel.swift
+++ b/Foundation Lab/ViewModels/ImageInputViewModel.swift
@@ -18,6 +18,7 @@ final class ImageInputViewModel {
     private(set) var result: ImageInputRunResult?
     private(set) var isImporting = false
     private(set) var isRunning = false
+    private(set) var isStoppingRun = false
     var prompt = ImageInputRecipe.altText.prompt {
         didSet {
             if prompt != oldValue {
@@ -48,6 +49,7 @@ final class ImageInputViewModel {
             && readinessMessage == nil
             && !isImporting
             && !isRunning
+            && !isStoppingRun
     }
 
     var readinessMessage: String? {
@@ -111,12 +113,12 @@ final class ImageInputViewModel {
 
     func startRun() {
         guard canRun, let selection else { return }
-        cancelRun()
 
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let runID = UUID()
         activeRunID = runID
         isRunning = true
+        isStoppingRun = false
         errorMessage = nil
 
         runTask = Task { @MainActor [weak self] in
@@ -125,10 +127,9 @@ final class ImageInputViewModel {
     }
 
     func cancelRun() {
-        activeRunID = nil
+        guard isRunning, !isStoppingRun else { return }
+        isStoppingRun = true
         runTask?.cancel()
-        runTask = nil
-        isRunning = false
     }
 
     func cancelImport() {
@@ -198,6 +199,7 @@ private extension ImageInputViewModel {
                 activeRunID = nil
                 runTask = nil
                 isRunning = false
+                isStoppingRun = false
             }
         }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputAccessibilityFocusTarget.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputAccessibilityFocusTarget.swift
@@ -1,0 +1,13 @@
+//
+//  ImageInputAccessibilityFocusTarget.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+
+enum ImageInputAccessibilityFocusTarget: Hashable {
+    case error(String)
+    case result(UUID)
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputAttachmentNotesView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputAttachmentNotesView.swift
@@ -1,0 +1,52 @@
+//
+//  ImageInputAttachmentNotesView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+struct ImageInputAttachmentNotesView: View {
+    @State private var isExpanded = false
+
+    var body: some View {
+        DisclosureGroup("Attachment API Notes", isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 0) {
+                Xcode27InfoRow(
+                    title: String(localized: "Attach an image"),
+                    detail: String(localized: """
+                    Attachment<ImageAttachmentContent> accepts CGImage, CIImage, a pixel buffer, or an image URL.
+                    """),
+                    systemImage: "1.circle"
+                )
+                .padding(.vertical, Spacing.small)
+
+                Divider()
+
+                Xcode27InfoRow(
+                    title: String(localized: "Give it a stable label"),
+                    detail: String(localized: """
+                    The lab labels the selected input as selected-image so generated ImageReference values can identify it.
+                    """),
+                    systemImage: "2.circle"
+                )
+                .padding(.vertical, Spacing.small)
+
+                Divider()
+
+                Xcode27InfoRow(
+                    title: String(localized: "Inspect the transcript"),
+                    detail: String(localized: """
+                    Run Evidence counts the attachment segments that Foundation Models records in the live session transcript.
+                    """),
+                    systemImage: "3.circle"
+                )
+                .padding(.vertical, Spacing.small)
+            }
+            .padding(.top, Spacing.small)
+        }
+        .font(.callout)
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputAvailabilityView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputAvailabilityView.swift
@@ -1,0 +1,29 @@
+//
+//  ImageInputAvailabilityView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+struct ImageInputAvailabilityView: View {
+    let message: String?
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                Text(message == nil ? "Image input ready" : "Image input unavailable")
+                    .bold()
+                Text(message ?? String(localized: "The image and prompt stay on this device for this system-model request."))
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: message == nil ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                .foregroundStyle(message == nil ? .green : .orange)
+        }
+        .font(.callout)
+        .accessibilityElement(children: .combine)
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputFileCoordination.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputFileCoordination.swift
@@ -1,0 +1,44 @@
+//
+//  ImageInputFileCoordination.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+
+nonisolated final class ImageInputFileCoordination: @unchecked Sendable {
+    let coordinator = NSFileCoordinator()
+    let intent: NSFileAccessIntent
+    let queue: OperationQueue
+
+    private let lock = NSLock()
+    private var isCancelled = false
+
+    init(url: URL) {
+        intent = NSFileAccessIntent.readingIntent(with: url, options: [])
+
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.name = "ImageInputFileCoordination"
+        self.queue = queue
+    }
+
+    func cancel() {
+        lock.lock()
+        isCancelled = true
+        lock.unlock()
+        coordinator.cancel()
+    }
+
+    func checkCancellation() throws {
+        try Task.checkCancellation()
+
+        lock.lock()
+        let wasCancelled = isCancelled
+        lock.unlock()
+        if wasCancelled {
+            throw CancellationError()
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImportError.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImportError.swift
@@ -10,7 +10,7 @@ enum ImageInputImportError: LocalizedError {
     case unsupportedImage
     case missingDimensions
     case fileTooLarge(actualByteCount: Int64, maximumByteCount: Int64)
-    case decodedImageTooLarge(estimatedByteCount: Int64, maximumByteCount: Int64)
+    case decodedImageTooLarge(byteCount: Int64, maximumByteCount: Int64)
 
     var errorDescription: String? {
         switch self {
@@ -27,10 +27,10 @@ enum ImageInputImportError: LocalizedError {
                 \(Self.formattedByteCount(maximumByteCount)) import limit. Use Tools/ImageInputProbe for large-file stress tests.
                 """
             )
-        case .decodedImageTooLarge(let estimatedByteCount, let maximumByteCount):
+        case .decodedImageTooLarge(let byteCount, let maximumByteCount):
             String(
                 localized: """
-                This image would decode to about \(Self.formattedByteCount(estimatedByteCount)), above the interactive lab's \
+                This image needs about \(Self.formattedByteCount(byteCount)) to decode, above the interactive lab's \
                 \(Self.formattedByteCount(maximumByteCount)) safety limit. Use Tools/ImageInputProbe for resolution stress tests.
                 """
             )

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImportError.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImportError.swift
@@ -1,0 +1,43 @@
+//
+//  ImageInputImportError.swift
+//  FoundationLab
+//
+
+import Foundation
+
+enum ImageInputImportError: LocalizedError {
+    case unreadableFile
+    case unsupportedImage
+    case missingDimensions
+    case fileTooLarge(actualByteCount: Int64, maximumByteCount: Int64)
+    case decodedImageTooLarge(estimatedByteCount: Int64, maximumByteCount: Int64)
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadableFile:
+            String(localized: "Foundation Lab could not read that file.")
+        case .unsupportedImage:
+            String(localized: "That file could not be decoded as an image.")
+        case .missingDimensions:
+            String(localized: "The image does not report valid pixel dimensions.")
+        case .fileTooLarge(let actualByteCount, let maximumByteCount):
+            String(
+                localized: """
+                This file is \(Self.formattedByteCount(actualByteCount)), above the interactive lab's \
+                \(Self.formattedByteCount(maximumByteCount)) import limit. Use Tools/ImageInputProbe for large-file stress tests.
+                """
+            )
+        case .decodedImageTooLarge(let estimatedByteCount, let maximumByteCount):
+            String(
+                localized: """
+                This image would decode to about \(Self.formattedByteCount(estimatedByteCount)), above the interactive lab's \
+                \(Self.formattedByteCount(maximumByteCount)) safety limit. Use Tools/ImageInputProbe for resolution stress tests.
+                """
+            )
+        }
+    }
+
+    private static func formattedByteCount(_ byteCount: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file)
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImportProgressView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImportProgressView.swift
@@ -1,0 +1,39 @@
+//
+//  ImageInputImportProgressView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+struct ImageInputImportProgressView: View {
+    let retainedFileName: String?
+    let cancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: Spacing.medium) {
+            ProgressView()
+
+            VStack(spacing: Spacing.xSmall) {
+                Text(retainedFileName == nil ? "Importing image…" : "Importing replacement…")
+                    .bold()
+
+                if let retainedFileName {
+                    Text("Keeping \(retainedFileName) selected unless the replacement succeeds.")
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+
+            Button("Cancel Import", systemImage: "xmark", action: cancel)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .frame(minHeight: 44)
+        }
+        .font(.callout)
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .contain)
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
@@ -12,6 +12,7 @@ import UniformTypeIdentifiers
 actor ImageInputImporter {
     static let maximumEncodedByteCount: Int64 = 64 * 1_024 * 1_024
     static let maximumDecodedByteCount: Int64 = 256 * 1_024 * 1_024
+    private static let readChunkByteCount = 1_024 * 1_024
 
     func load(_ url: URL) throws -> ImageInputSelection {
         let accessedSecurityScope = url.startAccessingSecurityScopedResource()
@@ -25,7 +26,7 @@ actor ImageInputImporter {
             try Self.validateEncodedByteCount(Int64(fileSize))
         }
 
-        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+        guard let data = try? Self.readOwnedData(from: url) else {
             throw ImageInputImportError.unreadableFile
         }
         try Self.validateEncodedByteCount(Int64(data.count))
@@ -90,6 +91,23 @@ actor ImageInputImporter {
                 maximumByteCount: maximumEncodedByteCount
             )
         }
+    }
+
+    private nonisolated static func readOwnedData(from url: URL) throws -> Data {
+        let fileHandle = try FileHandle(forReadingFrom: url)
+        defer { try? fileHandle.close() }
+
+        let maximumReadByteCount = Int(maximumEncodedByteCount) + 1
+        var data = Data()
+        while data.count < maximumReadByteCount {
+            let remainingByteCount = maximumReadByteCount - data.count
+            let chunkByteCount = min(readChunkByteCount, remainingByteCount)
+            guard let chunk = try fileHandle.read(upToCount: chunkByteCount), !chunk.isEmpty else {
+                break
+            }
+            data.append(chunk)
+        }
+        return data
     }
 
     nonisolated static func validateDecodedDimensions(width: Int, height: Int) throws {

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
@@ -79,6 +79,7 @@ actor ImageInputImporter {
               ) else {
             throw ImageInputImportError.unsupportedImage
         }
+        try Self.validateDecodedBuffer(bytesPerRow: image.bytesPerRow, height: image.height)
         return image
     }
 
@@ -93,12 +94,11 @@ actor ImageInputImporter {
 
     nonisolated static func validateDecodedDimensions(width: Int, height: Int) throws {
         let estimatedByteCount = estimatedDecodedByteCount(width: width, height: height)
-        guard estimatedByteCount <= maximumDecodedByteCount else {
-            throw ImageInputImportError.decodedImageTooLarge(
-                estimatedByteCount: estimatedByteCount,
-                maximumByteCount: maximumDecodedByteCount
-            )
-        }
+        try validateDecodedByteCount(estimatedByteCount)
+    }
+
+    nonisolated static func validateDecodedBuffer(bytesPerRow: Int, height: Int) throws {
+        try validateDecodedByteCount(decodedByteCount(bytesPerRow: bytesPerRow, height: height))
     }
 
     nonisolated static func estimatedDecodedByteCount(width: Int, height: Int) -> Int64 {
@@ -113,6 +113,27 @@ actor ImageInputImporter {
         let alignedRowBytes = (paddedRowBytes / 16) * 16
         let (decodedByteCount, decodedOverflow) = alignedRowBytes.multipliedReportingOverflow(by: Int64(height))
         return decodedOverflow ? .max : decodedByteCount
+    }
+
+    nonisolated static func decodedByteCount(bytesPerRow: Int, height: Int) -> Int64 {
+        guard let rowByteCount = Int64(exactly: bytesPerRow),
+              let rowCount = Int64(exactly: height),
+              rowByteCount >= 0,
+              rowCount >= 0 else {
+            return .max
+        }
+
+        let (decodedByteCount, overflow) = rowByteCount.multipliedReportingOverflow(by: rowCount)
+        return overflow ? .max : decodedByteCount
+    }
+
+    private nonisolated static func validateDecodedByteCount(_ byteCount: Int64) throws {
+        guard byteCount <= maximumDecodedByteCount else {
+            throw ImageInputImportError.decodedImageTooLarge(
+                byteCount: byteCount,
+                maximumByteCount: maximumDecodedByteCount
+            )
+        }
     }
 }
 #endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
@@ -123,8 +123,10 @@ actor ImageInputImporter {
                     do {
                         try operation.checkCancellation()
                         let coordinatedURL = operation.intent.url
-                        let resourceValues = try coordinatedURL.resourceValues(forKeys: [.fileSizeKey])
-                        if let fileSize = resourceValues.fileSize {
+                        let fileSize: Int? = try? coordinatedURL
+                            .resourceValues(forKeys: [.fileSizeKey])
+                            .fileSize
+                        if let fileSize {
                             try validateEncodedByteCount(Int64(fileSize))
                         }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
@@ -1,0 +1,118 @@
+//
+//  ImageInputImporter.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+actor ImageInputImporter {
+    static let maximumEncodedByteCount: Int64 = 64 * 1_024 * 1_024
+    static let maximumDecodedByteCount: Int64 = 256 * 1_024 * 1_024
+
+    func load(_ url: URL) throws -> ImageInputSelection {
+        let accessedSecurityScope = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessedSecurityScope {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+            try Self.validateEncodedByteCount(Int64(fileSize))
+        }
+
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            throw ImageInputImportError.unreadableFile
+        }
+        try Self.validateEncodedByteCount(Int64(data.count))
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            throw ImageInputImportError.unsupportedImage
+        }
+
+        let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as NSDictionary?
+        guard let width = (properties?[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+              let height = (properties?[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+              width > 0,
+              height > 0 else {
+            throw ImageInputImportError.missingDimensions
+        }
+        try Self.validateDecodedDimensions(width: width, height: height)
+
+        let options = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: 1_600
+        ] as CFDictionary
+        guard let previewImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else {
+            throw ImageInputImportError.unsupportedImage
+        }
+
+        let orientationValue = (properties?[kCGImagePropertyOrientation] as? NSNumber)?.uint32Value ?? 1
+        let orientation = CGImagePropertyOrientation(rawValue: orientationValue) ?? .up
+        let typeIdentifier = CGImageSourceGetType(source) as String?
+        let formatDescription = typeIdentifier
+            .flatMap { UTType($0)?.localizedDescription }
+            ?? String(localized: "Image")
+
+        return ImageInputSelection(
+            id: UUID(),
+            fileName: url.lastPathComponent,
+            data: data,
+            previewImage: previewImage,
+            pixelWidth: width,
+            pixelHeight: height,
+            formatDescription: formatDescription,
+            orientation: orientation
+        )
+    }
+
+    func fullResolutionImage(from data: Data) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(
+                source,
+                0,
+                [kCGImageSourceShouldCache: false] as CFDictionary
+              ) else {
+            throw ImageInputImportError.unsupportedImage
+        }
+        return image
+    }
+
+    nonisolated static func validateEncodedByteCount(_ byteCount: Int64) throws {
+        guard byteCount <= maximumEncodedByteCount else {
+            throw ImageInputImportError.fileTooLarge(
+                actualByteCount: byteCount,
+                maximumByteCount: maximumEncodedByteCount
+            )
+        }
+    }
+
+    nonisolated static func validateDecodedDimensions(width: Int, height: Int) throws {
+        let estimatedByteCount = estimatedDecodedByteCount(width: width, height: height)
+        guard estimatedByteCount <= maximumDecodedByteCount else {
+            throw ImageInputImportError.decodedImageTooLarge(
+                estimatedByteCount: estimatedByteCount,
+                maximumByteCount: maximumDecodedByteCount
+            )
+        }
+    }
+
+    nonisolated static func estimatedDecodedByteCount(width: Int, height: Int) -> Int64 {
+        guard width > 0, height > 0 else { return 0 }
+
+        let (rowBytes, rowOverflow) = Int64(width).multipliedReportingOverflow(by: 4)
+        guard !rowOverflow else { return .max }
+
+        let (paddedRowBytes, paddingOverflow) = rowBytes.addingReportingOverflow(15)
+        guard !paddingOverflow else { return .max }
+
+        let alignedRowBytes = (paddedRowBytes / 16) * 16
+        let (decodedByteCount, decodedOverflow) = alignedRowBytes.multipliedReportingOverflow(by: Int64(height))
+        return decodedOverflow ? .max : decodedByteCount
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputImporter.swift
@@ -14,7 +14,7 @@ actor ImageInputImporter {
     static let maximumDecodedByteCount: Int64 = 256 * 1_024 * 1_024
     private static let readChunkByteCount = 1_024 * 1_024
 
-    func load(_ url: URL) throws -> ImageInputSelection {
+    func load(_ url: URL) async throws -> ImageInputSelection {
         let accessedSecurityScope = url.startAccessingSecurityScopedResource()
         defer {
             if accessedSecurityScope {
@@ -22,17 +22,14 @@ actor ImageInputImporter {
             }
         }
 
-        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
-            try Self.validateEncodedByteCount(Int64(fileSize))
-        }
+        try Task.checkCancellation()
+        let data = try await Self.coordinatedOwnedData(from: url)
+        try Task.checkCancellation()
 
-        guard let data = try? Self.readOwnedData(from: url) else {
-            throw ImageInputImportError.unreadableFile
-        }
-        try Self.validateEncodedByteCount(Int64(data.count))
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
             throw ImageInputImportError.unsupportedImage
         }
+        try Task.checkCancellation()
 
         let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as NSDictionary?
         guard let width = (properties?[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
@@ -42,6 +39,7 @@ actor ImageInputImporter {
             throw ImageInputImportError.missingDimensions
         }
         try Self.validateDecodedDimensions(width: width, height: height)
+        try Task.checkCancellation()
 
         let options = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
@@ -51,6 +49,7 @@ actor ImageInputImporter {
         guard let previewImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else {
             throw ImageInputImportError.unsupportedImage
         }
+        try Task.checkCancellation()
 
         let orientationValue = (properties?[kCGImagePropertyOrientation] as? NSNumber)?.uint32Value ?? 1
         let orientation = CGImagePropertyOrientation(rawValue: orientationValue) ?? .up
@@ -72,14 +71,19 @@ actor ImageInputImporter {
     }
 
     func fullResolutionImage(from data: Data) throws -> CGImage {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              let image = CGImageSourceCreateImageAtIndex(
-                source,
-                0,
-                [kCGImageSourceShouldCache: false] as CFDictionary
-              ) else {
+        try Task.checkCancellation()
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
             throw ImageInputImportError.unsupportedImage
         }
+        try Task.checkCancellation()
+        guard let image = CGImageSourceCreateImageAtIndex(
+            source,
+            0,
+            [kCGImageSourceShouldCache: false] as CFDictionary
+        ) else {
+            throw ImageInputImportError.unsupportedImage
+        }
+        try Task.checkCancellation()
         try Self.validateDecodedBuffer(bytesPerRow: image.bytesPerRow, height: image.height)
         return image
     }
@@ -93,13 +97,67 @@ actor ImageInputImporter {
         }
     }
 
-    private nonisolated static func readOwnedData(from url: URL) throws -> Data {
+    private nonisolated static func coordinatedOwnedData(from url: URL) async throws -> Data {
+        let operation = ImageInputFileCoordination(url: url)
+
+        return try await withTaskCancellationHandler {
+            try operation.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                operation.coordinator.coordinate(with: [operation.intent], queue: operation.queue) { coordinationError in
+                    if let coordinationError {
+                        do {
+                            try operation.checkCancellation()
+                        } catch {
+                            continuation.resume(throwing: error)
+                            return
+                        }
+
+                        if (coordinationError as? CocoaError)?.code == .userCancelled {
+                            continuation.resume(throwing: CancellationError())
+                        } else {
+                            continuation.resume(throwing: coordinationError)
+                        }
+                        return
+                    }
+
+                    do {
+                        try operation.checkCancellation()
+                        let coordinatedURL = operation.intent.url
+                        let resourceValues = try coordinatedURL.resourceValues(forKeys: [.fileSizeKey])
+                        if let fileSize = resourceValues.fileSize {
+                            try validateEncodedByteCount(Int64(fileSize))
+                        }
+
+                        let data = try readOwnedData(from: coordinatedURL, operation: operation)
+                        try validateEncodedByteCount(Int64(data.count))
+                        try operation.checkCancellation()
+                        continuation.resume(returning: data)
+                    } catch is CancellationError {
+                        continuation.resume(throwing: CancellationError())
+                    } catch let error as ImageInputImportError {
+                        continuation.resume(throwing: error)
+                    } catch {
+                        continuation.resume(throwing: ImageInputImportError.unreadableFile)
+                    }
+                }
+            }
+        } onCancel: {
+            operation.cancel()
+        }
+    }
+
+    private nonisolated static func readOwnedData(
+        from url: URL,
+        operation: ImageInputFileCoordination
+    ) throws -> Data {
+        try operation.checkCancellation()
         let fileHandle = try FileHandle(forReadingFrom: url)
         defer { try? fileHandle.close() }
 
         let maximumReadByteCount = Int(maximumEncodedByteCount) + 1
         var data = Data()
         while data.count < maximumReadByteCount {
+            try operation.checkCancellation()
             let remainingByteCount = maximumReadByteCount - data.count
             let chunkByteCount = min(readChunkByteCount, remainingByteCount)
             guard let chunk = try fileHandle.read(upToCount: chunkByteCount), !chunk.isEmpty else {
@@ -107,6 +165,7 @@ actor ImageInputImporter {
             }
             data.append(chunk)
         }
+        try operation.checkCancellation()
         return data
     }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -116,13 +116,13 @@ struct ImageInputLiveView: View {
             isResultFocused = false
             isErrorFocused = true
         }
-        .onChange(of: model.result != nil) { _, hasResult in
-            guard hasResult else { return }
+        .onChange(of: model.result?.id) { _, resultID in
+            guard resultID != nil else { return }
             isErrorFocused = false
             isResultFocused = true
         }
-        .sensoryFeedback(.success, trigger: model.result != nil) { oldValue, newValue in
-            !oldValue && newValue
+        .sensoryFeedback(.success, trigger: model.result?.id) { oldValue, newValue in
+            newValue != nil && newValue != oldValue
         }
     }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -13,8 +13,7 @@ import UniformTypeIdentifiers
 struct ImageInputLiveView: View {
     @State private var model = ImageInputViewModel()
     @State private var isImporterPresented = false
-    @AccessibilityFocusState private var isErrorFocused: Bool
-    @AccessibilityFocusState private var isResultFocused: Bool
+    @AccessibilityFocusState private var accessibilityFocus: ImageInputAccessibilityFocusTarget?
 
     var body: some View {
         @Bindable var model = model
@@ -76,13 +75,13 @@ struct ImageInputLiveView: View {
                     .background(.quaternary, in: .rect(cornerRadius: CornerRadius.medium))
                     .accessibilityLabel("Error: \(errorMessage)")
                     .accessibilityElement(children: .combine)
-                    .accessibilityFocused($isErrorFocused)
+                    .accessibilityFocused($accessibilityFocus, equals: .error(errorMessage))
                 }
 
                 if let result = model.result {
                     ImageInputResultSection(result: result)
-                        .id("image-input-result")
-                        .accessibilityFocused($isResultFocused)
+                        .id(result.id)
+                        .accessibilityFocused($accessibilityFocus, equals: .result(result.id))
                 }
 
                 ImageInputAttachmentNotesView()
@@ -112,14 +111,10 @@ struct ImageInputLiveView: View {
         )
         .onDisappear(perform: model.cancelAll)
         .onChange(of: model.errorMessage) { _, errorMessage in
-            guard errorMessage != nil else { return }
-            isResultFocused = false
-            isErrorFocused = true
+            accessibilityFocus = errorMessage.map(ImageInputAccessibilityFocusTarget.error)
         }
         .onChange(of: model.result?.id) { _, resultID in
-            guard resultID != nil else { return }
-            isErrorFocused = false
-            isResultFocused = true
+            accessibilityFocus = resultID.map(ImageInputAccessibilityFocusTarget.result)
         }
         .sensoryFeedback(.success, trigger: model.result?.id) { oldValue, newValue in
             newValue != nil && newValue != oldValue

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -78,7 +78,7 @@ struct ImageInputLiveView: View {
                     .accessibilityFocused($accessibilityFocus, equals: .error(errorMessage))
                 }
 
-                if let result = model.result {
+                if let result = model.result, !model.isRunning {
                     ImageInputResultSection(result: result)
                         .id(result.id)
                         .accessibilityFocused($accessibilityFocus, equals: .result(result.id))
@@ -112,6 +112,11 @@ struct ImageInputLiveView: View {
         .onDisappear(perform: model.cancelAll)
         .onChange(of: model.errorMessage) { _, errorMessage in
             accessibilityFocus = errorMessage.map(ImageInputAccessibilityFocusTarget.error)
+        }
+        .onChange(of: model.isRunning) { _, isRunning in
+            if isRunning, case .some(.result) = accessibilityFocus {
+                accessibilityFocus = nil
+            }
         }
         .onChange(of: model.result?.id) { _, resultID in
             accessibilityFocus = resultID.map(ImageInputAccessibilityFocusTarget.result)

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -1,0 +1,131 @@
+//
+//  ImageInputLiveView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+import UniformTypeIdentifiers
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ImageInputLiveView: View {
+    @State private var model = ImageInputViewModel()
+    @State private var isImporterPresented = false
+
+    var body: some View {
+        @Bindable var model = model
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.xLarge) {
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Ask the on-device model about an image")
+                        .font(.title2.bold())
+                    Text("Choose one image, edit the prompt, then inspect the model's answer and run evidence.")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                ImageInputAvailabilityView(message: model.readinessMessage)
+
+                ImageInputSelectionSection(
+                    selection: model.selection,
+                    isImporting: model.isImporting,
+                    chooseImage: presentImporter,
+                    removeImage: model.removeImage
+                )
+
+                ImageInputPromptSection(
+                    prompt: $model.prompt,
+                    recipe: $model.recipe,
+                    isBusy: model.isImporting || model.isRunning,
+                    chooseRecipe: model.chooseRecipe,
+                    reset: model.reset
+                )
+
+                Button(
+                    model.isRunning ? "Stop" : "Analyze Image",
+                    systemImage: model.isRunning ? "stop.fill" : "sparkles",
+                    action: toggleRun
+                )
+                .buttonStyle(.glassProminent)
+                .controlSize(.large)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .disabled(!model.isRunning && !model.canRun)
+                .accessibilityHint(runButtonHint)
+                #if os(macOS)
+                .keyboardShortcut(.return, modifiers: [.command])
+                #endif
+
+                if let errorMessage = model.errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .padding(Spacing.medium)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.red.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+                        .accessibilityLabel("Error: \(errorMessage)")
+                }
+
+                if let result = model.result {
+                    ImageInputResultSection(result: result)
+                        .id("image-input-result")
+                }
+
+                ImageInputAttachmentNotesView()
+                    .id("image-input-attachment-notes")
+                ImageInputResolutionFindingsView()
+                    .id("image-input-resolution-notes")
+                CodeDisclosure(code: model.recipe.code)
+                    .id("image-input-code")
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+            .frame(maxWidth: .infinity)
+        }
+        #if os(iOS)
+        .scrollDismissesKeyboard(.interactively)
+        #endif
+        .navigationTitle("Image Input")
+        .navigationSubtitle("Run a real multimodal request")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        #endif
+        .fileImporter(
+            isPresented: $isImporterPresented,
+            allowedContentTypes: [.image],
+            onCompletion: model.importImage
+        )
+        .onDisappear(perform: model.cancelAll)
+        .sensoryFeedback(.success, trigger: model.result != nil) { oldValue, newValue in
+            !oldValue && newValue
+        }
+    }
+
+    private var runButtonHint: String {
+        if model.isRunning {
+            String(localized: "Cancel the current model request")
+        } else if model.selection == nil {
+            String(localized: "Choose an image before running the model")
+        } else if model.readinessMessage != nil {
+            String(localized: "The on-device model must be ready for image input before this request can run")
+        } else {
+            String(localized: "Send the selected image and prompt to the on-device model")
+        }
+    }
+
+    private func presentImporter() {
+        isImporterPresented = true
+    }
+
+    private func toggleRun() {
+        if model.isRunning {
+            model.cancelRun()
+        } else {
+            model.startRun()
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -13,6 +13,8 @@ import UniformTypeIdentifiers
 struct ImageInputLiveView: View {
     @State private var model = ImageInputViewModel()
     @State private var isImporterPresented = false
+    @AccessibilityFocusState private var isErrorFocused: Bool
+    @AccessibilityFocusState private var isResultFocused: Bool
 
     var body: some View {
         @Bindable var model = model
@@ -32,8 +34,10 @@ struct ImageInputLiveView: View {
                 ImageInputSelectionSection(
                     selection: model.selection,
                     isImporting: model.isImporting,
+                    isRunning: model.isRunning,
                     chooseImage: presentImporter,
-                    removeImage: model.removeImage
+                    removeImage: model.removeImage,
+                    cancelImport: model.cancelImport
                 )
 
                 ImageInputPromptSection(
@@ -59,18 +63,26 @@ struct ImageInputLiveView: View {
                 #endif
 
                 if let errorMessage = model.errorMessage {
-                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
-                        .font(.callout)
-                        .foregroundStyle(.red)
-                        .padding(Spacing.medium)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.red.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
-                        .accessibilityLabel("Error: \(errorMessage)")
+                    Label {
+                        Text(errorMessage)
+                            .foregroundStyle(.primary)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                    .font(.callout)
+                    .padding(Spacing.medium)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.quaternary, in: .rect(cornerRadius: CornerRadius.medium))
+                    .accessibilityLabel("Error: \(errorMessage)")
+                    .accessibilityElement(children: .combine)
+                    .accessibilityFocused($isErrorFocused)
                 }
 
                 if let result = model.result {
                     ImageInputResultSection(result: result)
                         .id("image-input-result")
+                        .accessibilityFocused($isResultFocused)
                 }
 
                 ImageInputAttachmentNotesView()
@@ -99,6 +111,16 @@ struct ImageInputLiveView: View {
             onCompletion: model.importImage
         )
         .onDisappear(perform: model.cancelAll)
+        .onChange(of: model.errorMessage) { _, errorMessage in
+            guard errorMessage != nil else { return }
+            isResultFocused = false
+            isErrorFocused = true
+        }
+        .onChange(of: model.result != nil) { _, hasResult in
+            guard hasResult else { return }
+            isErrorFocused = false
+            isResultFocused = true
+        }
         .sensoryFeedback(.success, trigger: model.result != nil) { oldValue, newValue in
             !oldValue && newValue
         }

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -129,8 +129,12 @@ struct ImageInputLiveView: View {
     private var runButtonHint: String {
         if model.isRunning {
             String(localized: "Cancel the current model request")
+        } else if model.isImporting {
+            String(localized: "Wait for the image import to finish or cancel the import")
         } else if model.selection == nil {
             String(localized: "Choose an image before running the model")
+        } else if model.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            String(localized: "Enter a prompt before running the model")
         } else if model.readinessMessage != nil {
             String(localized: "The on-device model must be ready for image input before this request can run")
         } else {

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputLiveView.swift
@@ -48,14 +48,14 @@ struct ImageInputLiveView: View {
                 )
 
                 Button(
-                    model.isRunning ? "Stop" : "Analyze Image",
-                    systemImage: model.isRunning ? "stop.fill" : "sparkles",
+                    model.isStoppingRun ? "Stopping…" : (model.isRunning ? "Stop" : "Analyze Image"),
+                    systemImage: model.isStoppingRun ? "hourglass" : (model.isRunning ? "stop.fill" : "sparkles"),
                     action: toggleRun
                 )
                 .buttonStyle(.glassProminent)
                 .controlSize(.large)
                 .frame(maxWidth: .infinity, minHeight: 44)
-                .disabled(!model.isRunning && !model.canRun)
+                .disabled(model.isStoppingRun || (!model.isRunning && !model.canRun))
                 .accessibilityHint(runButtonHint)
                 #if os(macOS)
                 .keyboardShortcut(.return, modifiers: [.command])
@@ -122,7 +122,9 @@ struct ImageInputLiveView: View {
     }
 
     private var runButtonHint: String {
-        if model.isRunning {
+        if model.isStoppingRun {
+            String(localized: "Waiting for the current model request to stop")
+        } else if model.isRunning {
             String(localized: "Cancel the current model request")
         } else if model.isImporting {
             String(localized: "Wait for the image import to finish or cancel the import")

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputPlaygroundView.swift
@@ -2,142 +2,27 @@
 //  ImageInputPlaygroundView.swift
 //  FoundationLab
 //
-//  Created by Codex on 6/8/26.
-//
 
 import SwiftUI
 
 struct ImageInputPlaygroundView: View {
-    @State private var selectedRecipe = ImageInputRecipe.altText
-
+    @ViewBuilder
     var body: some View {
-        ReferenceExampleView(
-            title: String(localized: "Image Input Reference"),
-            description: String(localized: "Inspect image attachment recipes and measured resolution boundaries"),
-            codeExample: selectedRecipe.code,
-            referenceNote: String(localized: """
-            Choose a recipe to update the sample prompt and code. No image is attached and no model request is sent on this page.
-            """)
-        ) {
-            VStack(spacing: Spacing.medium) {
-                Xcode27Section(String(localized: "Attachment Flow")) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Xcode27InfoRow(
-                            title: String(localized: "Attach an image"),
-                            detail: String(localized: """
-                            Create Attachment<ImageAttachmentContent> from a CGImage, CIImage, pixel buffer, or image URL. On supported \
-                            platforms, UIImage and NSImage also work.
-                            """),
-                            systemImage: "1.circle"
-                        )
-                        .padding(.vertical, Spacing.small)
-
-                        Divider()
-
-                        Xcode27InfoRow(
-                            title: String(localized: "Label it"),
-                            detail: String(localized: """
-                            Use a short label so generated ImageReference values can resolve back to the right transcript attachment.
-                            """),
-                            systemImage: "2.circle"
-                        )
-                        .padding(.vertical, Spacing.small)
-
-                        Divider()
-
-                        Xcode27InfoRow(
-                            title: String(localized: "Resolve references"),
-                            detail: String(
-                                localized: """
-                                Generated ImageReference can resolve in the transcript, which is useful for multimodal follow-ups.
-                                """
-                            ),
-                            systemImage: "3.circle"
-                        )
-                        .padding(.vertical, Spacing.small)
-                    }
-                }
-
-                ImageInputResolutionFindingsView()
-
-                Xcode27Section(String(localized: "Recipes")) {
-                    Picker("Recipe", selection: $selectedRecipe) {
-                        ForEach(ImageInputRecipe.allCases) { recipe in
-                            Text(recipe.title).tag(recipe)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-
-                    Text(selectedRecipe.prompt)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .padding(.top, Spacing.small)
-                }
-
-                Xcode27Section(String(localized: "Response focus")) {
-                    Text(selectedRecipe.responseFocus)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            ImageInputLiveView()
+        } else {
+            ImageInputUnavailableView(
+                title: String(localized: "OS 27 Required"),
+                message: String(localized: "Image attachments require iOS, macOS, or visionOS 27.")
+            )
         }
-    }
-}
-
-private enum ImageInputRecipe: String, CaseIterable, Identifiable {
-    case altText
-    case screenshotBug
-    case uiAudit
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .altText:
-            return String(localized: "Alt Text")
-        case .screenshotBug:
-            return String(localized: "Bug Report")
-        case .uiAudit:
-            return String(localized: "UI Audit")
-        }
-    }
-
-    var prompt: String {
-        switch self {
-        case .altText:
-            return "Generate concise alt text for this image."
-        case .screenshotBug:
-            return "Turn this screenshot into a concise bug report."
-        case .uiAudit:
-            return "Audit this UI screenshot for accessibility and layout issues."
-        }
-    }
-
-    var responseFocus: String {
-        switch self {
-        case .altText:
-            return String(localized: "Ask for a compact description suitable for accessibility labels and summaries.")
-        case .screenshotBug:
-            return String(localized: "Ask for a title, observed behavior, expected behavior, visible evidence, and reproduction hints.")
-        case .uiAudit:
-            return String(localized: "Ask the model to inspect layout, hierarchy, contrast, spacing, text clipping, and actionable fixes.")
-        }
-    }
-
-    var code: String {
-        """
-        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-            let image = Attachment<ImageAttachmentContent>(imageURL: imageURL)
-                .label("screenshot")
-
-            let session = LanguageModelSession()
-            let response = try await session.respond {
-                "\(prompt)"
-                image
-            }
-            print(response.content)
-        }
-        """
+        #else
+        ImageInputUnavailableView(
+            title: String(localized: "Xcode 27 Required"),
+            message: String(localized: "Build Foundation Lab with the Xcode 27 SDK to run image attachment requests.")
+        )
+        #endif
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputPromptSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputPromptSection.swift
@@ -1,0 +1,50 @@
+//
+//  ImageInputPromptSection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+struct ImageInputPromptSection: View {
+    @Binding var prompt: String
+    @Binding var recipe: ImageInputRecipe
+    let isBusy: Bool
+    let chooseRecipe: (ImageInputRecipe) -> Void
+    let reset: () -> Void
+
+    var body: some View {
+        Xcode27Section(String(localized: "Prompt")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                LabeledContent("Starting prompt") {
+                    Picker("Starting prompt", selection: $recipe) {
+                        ForEach(ImageInputRecipe.allCases) { recipe in
+                            Text(recipe.title).tag(recipe)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .disabled(isBusy)
+                    .onChange(of: recipe) { _, newValue in
+                        chooseRecipe(newValue)
+                    }
+                }
+                .frame(minHeight: 44)
+
+                TextField("Ask about the image", text: $prompt, axis: .vertical)
+                    .lineLimit(3...8)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(isBusy)
+                    .accessibilityHint("Edit what the model should inspect in the selected image")
+
+                Button("Reset Lab", systemImage: "arrow.counterclockwise", action: reset)
+                    .buttonStyle(.borderless)
+                    .controlSize(.large)
+                    .frame(minHeight: 44)
+                    .disabled(isBusy)
+            }
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputRecipe.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputRecipe.swift
@@ -1,0 +1,55 @@
+//
+//  ImageInputRecipe.swift
+//  FoundationLab
+//
+
+import Foundation
+
+enum ImageInputRecipe: String, CaseIterable, Identifiable {
+    case altText
+    case screenshotBug
+    case uiAudit
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .altText:
+            String(localized: "Alt Text")
+        case .screenshotBug:
+            String(localized: "Bug Report")
+        case .uiAudit:
+            String(localized: "UI Audit")
+        }
+    }
+
+    var prompt: String {
+        switch self {
+        case .altText:
+            String(localized: "Generate concise alt text for this image. Describe only what is visibly supported.")
+        case .screenshotBug:
+            String(localized: "Turn this screenshot into a concise bug report. Separate visible evidence from inference.")
+        case .uiAudit:
+            String(localized: "Audit this UI screenshot for accessibility and layout issues. Describe only visible evidence.")
+        }
+    }
+
+    var code: String {
+        """
+        import FoundationModels
+
+        let image = Attachment<ImageAttachmentContent>(cgImage)
+            .label("selected-image")
+
+        let session = LanguageModelSession()
+        let response = try await session.respond {
+            prompt
+            image
+        }
+
+        print(response.content)
+        print(response.usage.totalTokenCount)
+        print(session.transcript)
+        """
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputRecipe.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputRecipe.swift
@@ -36,20 +36,36 @@ enum ImageInputRecipe: String, CaseIterable, Identifiable {
 
     var code: String {
         """
+        import Foundation
         import FoundationModels
+        import ImageIO
 
-        let image = Attachment<ImageAttachmentContent>(cgImage)
+        func analyzeImage(at imageURL: URL, prompt: String) async throws {
+            guard let source = CGImageSourceCreateWithURL(imageURL as CFURL, nil),
+                  let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+
+            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as NSDictionary?
+            let orientationValue = (properties?[kCGImagePropertyOrientation] as? NSNumber)?.uint32Value ?? 1
+            let orientation = CGImagePropertyOrientation(rawValue: orientationValue) ?? .up
+
+            let image = Attachment<ImageAttachmentContent>(
+                cgImage,
+                orientation: orientation
+            )
             .label("selected-image")
 
-        let session = LanguageModelSession()
-        let response = try await session.respond {
-            prompt
-            image
-        }
+            let session = LanguageModelSession()
+            let response = try await session.respond {
+                prompt
+                image
+            }
 
-        print(response.content)
-        print(response.usage.totalTokenCount)
-        print(session.transcript)
+            print(response.content)
+            print(response.usage.totalTokenCount)
+            print(session.transcript)
+        }
         """
     }
 }

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputRecipe.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputRecipe.swift
@@ -40,8 +40,8 @@ enum ImageInputRecipe: String, CaseIterable, Identifiable {
         import FoundationModels
         import ImageIO
 
-        func analyzeImage(at imageURL: URL, prompt: String) async throws {
-            guard let source = CGImageSourceCreateWithURL(imageURL as CFURL, nil),
+        func analyzeImage(data: Data, prompt: String) async throws {
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil),
                   let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
                 throw CocoaError(.fileReadCorruptFile)
             }

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResolutionFindingsView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResolutionFindingsView.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct ImageInputResolutionFindingsView: View {
+    @State private var isExpanded = false
+
     var body: some View {
-        Xcode27Section(String(localized: "Resolution Probe")) {
+        DisclosureGroup("Measured Resolution Notes", isExpanded: $isExpanded) {
             VStack(alignment: .leading, spacing: Spacing.medium) {
                 Text(
                     """
@@ -20,6 +22,16 @@ struct ImageInputResolutionFindingsView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+
+                Label(
+                    """
+                    The interactive picker caps encoded files at 64 MB and estimated decoded buffers at 256 MB. \
+                    Use ImageInputProbe for boundary tests.
+                    """,
+                    systemImage: "shield.checkered"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
 
                 Label(
                     "Observed June 14, 2026 on macOS 27.0 beta build 26A5353q using the system model and a Display P3 JPEG.",
@@ -98,6 +110,8 @@ struct ImageInputResolutionFindingsView: View {
                     tint: .blue
                 )
             }
+            .padding(.top, Spacing.small)
         }
+        .font(.callout)
     }
 }

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
@@ -12,7 +12,7 @@ struct ImageInputResultSection: View {
     @State private var showsDetails = false
 
     var body: some View {
-        Xcode27Section(String(localized: "Model Response")) {
+        Xcode27Section(String(localized: "Last Successful Response")) {
             VStack(alignment: .leading, spacing: Spacing.medium) {
                 Text(result.response)
                     .font(.body)

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
@@ -21,10 +21,16 @@ struct ImageInputResultSection: View {
 
                 Divider()
 
-                Label(summary, systemImage: "checkmark.circle.fill")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel(accessibilitySummary)
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: hasAttachmentEvidence ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                        .foregroundStyle(hasAttachmentEvidence ? Color.secondary : Color.orange)
+
+                    Text(summary)
+                        .foregroundStyle(.secondary)
+                }
+                .font(.callout)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(accessibilitySummary)
 
                 DisclosureGroup("Run Evidence", isExpanded: $showsDetails) {
                     VStack(spacing: Spacing.small) {
@@ -46,18 +52,37 @@ struct ImageInputResultSection: View {
         }
     }
 
+    private var hasAttachmentEvidence: Bool {
+        result.attachmentSegmentCount > 0
+    }
+
     private var summary: String {
-        String(
-            localized: "\(result.totalTokens) tokens · \(result.transcriptEntryCount) transcript entries · \(durationLabel)"
-        )
+        if hasAttachmentEvidence {
+            String(
+                localized: """
+                \(result.totalTokens) tokens · \(result.attachmentSegmentCount) attachment segments · \(durationLabel)
+                """
+            )
+        } else {
+            String(localized: "Attachment evidence missing · 0 attachment segments · \(result.totalTokens) tokens")
+        }
     }
 
     private var accessibilitySummary: String {
-        String(
-            localized: """
-            Run completed with \(result.totalTokens) total tokens, \(result.transcriptEntryCount) transcript entries, in \(durationLabel)
-            """
-        )
+        if hasAttachmentEvidence {
+            String(
+                localized: """
+                Run completed with \(result.totalTokens) total tokens, \(result.attachmentSegmentCount) attachment segments, \
+                and \(result.transcriptEntryCount) transcript entries, in \(durationLabel)
+                """
+            )
+        } else {
+            String(
+                localized: """
+                Warning: run completed with no attachment segment in the transcript. Total tokens: \(result.totalTokens).
+                """
+            )
+        }
     }
 
     private var durationLabel: String {

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
@@ -25,7 +25,7 @@ struct ImageInputResultSection: View {
                     Image(systemName: hasAttachmentEvidence ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                         .foregroundStyle(hasAttachmentEvidence ? Color.secondary : Color.orange)
 
-                    Text(summary)
+                    summary
                         .foregroundStyle(.secondary)
                 }
                 .font(.callout)
@@ -56,30 +56,31 @@ struct ImageInputResultSection: View {
         result.attachmentSegmentCount > 0
     }
 
-    private var summary: String {
+    private var attachmentSegmentLabel: Text {
+        Text("^[\(result.attachmentSegmentCount) attachment segment](inflect: true)")
+    }
+
+    private var summary: Text {
         if hasAttachmentEvidence {
-            String(
-                localized: """
-                \(result.totalTokens) tokens · \(result.attachmentSegmentCount) attachment segments · \(durationLabel)
-                """
-            )
+            Text("\(result.totalTokens) tokens · \(attachmentSegmentLabel) · \(durationLabel)")
         } else {
-            String(localized: "Attachment evidence missing · 0 attachment segments · \(result.totalTokens) tokens")
+            Text("Attachment evidence missing · \(attachmentSegmentLabel) · \(result.totalTokens) tokens")
         }
     }
 
-    private var accessibilitySummary: String {
+    private var accessibilitySummary: Text {
         if hasAttachmentEvidence {
-            String(
-                localized: """
-                Run completed with \(result.totalTokens) total tokens, \(result.attachmentSegmentCount) attachment segments, \
+            Text(
+                """
+                Run completed with \(result.totalTokens) total tokens, \(attachmentSegmentLabel), \
                 and \(result.transcriptEntryCount) transcript entries, in \(durationLabel)
                 """
             )
         } else {
-            String(
-                localized: """
-                Warning: run completed with no attachment segment in the transcript. Total tokens: \(result.totalTokens).
+            Text(
+                """
+                Warning: run completed with \(attachmentSegmentLabel) in the transcript. \
+                Total tokens: \(result.totalTokens).
                 """
             )
         }

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputResultSection.swift
@@ -1,0 +1,69 @@
+//
+//  ImageInputResultSection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+struct ImageInputResultSection: View {
+    let result: ImageInputRunResult
+    @State private var showsDetails = false
+
+    var body: some View {
+        Xcode27Section(String(localized: "Model Response")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                Text(result.response)
+                    .font(.body)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider()
+
+                Label(summary, systemImage: "checkmark.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(accessibilitySummary)
+
+                DisclosureGroup("Run Evidence", isExpanded: $showsDetails) {
+                    VStack(spacing: Spacing.small) {
+                        LabeledContent("Image", value: result.imageName)
+                        LabeledContent("Prompt", value: result.prompt)
+                        LabeledContent("Input tokens", value: result.inputTokens.formatted())
+                        LabeledContent("Cached input tokens", value: result.cachedInputTokens.formatted())
+                        LabeledContent("Output tokens", value: result.outputTokens.formatted())
+                        LabeledContent("Reasoning tokens", value: result.reasoningTokens.formatted())
+                        LabeledContent("Total tokens", value: result.totalTokens.formatted())
+                        LabeledContent("Transcript entries", value: result.transcriptEntryCount.formatted())
+                        LabeledContent("Attachment segments", value: result.attachmentSegmentCount.formatted())
+                        LabeledContent("Elapsed time", value: durationLabel)
+                    }
+                    .font(.callout)
+                    .padding(.top, Spacing.small)
+                }
+            }
+        }
+    }
+
+    private var summary: String {
+        String(
+            localized: "\(result.totalTokens) tokens · \(result.transcriptEntryCount) transcript entries · \(durationLabel)"
+        )
+    }
+
+    private var accessibilitySummary: String {
+        String(
+            localized: """
+            Run completed with \(result.totalTokens) total tokens, \(result.transcriptEntryCount) transcript entries, in \(durationLabel)
+            """
+        )
+    }
+
+    private var durationLabel: String {
+        let seconds = Double(result.duration.components.seconds)
+            + (Double(result.duration.components.attoseconds) / 1_000_000_000_000_000_000)
+        return String(localized: "\(seconds.formatted(.number.precision(.fractionLength(2)))) s")
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputRunResult.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputRunResult.swift
@@ -6,7 +6,8 @@
 #if compiler(>=6.4)
 import Foundation
 
-struct ImageInputRunResult {
+struct ImageInputRunResult: Identifiable {
+    let id = UUID()
     let response: String
     let prompt: String
     let imageName: String

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputRunResult.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputRunResult.swift
@@ -1,0 +1,22 @@
+//
+//  ImageInputRunResult.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+
+struct ImageInputRunResult {
+    let response: String
+    let prompt: String
+    let imageName: String
+    let inputTokens: Int
+    let cachedInputTokens: Int
+    let outputTokens: Int
+    let reasoningTokens: Int
+    let totalTokens: Int
+    let transcriptEntryCount: Int
+    let attachmentSegmentCount: Int
+    let duration: Duration
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputSelection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputSelection.swift
@@ -1,0 +1,31 @@
+//
+//  ImageInputSelection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import CoreGraphics
+import Foundation
+import ImageIO
+
+struct ImageInputSelection: Identifiable {
+    let id: UUID
+    let fileName: String
+    let data: Data
+    let previewImage: CGImage
+    let pixelWidth: Int
+    let pixelHeight: Int
+    let formatDescription: String
+    let orientation: CGImagePropertyOrientation
+
+    var byteCount: Int { data.count }
+
+    var fileSizeDescription: String {
+        ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
+    }
+
+    var pixelDimensions: String {
+        "\(pixelWidth) × \(pixelHeight)"
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputSelectionSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputSelectionSection.swift
@@ -1,0 +1,88 @@
+//
+//  ImageInputSelectionSection.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+struct ImageInputSelectionSection: View {
+    let selection: ImageInputSelection?
+    let isImporting: Bool
+    let chooseImage: () -> Void
+    let removeImage: () -> Void
+
+    var body: some View {
+        Xcode27Section(String(localized: "Image")) {
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isImporting {
+            ProgressView("Importing image…")
+                .frame(maxWidth: .infinity, minHeight: 160)
+        } else if let selection {
+            selectedImageContent(selection)
+        } else {
+            emptyContent
+        }
+    }
+
+    private func selectedImageContent(_ selection: ImageInputSelection) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            Image(
+                selection.previewImage,
+                scale: 1,
+                orientation: .up,
+                label: Text("Selected image preview: \(selection.fileName)")
+            )
+            .resizable()
+            .scaledToFit()
+            .frame(maxWidth: .infinity, maxHeight: 360)
+            .background(.quaternary, in: .rect(cornerRadius: CornerRadius.medium))
+            .clipShape(.rect(cornerRadius: CornerRadius.medium))
+
+            metadata(for: selection)
+
+            VStack(spacing: Spacing.small) {
+                Button("Replace Image", systemImage: "photo.badge.plus", action: chooseImage)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+
+                Button("Remove", systemImage: "trash", action: removeImage)
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+        }
+    }
+
+    private func metadata(for selection: ImageInputSelection) -> some View {
+        VStack(spacing: Spacing.small) {
+            LabeledContent("File", value: selection.fileName)
+            LabeledContent("Dimensions", value: selection.pixelDimensions)
+            LabeledContent("Format", value: selection.formatDescription)
+            LabeledContent("File size", value: selection.fileSizeDescription)
+        }
+        .font(.callout)
+    }
+
+    private var emptyContent: some View {
+        ContentUnavailableView {
+            Label("Choose an Image", systemImage: "photo.on.rectangle.angled")
+        } description: {
+            Text("Import a JPEG, HEIF, PNG, or another image format supported by this device.")
+        } actions: {
+            Button("Choose Image", systemImage: "photo.badge.plus", action: chooseImage)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .frame(minHeight: 44)
+        }
+        .frame(minHeight: 220)
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputSelectionSection.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputSelectionSection.swift
@@ -10,8 +10,10 @@ import SwiftUI
 struct ImageInputSelectionSection: View {
     let selection: ImageInputSelection?
     let isImporting: Bool
+    let isRunning: Bool
     let chooseImage: () -> Void
     let removeImage: () -> Void
+    let cancelImport: () -> Void
 
     var body: some View {
         Xcode27Section(String(localized: "Image")) {
@@ -21,11 +23,11 @@ struct ImageInputSelectionSection: View {
 
     @ViewBuilder
     private var content: some View {
-        if isImporting {
-            ProgressView("Importing image…")
-                .frame(maxWidth: .infinity, minHeight: 160)
-        } else if let selection {
+        if let selection {
             selectedImageContent(selection)
+        } else if isImporting {
+            ImageInputImportProgressView(retainedFileName: nil, cancel: cancelImport)
+                .frame(maxWidth: .infinity, minHeight: 160)
         } else {
             emptyContent
         }
@@ -47,16 +49,25 @@ struct ImageInputSelectionSection: View {
 
             metadata(for: selection)
 
-            VStack(spacing: Spacing.small) {
-                Button("Replace Image", systemImage: "photo.badge.plus", action: chooseImage)
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .frame(maxWidth: .infinity, minHeight: 44)
+            if isImporting {
+                ImageInputImportProgressView(
+                    retainedFileName: selection.fileName,
+                    cancel: cancelImport
+                )
+            } else {
+                VStack(spacing: Spacing.small) {
+                    Button("Replace Image", systemImage: "photo.badge.plus", action: chooseImage)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .disabled(isRunning)
 
-                Button("Remove", systemImage: "trash", action: removeImage)
-                    .buttonStyle(.bordered)
-                    .controlSize(.large)
-                    .frame(maxWidth: .infinity, minHeight: 44)
+                    Button("Remove", systemImage: "trash", action: removeImage)
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .disabled(isRunning)
+                }
             }
         }
     }

--- a/Foundation Lab/Views/Examples/Xcode27/ImageInputUnavailableView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ImageInputUnavailableView.swift
@@ -1,0 +1,42 @@
+//
+//  ImageInputUnavailableView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct ImageInputUnavailableView: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.xLarge) {
+                ContentUnavailableView {
+                    Label(title, systemImage: "photo.badge.exclamationmark")
+                } description: {
+                    Text(message)
+                }
+                .frame(minHeight: 240)
+
+                Text(
+                    """
+                    The live request is unavailable in this build. You can still inspect the verified attachment shape and measured \
+                    resolution notes.
+                    """
+                )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                ImageInputResolutionFindingsView()
+                CodeDisclosure(code: ImageInputRecipe.altText.code)
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+            .frame(maxWidth: .infinity)
+        }
+        .navigationTitle("Image Input")
+        .navigationSubtitle("Attachment reference")
+    }
+}

--- a/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
+++ b/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
@@ -222,7 +222,7 @@ private extension ExampleType {
         case .privateCloudCompute:
             String(localized: "Probe PCC availability, quota, and context size")
         case .imageInputPlayground:
-            String(localized: "Inspect image attachment recipes and measured resolution boundaries")
+            String(localized: "Import an image, ask the on-device model, and inspect live usage evidence")
         case .usagePerformanceTrace:
             String(localized: "Run a real streamed response and inspect its reported usage")
         case .toolCallingModeLab:


### PR DESCRIPTION
## Summary

- replace the static image-input reference with a real iOS/macOS image importer, preview, editable prompt recipes, and on-device `Attachment<ImageAttachmentContent>` request
- coordinate security-scoped provider reads into bounded, caller-owned `Data`, preserve valid evidence through cancellation or replacement failure, and commit replacement state only after success
- surface model/vision availability, cancellation-safe run state, errors, usage metrics, transcript evidence, and attachment-segment proof
- keep API/resolution details progressively disclosed and protect the interactive lab with 64 MB encoded / 256 MB decoded-buffer limits that route stress testing to `ImageInputProbe`
- preserve an informative Xcode 26 / pre-OS 27 fallback

## Validation

- Xcode 27 beta 2: generic macOS build passed
- Xcode 27 beta 2: generic iOS Simulator build passed
- Xcode 26.6 RC 2: generic macOS and iOS Simulator builds passed
- Xcode 26.6 RC 2: `swift test` passed (48 XCTest tests plus 197 Swift Testing tests)
- SwiftLint strict and `git diff --check` passed
- live macOS 27 UI run returned a non-empty image description with 347 total tokens, 2 transcript entries, and 1 attachment segment
- importer harness verified valid/invalid images, cooperative cancellation, owned-data lifetime, oversized-file preflight rejection, and encoded/decoded safety boundaries
- view-model harness verified picker cancellation, prompt/recipe invalidation, retained replacement state, contextual failure copy, and transactional result clearing on successful commit
- the displayed owned-data/EXIF-orientation recipe type-checked verbatim under Xcode 27 beta 2
- Impeccable native UI and accessibility-tree validation covered retained replacement progress, explicit cancel controls, result/error focus, contrast, and truthful disabled-action hints

## Known beta baseline

Xcode 27 beta 2 `swift test` still stops in the existing `FoundationLabModelErrorProjectionModernTests`: the beta now requires an `explanation` argument for `LanguageModelError.Refusal`. This PR does not touch that unrelated test; app builds and the live attachment runtime smoke both pass under beta 2.
