### PR TITLE
Make reasoning and tool-mode labs interactive

### DIFF
--- a/Foundation Lab/ViewModels/ReasoningLevelComparisonViewModel.swift
+++ b/Foundation Lab/ViewModels/ReasoningLevelComparisonViewModel.swift
@@ -24,6 +24,7 @@ final class ReasoningLevelComparisonViewModel {
     }
     var results = ReasoningComparisonLevel.allCases.map { ReasoningComparisonResult.pending($0) }
     var isRunning = false
+    var isStoppingRun = false
     var activeLevel: ReasoningComparisonLevel?
     var errorMessage: String?
 
@@ -37,6 +38,7 @@ final class ReasoningLevelComparisonViewModel {
     var canRun: Bool {
         !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !isRunning
+            && !isStoppingRun
             && readinessIssue == nil
     }
 
@@ -75,7 +77,7 @@ final class ReasoningLevelComparisonViewModel {
     }
 
     func startComparison() {
-        guard !isRunning else { return }
+        guard !isRunning, !isStoppingRun else { return }
         guard let trimmedPrompt = nonemptyPrompt else { return }
         if let readinessIssue {
             errorMessage = readinessIssue
@@ -85,11 +87,9 @@ final class ReasoningLevelComparisonViewModel {
     }
 
     func cancelRun() {
-        activeRunID = nil
+        guard isRunning, !isStoppingRun else { return }
+        isStoppingRun = true
         runTask?.cancel()
-        runTask = nil
-        isRunning = false
-        activeLevel = nil
         results = results.map { result in
             guard result.state == .running else { return result }
             var cancelled = result
@@ -121,6 +121,7 @@ private extension ReasoningLevelComparisonViewModel {
         let runID = UUID()
         activeRunID = runID
         isRunning = true
+        isStoppingRun = false
         errorMessage = nil
         results = ReasoningComparisonLevel.allCases.map { ReasoningComparisonResult.pending($0) }
 
@@ -135,12 +136,15 @@ private extension ReasoningLevelComparisonViewModel {
                 activeRunID = nil
                 runTask = nil
                 isRunning = false
+                isStoppingRun = false
                 activeLevel = nil
             }
         }
 
         for level in ReasoningComparisonLevel.allCases {
-            guard activeRunID == id, self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
+            guard !Task.isCancelled,
+                  activeRunID == id,
+                  self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
                 return
             }
 
@@ -159,6 +163,7 @@ private extension ReasoningLevelComparisonViewModel {
             } catch is CancellationError {
                 return
             } catch {
+                guard !Task.isCancelled else { return }
                 guard activeRunID == id else { return }
                 update(level: level) { result in
                     result.state = .failed(error.localizedDescription)

--- a/Foundation Lab/ViewModels/ReasoningLevelComparisonViewModel.swift
+++ b/Foundation Lab/ViewModels/ReasoningLevelComparisonViewModel.swift
@@ -1,0 +1,226 @@
+//
+//  ReasoningLevelComparisonViewModel.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+import FoundationModels
+import Observation
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+@Observable
+final class ReasoningLevelComparisonViewModel {
+    static let defaultPrompt = "Plan a safe migration from callback-based networking to async/await in three ordered steps."
+
+    var prompt = defaultPrompt {
+        didSet {
+            guard prompt != oldValue else { return }
+            invalidateEditedPrompt()
+        }
+    }
+    var results = ReasoningComparisonLevel.allCases.map { ReasoningComparisonResult.pending($0) }
+    var isRunning = false
+    var activeLevel: ReasoningComparisonLevel?
+    var errorMessage: String?
+
+    private var activeRunID: UUID?
+    private var runTask: Task<Void, Never>?
+
+    var hasResults: Bool {
+        results.contains { $0.state != .pending }
+    }
+
+    var canRun: Bool {
+        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isRunning
+            && readinessIssue == nil
+    }
+
+    var readinessIssue: String? {
+        #if targetEnvironment(simulator)
+        return String(
+            localized: """
+            Private Cloud Compute reasoning runs are unavailable in Simulator. \
+            Run this lab on a supported Mac or physical device.
+            """
+        )
+        #else
+        let model = PrivateCloudComputeLanguageModel()
+
+        switch model.availability {
+        case .available:
+            break
+        case .unavailable(.deviceNotEligible):
+            return String(localized: "This device is not eligible for Private Cloud Compute.")
+        case .unavailable(.systemNotReady):
+            return String(localized: "Private Cloud Compute is not ready on this system.")
+        @unknown default:
+            return String(localized: "Private Cloud Compute is currently unavailable.")
+        }
+
+        guard !model.quotaUsage.isLimitReached else {
+            return String(localized: "The Private Cloud Compute usage limit has been reached.")
+        }
+
+        guard model.capabilities.contains(.reasoning) else {
+            return String(localized: "Private Cloud Compute does not report the reasoning capability on this runtime.")
+        }
+
+        return nil
+        #endif
+    }
+
+    func startComparison() {
+        guard !isRunning else { return }
+        guard let trimmedPrompt = nonemptyPrompt else { return }
+        if let readinessIssue {
+            errorMessage = readinessIssue
+            return
+        }
+        beginComparison(prompt: trimmedPrompt)
+    }
+
+    func cancelRun() {
+        activeRunID = nil
+        runTask?.cancel()
+        runTask = nil
+        isRunning = false
+        activeLevel = nil
+        results = results.map { result in
+            guard result.state == .running else { return result }
+            var cancelled = result
+            cancelled.state = .cancelled
+            return cancelled
+        }
+    }
+
+    func reset() {
+        cancelRun()
+        prompt = Self.defaultPrompt
+        results = ReasoningComparisonLevel.allCases.map { ReasoningComparisonResult.pending($0) }
+        errorMessage = nil
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension ReasoningLevelComparisonViewModel {
+    var nonemptyPrompt: String? {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedPrompt.isEmpty ? nil : trimmedPrompt
+    }
+
+    func beginComparison(prompt: String) {
+        cancelRun()
+
+        let runID = UUID()
+        activeRunID = runID
+        isRunning = true
+        errorMessage = nil
+        results = ReasoningComparisonLevel.allCases.map { ReasoningComparisonResult.pending($0) }
+
+        runTask = Task { @MainActor [weak self] in
+            await self?.performComparison(prompt: prompt, id: runID)
+        }
+    }
+
+    func performComparison(prompt: String, id: UUID) async {
+        defer {
+            if activeRunID == id {
+                activeRunID = nil
+                runTask = nil
+                isRunning = false
+                activeLevel = nil
+            }
+        }
+
+        for level in ReasoningComparisonLevel.allCases {
+            guard activeRunID == id, self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
+                return
+            }
+
+            activeLevel = level
+            update(level: level) { result in
+                result.state = .running
+            }
+
+            do {
+                let result = try await run(level: level, prompt: prompt)
+                try Task.checkCancellation()
+                guard activeRunID == id, self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
+                    return
+                }
+                replace(result)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard activeRunID == id else { return }
+                update(level: level) { result in
+                    result.state = .failed(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    func run(level: ReasoningComparisonLevel, prompt: String) async throws -> ReasoningComparisonResult {
+        #if targetEnvironment(simulator)
+        throw NSError(
+            domain: "FoundationLab.ReasoningLevelComparison",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: String(
+                    localized: "Private Cloud Compute reasoning runs are unavailable in Simulator."
+                )
+            ]
+        )
+        #else
+        let model = PrivateCloudComputeLanguageModel()
+        let session = LanguageModelSession(model: model)
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let response = try await session.respond(
+            to: prompt,
+            contextOptions: ContextOptions(reasoningLevel: level.frameworkValue),
+            metadata: ["foundation-lab-reasoning-level": level.rawValue]
+        )
+        let finishedAt = clock.now
+
+        return ReasoningComparisonResult(
+            level: level,
+            state: .completed,
+            response: response.content,
+            elapsed: startedAt.duration(to: finishedAt),
+            inputTokens: response.usage.input.totalTokenCount,
+            cachedInputTokens: response.usage.input.cachedTokenCount,
+            outputTokens: response.usage.output.totalTokenCount,
+            reasoningTokens: response.usage.output.reasoningTokenCount,
+            totalTokens: response.usage.totalTokenCount
+        )
+        #endif
+    }
+
+    func update(
+        level: ReasoningComparisonLevel,
+        mutation: (inout ReasoningComparisonResult) -> Void
+    ) {
+        guard let index = results.firstIndex(where: { $0.level == level }) else { return }
+        mutation(&results[index])
+    }
+
+    func replace(_ result: ReasoningComparisonResult) {
+        guard let index = results.firstIndex(where: { $0.level == result.level }) else { return }
+        results[index] = result
+    }
+
+    func invalidateEditedPrompt() {
+        cancelRun()
+        results = ReasoningComparisonLevel.allCases.map { ReasoningComparisonResult.pending($0) }
+        errorMessage = nil
+    }
+}
+#endif

--- a/Foundation Lab/ViewModels/ToolCallingModeLabViewModel.swift
+++ b/Foundation Lab/ViewModels/ToolCallingModeLabViewModel.swift
@@ -1,0 +1,216 @@
+//
+//  ToolCallingModeLabViewModel.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+import FoundationModels
+import Observation
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+@Observable
+final class ToolCallingModeLabViewModel {
+    static let defaultPrompt = "What validation result is stored for the Foundation Lab release record?"
+
+    var prompt = defaultPrompt {
+        didSet {
+            guard prompt != oldValue else { return }
+            invalidateEditedPrompt()
+        }
+    }
+    var results = ToolCallingExperimentMode.allCases.map { ToolCallingModeRunResult.pending($0) }
+    var isRunning = false
+    var activeMode: ToolCallingExperimentMode?
+    var errorMessage: String?
+
+    private var activeRunID: UUID?
+    private var runTask: Task<Void, Never>?
+
+    var canRun: Bool {
+        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isRunning
+            && readinessIssue == nil
+    }
+
+    var readinessIssue: String? {
+        let model = SystemLanguageModel.default
+        switch model.availability {
+        case .available:
+            break
+        case .unavailable(.deviceNotEligible):
+            return String(localized: "This device is not eligible for the on-device system language model.")
+        case .unavailable(.appleIntelligenceNotEnabled):
+            return String(localized: "Apple Intelligence is not enabled.")
+        case .unavailable(.modelNotReady):
+            return String(localized: "The on-device system language model is not ready.")
+        @unknown default:
+            return String(localized: "The on-device system language model is unavailable.")
+        }
+
+        guard model.capabilities.contains(.toolCalling) else {
+            return String(localized: "The system language model does not report tool-calling support on this runtime.")
+        }
+
+        return nil
+    }
+
+    func startComparison() {
+        guard !isRunning else { return }
+        guard let trimmedPrompt = nonemptyPrompt else { return }
+        if let readinessIssue {
+            errorMessage = readinessIssue
+            return
+        }
+        beginComparison(prompt: trimmedPrompt)
+    }
+
+    func cancelRun() {
+        activeRunID = nil
+        runTask?.cancel()
+        runTask = nil
+        isRunning = false
+        activeMode = nil
+        results = results.map { result in
+            guard result.state == .running else { return result }
+            var cancelled = result
+            cancelled.state = .cancelled
+            return cancelled
+        }
+    }
+
+    func reset() {
+        cancelRun()
+        prompt = Self.defaultPrompt
+        results = ToolCallingExperimentMode.allCases.map { ToolCallingModeRunResult.pending($0) }
+        errorMessage = nil
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension ToolCallingModeLabViewModel {
+    var nonemptyPrompt: String? {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedPrompt.isEmpty ? nil : trimmedPrompt
+    }
+
+    func beginComparison(prompt: String) {
+        cancelRun()
+
+        let runID = UUID()
+        activeRunID = runID
+        isRunning = true
+        errorMessage = nil
+        results = ToolCallingExperimentMode.allCases.map { ToolCallingModeRunResult.pending($0) }
+
+        runTask = Task { @MainActor [weak self] in
+            await self?.performComparison(prompt: prompt, id: runID)
+        }
+    }
+
+    func performComparison(prompt: String, id: UUID) async {
+        defer {
+            if activeRunID == id {
+                activeRunID = nil
+                runTask = nil
+                isRunning = false
+                activeMode = nil
+            }
+        }
+
+        for mode in ToolCallingExperimentMode.allCases {
+            guard activeRunID == id, self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
+                return
+            }
+
+            activeMode = mode
+            update(mode: mode) { result in
+                result.state = .running
+            }
+
+            do {
+                let result = try await run(mode: mode, prompt: prompt)
+                try Task.checkCancellation()
+                guard activeRunID == id, self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
+                    return
+                }
+                replace(result)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard activeRunID == id else { return }
+                update(mode: mode) { result in
+                    result.state = .failed(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    func run(mode: ToolCallingExperimentMode, prompt: String) async throws -> ToolCallingModeRunResult {
+        let recorder = LocalReleaseRecordExecutionRecorder()
+        let tool = LocalReleaseRecordTool(recorder: recorder)
+        let session = LanguageModelSession(profile: ToolCallingModeProfile(tool: tool, mode: mode))
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let response = try await session.respond(
+            to: prompt,
+            metadata: ["foundation-lab-tool-mode": mode.rawValue]
+        )
+        let finishedAt = clock.now
+        let localOutputs = await recorder.snapshot()
+
+        return ToolCallingModeRunResult(
+            mode: mode,
+            state: .completed,
+            modelResponse: response.content,
+            elapsed: startedAt.duration(to: finishedAt),
+            transcriptCalls: transcriptCalls(in: session.transcript),
+            transcriptOutputs: transcriptOutputs(in: session.transcript),
+            localToolOutputs: localOutputs
+        )
+    }
+
+    func transcriptCalls(in transcript: Transcript) -> [String] {
+        transcript.flatMap { entry -> [String] in
+            guard case .toolCalls(let calls) = entry else { return [] }
+            return calls.map { call in
+                let query = try? LocalReleaseRecordQuery(call.arguments)
+                let recordID = query?.recordID ?? String(localized: "Unreadable arguments")
+                return "\(call.toolName)(recordID: \(recordID))"
+            }
+        }
+    }
+
+    func transcriptOutputs(in transcript: Transcript) -> [String] {
+        transcript.compactMap { entry in
+            guard case .toolOutput(let output) = entry else { return nil }
+            let content = output.segments.textContentJoined() ?? String(localized: "No text output")
+            return "\(output.toolName): \(content)"
+        }
+    }
+
+    func update(
+        mode: ToolCallingExperimentMode,
+        mutation: (inout ToolCallingModeRunResult) -> Void
+    ) {
+        guard let index = results.firstIndex(where: { $0.mode == mode }) else { return }
+        mutation(&results[index])
+    }
+
+    func replace(_ result: ToolCallingModeRunResult) {
+        guard let index = results.firstIndex(where: { $0.mode == result.mode }) else { return }
+        results[index] = result
+    }
+
+    func invalidateEditedPrompt() {
+        cancelRun()
+        results = ToolCallingExperimentMode.allCases.map { ToolCallingModeRunResult.pending($0) }
+        errorMessage = nil
+    }
+}
+#endif

--- a/Foundation Lab/ViewModels/ToolCallingModeLabViewModel.swift
+++ b/Foundation Lab/ViewModels/ToolCallingModeLabViewModel.swift
@@ -24,6 +24,7 @@ final class ToolCallingModeLabViewModel {
     }
     var results = ToolCallingExperimentMode.allCases.map { ToolCallingModeRunResult.pending($0) }
     var isRunning = false
+    var isStoppingRun = false
     var activeMode: ToolCallingExperimentMode?
     var errorMessage: String?
 
@@ -33,6 +34,7 @@ final class ToolCallingModeLabViewModel {
     var canRun: Bool {
         !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !isRunning
+            && !isStoppingRun
             && readinessIssue == nil
     }
 
@@ -59,7 +61,7 @@ final class ToolCallingModeLabViewModel {
     }
 
     func startComparison() {
-        guard !isRunning else { return }
+        guard !isRunning, !isStoppingRun else { return }
         guard let trimmedPrompt = nonemptyPrompt else { return }
         if let readinessIssue {
             errorMessage = readinessIssue
@@ -69,11 +71,9 @@ final class ToolCallingModeLabViewModel {
     }
 
     func cancelRun() {
-        activeRunID = nil
+        guard isRunning, !isStoppingRun else { return }
+        isStoppingRun = true
         runTask?.cancel()
-        runTask = nil
-        isRunning = false
-        activeMode = nil
         results = results.map { result in
             guard result.state == .running else { return result }
             var cancelled = result
@@ -105,6 +105,7 @@ private extension ToolCallingModeLabViewModel {
         let runID = UUID()
         activeRunID = runID
         isRunning = true
+        isStoppingRun = false
         errorMessage = nil
         results = ToolCallingExperimentMode.allCases.map { ToolCallingModeRunResult.pending($0) }
 
@@ -119,12 +120,15 @@ private extension ToolCallingModeLabViewModel {
                 activeRunID = nil
                 runTask = nil
                 isRunning = false
+                isStoppingRun = false
                 activeMode = nil
             }
         }
 
         for mode in ToolCallingExperimentMode.allCases {
-            guard activeRunID == id, self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
+            guard !Task.isCancelled,
+                  activeRunID == id,
+                  self.prompt.trimmingCharacters(in: .whitespacesAndNewlines) == prompt else {
                 return
             }
 
@@ -143,6 +147,7 @@ private extension ToolCallingModeLabViewModel {
             } catch is CancellationError {
                 return
             } catch {
+                guard !Task.isCancelled else { return }
                 guard activeRunID == id else { return }
                 update(mode: mode) { result in
                     result.state = .failed(error.localizedDescription)

--- a/Foundation Lab/Views/Examples/Xcode27/InferenceExperimentRunState.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/InferenceExperimentRunState.swift
@@ -1,0 +1,12 @@
+//
+//  InferenceExperimentRunState.swift
+//  FoundationLab
+//
+
+nonisolated enum InferenceExperimentRunState: Equatable, Sendable {
+    case pending
+    case running
+    case completed
+    case cancelled
+    case failed(String)
+}

--- a/Foundation Lab/Views/Examples/Xcode27/LocalReleaseRecordExecutionRecorder.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/LocalReleaseRecordExecutionRecorder.swift
@@ -1,0 +1,18 @@
+//
+//  LocalReleaseRecordExecutionRecorder.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+actor LocalReleaseRecordExecutionRecorder {
+    private var outputs: [String] = []
+
+    func record(_ output: String) {
+        outputs.append(output)
+    }
+
+    func snapshot() -> [String] {
+        outputs
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/LocalReleaseRecordQuery.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/LocalReleaseRecordQuery.swift
@@ -1,0 +1,17 @@
+//
+//  LocalReleaseRecordQuery.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@Generable
+struct LocalReleaseRecordQuery {
+    @Guide(description: "The record identifier. Use foundation-lab for this experiment.")
+    let recordID: String
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/LocalReleaseRecordTool.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/LocalReleaseRecordTool.swift
@@ -1,0 +1,33 @@
+//
+//  LocalReleaseRecordTool.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import Foundation
+import FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct LocalReleaseRecordTool: Tool {
+    let name = "read_local_release_record"
+    let description = "Reads a deterministic, read-only sample record bundled with Foundation Lab."
+    let recorder: LocalReleaseRecordExecutionRecorder
+
+    @concurrent
+    func call(arguments: LocalReleaseRecordQuery) async throws -> String {
+        let recordID = arguments.recordID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let output: String
+
+        if recordID == "foundation-lab" {
+            output = "Local fixture foundation-lab: macOS generic build passed; iOS generic build passed; review status is ready."
+        } else {
+            output = "Local fixture has no record with identifier \(arguments.recordID)."
+        }
+
+        await recorder.record(output)
+        return output
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningComparisonLevel.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningComparisonLevel.swift
@@ -1,0 +1,69 @@
+//
+//  ReasoningComparisonLevel.swift
+//  FoundationLab
+//
+
+import Foundation
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+nonisolated enum ReasoningComparisonLevel: String, CaseIterable, Identifiable, Sendable {
+    case light
+    case moderate
+    case deep
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .light:
+            String(localized: "Light")
+        case .moderate:
+            String(localized: "Moderate")
+        case .deep:
+            String(localized: "Deep")
+        }
+    }
+
+    var requestedBudgetDescription: String {
+        switch self {
+        case .light:
+            String(localized: "Requests a light reasoning budget for this response.")
+        case .moderate:
+            String(localized: "Requests a moderate reasoning budget for this response.")
+        case .deep:
+            String(localized: "Requests a deep reasoning budget for this response.")
+        }
+    }
+
+    var code: String {
+        """
+        import FoundationModels
+
+        let model = PrivateCloudComputeLanguageModel()
+        let session = LanguageModelSession(model: model)
+        let response = try await session.respond(
+            to: prompt,
+            contextOptions: ContextOptions(reasoningLevel: .\(rawValue))
+        )
+
+        print(response.content)
+        print(response.usage.output.reasoningTokenCount)
+        """
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    var frameworkValue: ContextOptions.ReasoningLevel {
+        switch self {
+        case .light:
+            .light
+        case .moderate:
+            .moderate
+        case .deep:
+            .deep
+        }
+    }
+    #endif
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningComparisonResult.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningComparisonResult.swift
@@ -1,0 +1,24 @@
+//
+//  ReasoningComparisonResult.swift
+//  FoundationLab
+//
+
+import Foundation
+
+nonisolated struct ReasoningComparisonResult: Identifiable, Sendable {
+    let level: ReasoningComparisonLevel
+    var state: InferenceExperimentRunState
+    var response: String?
+    var elapsed: Duration?
+    var inputTokens: Int?
+    var cachedInputTokens: Int?
+    var outputTokens: Int?
+    var reasoningTokens: Int?
+    var totalTokens: Int?
+
+    var id: ReasoningComparisonLevel { level }
+
+    static func pending(_ level: ReasoningComparisonLevel) -> Self {
+        ReasoningComparisonResult(level: level, state: .pending)
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningComparisonResultView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningComparisonResultView.swift
@@ -1,0 +1,75 @@
+//
+//  ReasoningComparisonResultView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct ReasoningComparisonResultView: View {
+    let result: ReasoningComparisonResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            Text(result.level.requestedBudgetDescription)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            switch result.state {
+            case .pending:
+                Label("Not run yet", systemImage: "circle.dashed")
+                    .foregroundStyle(.secondary)
+            case .running:
+                HStack(spacing: Spacing.small) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Waiting for the framework response…")
+                }
+                .foregroundStyle(.secondary)
+            case .cancelled:
+                Label("Run stopped before this response completed.", systemImage: "stop.circle")
+                    .foregroundStyle(.secondary)
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            case .completed:
+                completedContent
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var completedContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            Xcode27KeyValueList(items: [
+                (String(localized: "Elapsed"), durationLabel(result.elapsed)),
+                (String(localized: "Input"), tokenLabel(result.inputTokens)),
+                (String(localized: "Cached input"), tokenLabel(result.cachedInputTokens)),
+                (String(localized: "Output"), tokenLabel(result.outputTokens)),
+                (String(localized: "Reasoning output"), tokenLabel(result.reasoningTokens)),
+                (String(localized: "Total"), tokenLabel(result.totalTokens))
+            ])
+
+            if let response = result.response {
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    Text("Model response")
+                        .font(.headline)
+                    Text(response)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func tokenLabel(_ count: Int?) -> String {
+        guard let count else { return String(localized: "Not reported") }
+        return count == 1 ? String(localized: "1 token") : String(localized: "\(count) tokens")
+    }
+
+    private func durationLabel(_ duration: Duration?) -> String {
+        guard let duration else { return String(localized: "Not measured") }
+        let components = duration.components
+        let seconds = Double(components.seconds) + Double(components.attoseconds) / 1e18
+        return String(localized: "\(seconds.formatted(.number.precision(.fractionLength(2)))) s")
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonLiveView.swift
@@ -92,6 +92,7 @@ struct ReasoningLevelComparisonLiveView: View {
                 TextField("Enter one prompt for all three levels", text: Bindable(model).prompt, axis: .vertical)
                     .lineLimit(4...8)
                     .textFieldStyle(.roundedBorder)
+                    .disabled(model.isRunning || model.isStoppingRun)
                     .accessibilityHint("The same prompt is sent to a new session for each reasoning level")
 
                 HStack {
@@ -99,17 +100,18 @@ struct ReasoningLevelComparisonLiveView: View {
                         .buttonStyle(.borderless)
                         .padding(.vertical, Spacing.medium)
                         .contentShape(.rect)
+                        .disabled(model.isRunning || model.isStoppingRun)
 
                     Spacer()
 
                     Button(
-                        model.isRunning ? "Stop" : "Run 3 Levels",
-                        systemImage: model.isRunning ? "stop.fill" : "play.fill",
+                        model.isStoppingRun ? "Stopping…" : (model.isRunning ? "Stop" : "Run 3 Levels"),
+                        systemImage: model.isStoppingRun ? "hourglass" : (model.isRunning ? "stop.fill" : "play.fill"),
                         action: toggleRun
                     )
                     .buttonStyle(.glassProminent)
                     .controlSize(.large)
-                    .disabled(!model.isRunning && !model.canRun)
+                    .disabled(model.isStoppingRun || (!model.isRunning && !model.canRun))
                 }
             }
         }

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonLiveView.swift
@@ -1,0 +1,158 @@
+//
+//  ReasoningLevelComparisonLiveView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ReasoningLevelComparisonLiveView: View {
+    @State private var model = ReasoningLevelComparisonViewModel()
+    @State private var selectedLevel = ReasoningComparisonLevel.moderate
+
+    var body: some View {
+        @Bindable var model = model
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.xLarge) {
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Compare requested reasoning budgets")
+                        .font(.title2.bold())
+                    Text("Send one prompt through fresh light, moderate, and deep Private Cloud Compute sessions.")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                runtimeStatus
+                promptSection
+
+                if let errorMessage = model.errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .padding(Spacing.medium)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.red.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+                }
+
+                resultsSection
+                measurementBoundary
+                CodeDisclosure(code: selectedLevel.code)
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+            .frame(maxWidth: .infinity)
+        }
+        #if os(iOS)
+        .scrollDismissesKeyboard(.interactively)
+        #endif
+        .navigationTitle("Reasoning Levels")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Inspect real responses and usage")
+        #endif
+        .onChange(of: model.activeLevel) { _, level in
+            if let level {
+                selectedLevel = level
+            }
+        }
+        .onDisappear(perform: model.cancelRun)
+    }
+
+    private var runtimeStatus: some View {
+        Xcode27Section(String(localized: "Runtime")) {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                Label("Private Cloud Compute", systemImage: "icloud")
+                    .font(.callout)
+
+                if let issue = model.readinessIssue {
+                    Label(issue, systemImage: "exclamationmark.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                } else {
+                    Label("Available and reporting reasoning support", systemImage: "checkmark.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Running the comparison makes three separate PCC requests and consumes the corresponding usage quota.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var promptSection: some View {
+        Xcode27Section(String(localized: "Shared Prompt")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                TextField("Enter one prompt for all three levels", text: Bindable(model).prompt, axis: .vertical)
+                    .lineLimit(4...8)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityHint("The same prompt is sent to a new session for each reasoning level")
+
+                HStack {
+                    Button("Reset", systemImage: "arrow.counterclockwise", action: model.reset)
+                        .buttonStyle(.borderless)
+                        .padding(.vertical, Spacing.medium)
+                        .contentShape(.rect)
+
+                    Spacer()
+
+                    Button(
+                        model.isRunning ? "Stop" : "Run 3 Levels",
+                        systemImage: model.isRunning ? "stop.fill" : "play.fill",
+                        action: toggleRun
+                    )
+                    .buttonStyle(.glassProminent)
+                    .controlSize(.large)
+                    .disabled(!model.isRunning && !model.canRun)
+                }
+            }
+        }
+    }
+
+    private var resultsSection: some View {
+        Xcode27Section(String(localized: "Observed Results")) {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Picker("Reasoning level", selection: $selectedLevel) {
+                    ForEach(ReasoningComparisonLevel.allCases) { level in
+                        Text(level.title).tag(level)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if let result = model.results.first(where: { $0.level == selectedLevel }) {
+                    ReasoningComparisonResultView(result: result)
+                }
+            }
+        }
+    }
+
+    private var measurementBoundary: some View {
+        Xcode27Section(String(localized: "Interpretation")) {
+            Text(
+                """
+                Token counts come from Response.Usage. Elapsed time is this app's wall-clock observation of sequential requests. \
+                Network conditions, service load, caching, generation variance, and run order are uncontrolled, so these results do \
+                not establish that a reasoning level caused a latency or quality difference.
+                """
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func toggleRun() {
+        if model.isRunning {
+            model.cancelRun()
+        } else {
+            model.startComparison()
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ReasoningLevelComparisonView.swift
@@ -2,114 +2,29 @@
 //  ReasoningLevelComparisonView.swift
 //  FoundationLab
 //
-//  Created by Codex on 6/8/26.
-//
 
 import SwiftUI
 
 struct ReasoningLevelComparisonView: View {
-    @State private var selectedLevel = ReasoningComparisonLevel.moderate
-
     var body: some View {
-        ReferenceExampleView(
-            title: String(localized: "Reasoning Levels"),
-            description: String(localized: "Inspect light, moderate, and deep ContextOptions"),
-            codeExample: selectedLevel.code,
-            referenceNote: String(localized: """
-            Choose a level to inspect its ContextOptions recipe. This page describes the requested reasoning budget; it does not run a \
-            comparison.
-            """)
-        ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Reasoning level", selection: $selectedLevel) {
-                    ForEach(ReasoningComparisonLevel.allCases) { level in
-                        Text(level.title).tag(level)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Xcode27Section(selectedLevel.title) {
-                    VStack(alignment: .leading, spacing: Spacing.medium) {
-                        Text(selectedLevel.detail)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-
-                        LabeledContent("Framework effect") {
-                            Text(selectedLevel.frameworkEffect)
-                                .multilineTextAlignment(.trailing)
-                        }
-                        .font(.callout)
-                    }
-                }
-
-                Xcode27Section(String(localized: "ContextOptions")) {
-                    Text(
-                        """
-                        Xcode 27 adds ContextOptions(reasoningLevel:) so examples can make reasoning depth an explicit runtime choice \
-                        instead of burying it in prompt wording.
-                        """
-                    )
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            ReasoningLevelComparisonLiveView()
+        } else {
+            unsupportedView
         }
+        #else
+        unsupportedView
+        #endif
     }
 
-}
-
-private enum ReasoningComparisonLevel: String, CaseIterable, Identifiable {
-    case light
-    case moderate
-    case deep
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .light: String(localized: "Light")
-        case .moderate: String(localized: "Moderate")
-        case .deep: String(localized: "Deep")
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .light:
-            return String(localized: "Use light reasoning for fast rewrites, labels, small summaries, and simple classification.")
-        case .moderate:
-            return String(localized: "Use moderate reasoning for normal app flows where the response needs a little planning.")
-        case .deep:
-            return String(localized: "Use deep reasoning for migration plans, multi-step tradeoffs, and complex tool orchestration.")
-        }
-    }
-
-    var frameworkEffect: String {
-        switch self {
-        case .light:
-            return String(localized: "Allows less thinking before the response.")
-        case .moderate:
-            return String(localized: "Allows a moderate amount of thinking before the response.")
-        case .deep:
-            return String(localized: "Allows more thinking before the response.")
-        }
-    }
-
-    var code: String {
-        """
-        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-            let context = ContextOptions(
-                includeSchemaInPrompt: true,
-                reasoningLevel: .\(rawValue)
-            )
-
-            let session = LanguageModelSession()
-            let response = try await session.respond(
-                to: Prompt("Plan the migration."),
-                contextOptions: context
-            )
-        }
-        """
+    private var unsupportedView: some View {
+        ContentUnavailableView(
+            "OS 27 Required",
+            systemImage: "brain.head.profile.slash",
+            description: Text("Live reasoning levels require the Xcode 27 SDK and an OS 27 runtime.")
+        )
+        .navigationTitle("Reasoning Levels")
     }
 }
 

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingExperimentMode.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingExperimentMode.swift
@@ -1,0 +1,97 @@
+//
+//  ToolCallingExperimentMode.swift
+//  FoundationLab
+//
+
+import Foundation
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+nonisolated enum ToolCallingExperimentMode: String, CaseIterable, Identifiable, Sendable {
+    case allowed
+    case required
+    case disallowed
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .allowed:
+            String(localized: "Allowed")
+        case .required:
+            String(localized: "Required")
+        case .disallowed:
+            String(localized: "Disallowed")
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .allowed:
+            String(localized: "The model may call the local tool, but the mode does not guarantee a call.")
+        case .required:
+            String(
+                localized: "The first generation step requires a tool call; the profile then switches to allowed so the model can answer."
+            )
+        case .disallowed:
+            String(localized: "The tool remains registered, but the model is prevented from calling it for this response.")
+        }
+    }
+
+    var code: String {
+        if self == .required {
+            return Self.requiredCode
+        }
+
+        return """
+        let profile = LanguageModelSession.Profile {
+            Instructions("Use the read-only local record when it is available.")
+            LocalReleaseRecordTool(recorder: recorder)
+        }
+        .toolCallingMode(.\(rawValue))
+
+        let session = LanguageModelSession(profile: profile)
+        let response = try await session.respond(to: prompt)
+        inspect(session.transcript)
+        """
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    var frameworkValue: GenerationOptions.ToolCallingMode {
+        switch self {
+        case .allowed:
+            .allowed
+        case .required:
+            .required
+        case .disallowed:
+            .disallowed
+        }
+    }
+    #endif
+
+    private static let requiredCode = """
+    extension SessionPropertyValues {
+        @SessionPropertyEntry
+        var toolCallingLabCallCount = 0
+    }
+
+    struct RequiredToolProfile: LanguageModelSession.DynamicProfile {
+        let tool: LocalReleaseRecordTool
+
+        @SessionProperty(\\.toolCallingLabCallCount)
+        private var callCount
+
+        var body: some LanguageModelSession.DynamicProfile {
+            LanguageModelSession.Profile { tool }
+                .toolCallingMode(callCount == 0 ? .required : .allowed)
+                .onToolCall { callCount += 1 }
+        }
+    }
+
+    let session = LanguageModelSession(profile: RequiredToolProfile(tool: tool))
+    let response = try await session.respond(to: prompt)
+    inspect(session.transcript)
+    """
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabLiveView.swift
@@ -1,0 +1,168 @@
+//
+//  ToolCallingModeLabLiveView.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import SwiftUI
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ToolCallingModeLabLiveView: View {
+    @State private var model = ToolCallingModeLabViewModel()
+    @State private var selectedMode = ToolCallingExperimentMode.allowed
+
+    var body: some View {
+        @Bindable var model = model
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Spacing.xLarge) {
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Observe tool policy in the transcript")
+                        .font(.title2.bold())
+                    Text("Run one prompt with allowed, required, and disallowed tool calling against a read-only local fixture.")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                runtimeStatus
+                localFixture
+                promptSection
+
+                if let errorMessage = model.errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .padding(Spacing.medium)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.red.opacity(0.08), in: .rect(cornerRadius: CornerRadius.medium))
+                }
+
+                resultsSection
+                policyBoundary
+                CodeDisclosure(code: selectedMode.code)
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.vertical, Spacing.large)
+            .frame(maxWidth: .infinity)
+        }
+        #if os(iOS)
+        .scrollDismissesKeyboard(.interactively)
+        #endif
+        .navigationTitle("Tool Calling Modes")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .navigationSubtitle("Compare real calls and outputs")
+        #endif
+        .onChange(of: model.activeMode) { _, mode in
+            if let mode {
+                selectedMode = mode
+            }
+        }
+        .onDisappear(perform: model.cancelRun)
+    }
+
+    private var runtimeStatus: some View {
+        Xcode27Section(String(localized: "Runtime")) {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                Label("On-device system language model", systemImage: "apple.intelligence")
+                    .font(.callout)
+
+                if let issue = model.readinessIssue {
+                    Label(issue, systemImage: "exclamationmark.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                } else {
+                    Label("Available and reporting tool-calling support", systemImage: "checkmark.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var localFixture: some View {
+        Xcode27Section(String(localized: "Read-only Local Tool")) {
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                LabeledContent("Tool", value: "read_local_release_record")
+                LabeledContent("Fixture record", value: "foundation-lab")
+                Text("The tool reads deterministic sample text bundled with this lab. It performs no network request and changes no data.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .font(.callout)
+        }
+    }
+
+    private var promptSection: some View {
+        Xcode27Section(String(localized: "Shared Prompt")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                TextField("Ask about the local fixture", text: Bindable(model).prompt, axis: .vertical)
+                    .lineLimit(3...7)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityHint("The same prompt is sent to a new session for each tool-calling mode")
+
+                HStack {
+                    Button("Reset", systemImage: "arrow.counterclockwise", action: model.reset)
+                        .buttonStyle(.borderless)
+                        .padding(.vertical, Spacing.medium)
+                        .contentShape(.rect)
+
+                    Spacer()
+
+                    Button(
+                        model.isRunning ? "Stop" : "Run 3 Modes",
+                        systemImage: model.isRunning ? "stop.fill" : "play.fill",
+                        action: toggleRun
+                    )
+                    .buttonStyle(.glassProminent)
+                    .controlSize(.large)
+                    .disabled(!model.isRunning && !model.canRun)
+                }
+            }
+        }
+    }
+
+    private var resultsSection: some View {
+        Xcode27Section(String(localized: "Observed Results")) {
+            VStack(alignment: .leading, spacing: Spacing.large) {
+                Picker("Tool-calling mode", selection: $selectedMode) {
+                    ForEach(ToolCallingExperimentMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if let result = model.results.first(where: { $0.mode == selectedMode }) {
+                    ToolCallingModeResultView(result: result)
+                }
+            }
+        }
+    }
+
+    private var policyBoundary: some View {
+        Xcode27Section(String(localized: "Interpretation")) {
+            Text(
+                """
+                Transcript calls and outputs come from the real LanguageModelSession transcript. Local executions are recorded inside \
+                the deterministic tool itself; the model response is shown separately. Allowed permits but does not require a call. \
+                Required forces the first call, then this lab switches to allowed so the model can finish its answer.
+                """
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func toggleRun() {
+        if model.isRunning {
+            model.cancelRun()
+        } else {
+            model.startComparison()
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabLiveView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabLiveView.swift
@@ -102,6 +102,7 @@ struct ToolCallingModeLabLiveView: View {
                 TextField("Ask about the local fixture", text: Bindable(model).prompt, axis: .vertical)
                     .lineLimit(3...7)
                     .textFieldStyle(.roundedBorder)
+                    .disabled(model.isRunning || model.isStoppingRun)
                     .accessibilityHint("The same prompt is sent to a new session for each tool-calling mode")
 
                 HStack {
@@ -109,17 +110,18 @@ struct ToolCallingModeLabLiveView: View {
                         .buttonStyle(.borderless)
                         .padding(.vertical, Spacing.medium)
                         .contentShape(.rect)
+                        .disabled(model.isRunning || model.isStoppingRun)
 
                     Spacer()
 
                     Button(
-                        model.isRunning ? "Stop" : "Run 3 Modes",
-                        systemImage: model.isRunning ? "stop.fill" : "play.fill",
+                        model.isStoppingRun ? "Stopping…" : (model.isRunning ? "Stop" : "Run 3 Modes"),
+                        systemImage: model.isStoppingRun ? "hourglass" : (model.isRunning ? "stop.fill" : "play.fill"),
                         action: toggleRun
                     )
                     .buttonStyle(.glassProminent)
                     .controlSize(.large)
-                    .disabled(!model.isRunning && !model.canRun)
+                    .disabled(model.isStoppingRun || (!model.isRunning && !model.canRun))
                 }
             }
         }

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeLabView.swift
@@ -2,185 +2,30 @@
 //  ToolCallingModeLabView.swift
 //  FoundationLab
 //
-//  Created by Codex on 6/8/26.
-//
 
-import FoundationModels
 import SwiftUI
 
 struct ToolCallingModeLabView: View {
-    @State private var selectedMode = ToolModeExample.allowed
-
     var body: some View {
-        ReferenceExampleView(
-            title: String(localized: "Tool Calling Modes"),
-            description: String(localized: "Inspect allowed, required, and disallowed tool behavior"),
-            codeExample: selectedMode.code,
-            referenceNote: String(
-                localized: "Choose a mode to inspect the corresponding GenerationOptions recipe. This page does not call a model or tool."
-            )
-        ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Tool mode", selection: $selectedMode) {
-                    ForEach(ToolModeExample.allCases) { mode in
-                        Text(mode.title).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Xcode27Section(selectedMode.title) {
-                    Text(selectedMode.explanation)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-
-                Xcode27Section(String(localized: "Behavior Matrix")) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(ToolModeExample.allCases) { mode in
-                            HStack {
-                                Xcode27InfoRow(
-                                    title: mode.title,
-                                    detail: mode.shortDescription,
-                                    systemImage: mode.icon,
-                                    tint: mode == selectedMode ? .blue : .secondary
-                                )
-
-                                if mode == selectedMode {
-                                    Image(systemName: "checkmark")
-                                        .foregroundStyle(.blue)
-                                        .accessibilityLabel("Selected")
-                                }
-                            }
-                            .frame(minHeight: 44)
-                            .accessibilityElement(children: .combine)
-
-                            if mode != ToolModeExample.allCases.last {
-                                Divider()
-                            }
-                        }
-                    }
-                }
-            }
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+            ToolCallingModeLabLiveView()
+        } else {
+            unsupportedView
         }
+        #else
+        unsupportedView
+        #endif
     }
 
-}
-
-private enum ToolModeExample: String, CaseIterable, Identifiable {
-    case allowed
-    case required
-    case disallowed
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .allowed:
-            return String(localized: "Allowed")
-        case .required:
-            return String(localized: "Required")
-        case .disallowed:
-            return String(localized: "Disallowed")
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .allowed:
-            return "checkmark.circle"
-        case .required:
-            return "exclamationmark.circle"
-        case .disallowed:
-            return "nosign"
-        }
-    }
-
-    var shortDescription: String {
-        switch self {
-        case .allowed:
-            return String(localized: "The model may call tools if they help.")
-        case .required:
-            return String(localized: "The model must call a tool before answering.")
-        case .disallowed:
-            return String(localized: "The model must answer without tool calls.")
-        }
-    }
-
-    var explanation: String {
-        switch self {
-        case .allowed:
-            return String(localized: "Use this for normal agentic flows where a tool is available but not always necessary.")
-        case .required:
-            return String(
-                localized: """
-                Use this when the response must be grounded in a tool result. Always define an exit condition; this recipe switches to \
-                Allowed after the first tool call so the model can answer.
-                """
-            )
-        case .disallowed:
-            return String(localized: "Use this for pure language tasks, drafts, or contexts where external actions would be surprising.")
-        }
-    }
-
-    var code: String {
-        if self == .required {
-            return Self.requiredModeCode
-        }
-
-        return """
-        import FoundationModels
-        import FoundationModelsTools
-
-        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-            let options = GenerationOptions(
-                samplingMode: nil,
-                temperature: 0.2,
-                maximumResponseTokens: 200,
-                toolCallingMode: .\(rawValue)
-            )
-
-            let session = LanguageModelSession(tools: [WeatherTool()])
-            let response = try await session.respond(
-                to: Prompt("What is the weather in Cupertino?"),
-                options: options
-            )
-        }
-        """
-    }
-
-    private static let requiredModeCode = """
-    import FoundationModels
-    import FoundationModelsTools
-
-    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
-    extension SessionPropertyValues {
-        @SessionPropertyEntry
-        var weatherToolCallCount = 0
-    }
-
-    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
-    struct RequiredWeatherProfile: LanguageModelSession.DynamicProfile {
-        @SessionProperty(\\.weatherToolCallCount)
-        var weatherToolCallCount
-
-        var body: some LanguageModelSession.DynamicProfile {
-            LanguageModelSession.Profile {
-                WeatherTool()
-            }
-            .toolCallingMode(weatherToolCallCount == 0 ? .required : .allowed)
-            .onToolCall {
-                weatherToolCallCount += 1
-            }
-        }
-    }
-
-    if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
-        let session = LanguageModelSession(profile: RequiredWeatherProfile())
-        let response = try await session.respond(
-            to: Prompt("What is the weather in Cupertino?")
+    private var unsupportedView: some View {
+        ContentUnavailableView(
+            "OS 27 Required",
+            systemImage: "wrench.and.screwdriver.fill",
+            description: Text("Live tool-calling modes require the Xcode 27 SDK and an OS 27 runtime.")
         )
+        .navigationTitle("Tool Calling Modes")
     }
-    """
 }
 
 #Preview {

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeProfile.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeProfile.swift
@@ -1,0 +1,51 @@
+//
+//  ToolCallingModeProfile.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension SessionPropertyValues {
+    @SessionPropertyEntry
+    var toolCallingLabCallCount = 0
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ToolCallingModeProfile: LanguageModelSession.DynamicProfile {
+    let tool: LocalReleaseRecordTool
+    let mode: ToolCallingExperimentMode
+
+    @SessionProperty(\.toolCallingLabCallCount)
+    private var callCount
+
+    var body: some LanguageModelSession.DynamicProfile {
+        LanguageModelSession.Profile {
+            Instructions(
+                """
+                The read-only local tool is the only source for the app's fixture release record. Use it when policy permits. If \
+                tool calling is unavailable, say that you cannot inspect the local record instead of inventing its contents.
+                """
+            )
+            tool
+        }
+        .toolCallingMode(effectiveMode)
+        .onToolCall {
+            callCount += 1
+        }
+    }
+
+    private var effectiveMode: GenerationOptions.ToolCallingMode {
+        if mode == .required, callCount > 0 {
+            .allowed
+        } else {
+            mode.frameworkValue
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeResultView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeResultView.swift
@@ -1,0 +1,100 @@
+//
+//  ToolCallingModeResultView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct ToolCallingModeResultView: View {
+    let result: ToolCallingModeRunResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            Text(result.mode.explanation)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            switch result.state {
+            case .pending:
+                Label("Not run yet", systemImage: "circle.dashed")
+                    .foregroundStyle(.secondary)
+            case .running:
+                HStack(spacing: Spacing.small) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Waiting for the framework response…")
+                }
+                .foregroundStyle(.secondary)
+            case .cancelled:
+                Label("Run stopped before this mode completed.", systemImage: "stop.circle")
+                    .foregroundStyle(.secondary)
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            case .completed:
+                completedContent
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var completedContent: some View {
+        VStack(alignment: .leading, spacing: Spacing.large) {
+            Xcode27KeyValueList(items: [
+                (String(localized: "Transcript calls"), result.transcriptCalls.count.formatted()),
+                (String(localized: "Local executions"), result.localToolOutputs.count.formatted()),
+                (String(localized: "Elapsed"), durationLabel(result.elapsed))
+            ])
+
+            evidenceSection
+
+            if let modelResponse = result.modelResponse {
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    Text("Model response")
+                        .font(.headline)
+                    Text(modelResponse)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private var evidenceSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            Text("Execution evidence")
+                .font(.headline)
+
+            if result.transcriptCalls.isEmpty {
+                Label("The transcript contains no tool call.", systemImage: "minus.circle")
+                    .foregroundStyle(.secondary)
+            } else {
+                evidenceList(title: String(localized: "Transcript call"), values: result.transcriptCalls)
+                evidenceList(title: String(localized: "Transcript output"), values: result.transcriptOutputs)
+                evidenceList(title: String(localized: "Local tool data"), values: result.localToolOutputs)
+            }
+        }
+    }
+
+    private func evidenceList(title: String, values: [String]) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            Text(title)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            ForEach(values, id: \.self) { value in
+                Text(value)
+                    .font(.callout.monospaced())
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func durationLabel(_ duration: Duration?) -> String {
+        guard let duration else { return String(localized: "Not measured") }
+        let components = duration.components
+        let seconds = Double(components.seconds) + Double(components.attoseconds) / 1e18
+        return String(localized: "\(seconds.formatted(.number.precision(.fractionLength(2)))) s")
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeRunResult.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallingModeRunResult.swift
@@ -1,0 +1,28 @@
+//
+//  ToolCallingModeRunResult.swift
+//  FoundationLab
+//
+
+import Foundation
+
+nonisolated struct ToolCallingModeRunResult: Identifiable, Sendable {
+    let mode: ToolCallingExperimentMode
+    var state: InferenceExperimentRunState
+    var modelResponse: String?
+    var elapsed: Duration?
+    var transcriptCalls: [String]
+    var transcriptOutputs: [String]
+    var localToolOutputs: [String]
+
+    var id: ToolCallingExperimentMode { mode }
+
+    static func pending(_ mode: ToolCallingExperimentMode) -> Self {
+        ToolCallingModeRunResult(
+            mode: mode,
+            state: .pending,
+            transcriptCalls: [],
+            transcriptOutputs: [],
+            localToolOutputs: []
+        )
+    }
+}

--- a/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
+++ b/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
@@ -226,7 +226,7 @@ private extension ExampleType {
         case .usagePerformanceTrace:
             String(localized: "Run a real streamed response and inspect its reported usage")
         case .toolCallingModeLab:
-            String(localized: "Inspect allowed, required, and disallowed tool behavior")
+            String(localized: "Run allowed, required, and disallowed modes with a local read-only tool")
         case .riskyToolConfirmation:
             String(localized: "Keep side-effect authorization inside app-owned tool code")
         case .foundationModelsSecurityPlayground:
@@ -236,7 +236,7 @@ private extension ExampleType {
         case .dynamicProfileBuilder:
             String(localized: "Compose a LanguageModelSession.Profile recipe")
         case .reasoningLevelComparison:
-            String(localized: "Inspect light, moderate, and deep ContextOptions")
+            String(localized: "Run one prompt across light, moderate, and deep reasoning budgets")
         case .transcriptExplorer:
             String(localized: "Inspect reasoning, attachment, and custom transcript cases")
         case .agentFlowInspector:


### PR DESCRIPTION
## Summary

- replace the static Reasoning Levels reference with a live Private Cloud Compute comparison across light, moderate, and deep budgets
- replace the static Tool Modes reference with a live allowed/required/disallowed experiment backed by a deterministic read-only local tool
- expose real framework responses, usage, elapsed time, transcript calls/outputs, and local execution evidence
- add availability, capability, quota, stale-run, and Simulator PCC safety guards while preserving Xcode 26 / pre-OS 27 fallbacks
- keep Stop honest: cancelled requests retain run ownership and disable reruns until the underlying framework task exits

## Validation

- strict SwiftLint: 0 violations
- Xcode 27 Beta 2: generic macOS app build
- Xcode 27 Beta 2: generic iOS Simulator app build
- Xcode 26.6 RC 2: full swift test suite (48 XCTest + 197 Swift Testing tests)
- combined branch includes merged #184–#186 and passes the same builds/tests
- iOS 27 Beta 2 simulator interaction: allowed and required each produced one real local tool execution; disallowed produced zero; transcript and recorder evidence matched
- iOS 27 Beta 2 simulator safety: PCC run is disabled before model construction with supported-device guidance
