### PR TITLE
Build live transcript and tool trajectory labs

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -171,7 +171,7 @@ extension ExampleType {
         case .reasoningLevelComparison:
             return "Compare light, moderate, and deep reasoning"
         case .transcriptExplorer:
-            return "Browse reasoning, attachments, and custom segments"
+            return "Run a session and inspect its observed transcript"
         case .agentFlowInspector:
             return "Inspect an agent turn from profile to usage"
         case .historyTransformLab:
@@ -183,7 +183,7 @@ extension ExampleType {
         case .contextBudgetVisualizer:
             return "Show kept, summarized, and dropped context"
         case .toolCallTrajectoryViewer:
-            return "Compare expected and actual tool paths"
+            return "Capture and verify an actual tool path"
         case .foundationModelsSecurityPlayground:
             return "Inspect framework guarantees and app-owned boundaries"
         case .usagePerformanceTrace:

--- a/Foundation Lab/Views/Examples/Xcode27/SessionObservabilityProfile.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SessionObservabilityProfile.swift
@@ -1,0 +1,44 @@
+//
+//  SessionObservabilityProfile.swift
+//  FoundationLab
+//
+
+#if compiler(>=6.4)
+import FoundationLabCore
+import FoundationModels
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension SessionPropertyValues {
+    @SessionPropertyEntry
+    var sessionObservabilityToolCallCount = 0
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct SessionObservabilityProfile: LanguageModelSession.DynamicProfile {
+    private let tool = FoundationLabSessionObservabilityTool()
+    let reasoningLevel: ContextOptions.ReasoningLevel?
+
+    @SessionProperty(\.sessionObservabilityToolCallCount)
+    private var toolCallCount
+
+    var body: some LanguageModelSession.DynamicProfile {
+        LanguageModelSession.Profile {
+            Instructions("""
+            Demonstrate an observable, read-only tool turn. Use the registered in-memory fact tool before answering, then ground the \
+            answer only in its output. Never claim that another tool ran.
+            """)
+            tool
+        }
+        .reasoningLevel(reasoningLevel)
+        .toolCallingMode(toolCallCount == 0 ? .required : .allowed)
+        .maximumResponseTokens(300)
+        .onToolCall {
+            toolCallCount += 1
+        }
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/SessionObservabilityRunner.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SessionObservabilityRunner.swift
@@ -1,0 +1,70 @@
+//
+//  SessionObservabilityRunner.swift
+//  FoundationLab
+//
+
+import Foundation
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+enum SessionObservabilityRunner {
+    enum RunError: LocalizedError {
+        case modelUnavailable
+        case toolCallingUnavailable
+        case emptyTranscript
+
+        var errorDescription: String? {
+            switch self {
+            case .modelUnavailable:
+                String(localized: "The on-device system language model is unavailable.")
+            case .toolCallingUnavailable:
+                String(localized: "This system language model does not support tool calling, which this lab requires.")
+            case .emptyTranscript:
+                String(localized: "The session completed without observable transcript entries.")
+            }
+        }
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    static func run(
+        prompt: String,
+        labIdentifier: String,
+        requestsReasoning: Bool = false
+    ) async throws -> SessionTranscriptSnapshot {
+        let model = SystemLanguageModel.default
+        guard model.isAvailable else {
+            throw RunError.modelUnavailable
+        }
+        guard model.capabilities.contains(.toolCalling) else {
+            throw RunError.toolCallingUnavailable
+        }
+
+        let reasoningLevel: ContextOptions.ReasoningLevel? = if requestsReasoning,
+                                                               model.capabilities.contains(.reasoning) {
+            .moderate
+        } else {
+            nil
+        }
+
+        let session = LanguageModelSession(
+            profile: SessionObservabilityProfile(reasoningLevel: reasoningLevel)
+        )
+        _ = try await session.respond(
+            to: prompt,
+            metadata: ["foundationLab.example": labIdentifier]
+        )
+        try Task.checkCancellation()
+
+        let snapshot = SessionTranscriptSnapshot(transcript: session.transcript)
+        guard !snapshot.entries.isEmpty else {
+            throw RunError.emptyTranscript
+        }
+        return snapshot
+    }
+    #endif
+}

--- a/Foundation Lab/Views/Examples/Xcode27/SessionTranscriptSnapshot.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/SessionTranscriptSnapshot.swift
@@ -1,0 +1,432 @@
+//
+//  SessionTranscriptSnapshot.swift
+//  FoundationLab
+//
+
+import Foundation
+import FoundationLabCore
+import CoreGraphics
+
+#if compiler(>=6.4)
+import FoundationModels
+#endif
+
+struct SessionTranscriptSnapshot: Equatable, Sendable {
+    struct Entry: Equatable, Identifiable, Sendable {
+        enum Kind: String, Equatable, Sendable {
+            case instructions
+            case prompt
+            case reasoning
+            case toolCalls
+            case toolOutput
+            case response
+            case unknown
+
+            var title: String {
+                switch self {
+                case .instructions:
+                    String(localized: "Instructions")
+                case .prompt:
+                    String(localized: "Prompt")
+                case .reasoning:
+                    String(localized: "Reasoning")
+                case .toolCalls:
+                    String(localized: "Tool Calls")
+                case .toolOutput:
+                    String(localized: "Tool Output")
+                case .response:
+                    String(localized: "Response")
+                case .unknown:
+                    String(localized: "Unknown Entry")
+                }
+            }
+
+            var systemImage: String {
+                switch self {
+                case .instructions:
+                    "text.badge.checkmark"
+                case .prompt:
+                    "person.crop.circle"
+                case .reasoning:
+                    "brain"
+                case .toolCalls:
+                    "hammer"
+                case .toolOutput:
+                    "wrench.and.screwdriver"
+                case .response:
+                    "sparkles"
+                case .unknown:
+                    "questionmark.circle"
+                }
+            }
+        }
+
+        struct Field: Equatable, Identifiable, Sendable {
+            let name: String
+            let value: String
+
+            var id: String { name }
+        }
+
+        let id: String
+        let frameworkID: String
+        let ordinal: Int
+        let kind: Kind
+        let summary: String
+        let segments: [Segment]
+        let fields: [Field]
+    }
+
+    struct Segment: Equatable, Identifiable, Sendable {
+        enum Kind: String, Equatable, Sendable {
+            case text
+            case structure
+            case attachment
+            case custom
+            case toolCall
+            case unknown
+
+            var title: String {
+                switch self {
+                case .text:
+                    String(localized: "Text")
+                case .structure:
+                    String(localized: "Structured Content")
+                case .attachment:
+                    String(localized: "Attachment")
+                case .custom:
+                    String(localized: "Custom Content")
+                case .toolCall:
+                    String(localized: "Tool Call")
+                case .unknown:
+                    String(localized: "Unknown Segment")
+                }
+            }
+        }
+
+        let id: String
+        let kind: Kind
+        let label: String
+        let content: String
+    }
+
+    struct ToolEvent: Equatable, Identifiable, Sendable {
+        enum Kind: Equatable, Sendable {
+            case call
+            case output
+        }
+
+        let id: String
+        let frameworkID: String
+        let kind: Kind
+        let toolName: String
+        let detail: String
+    }
+
+    let entries: [Entry]
+    let toolCalls: [FoundationLabToolTrajectoryEvaluation.Call]
+    let toolEvents: [ToolEvent]
+}
+
+#if compiler(>=6.4)
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension SessionTranscriptSnapshot {
+    private struct Capture {
+        let entry: Entry
+        var calls: [FoundationLabToolTrajectoryEvaluation.Call] = []
+        var events: [ToolEvent] = []
+    }
+
+    init(transcript: Transcript) {
+        let captures = transcript.enumerated().map { index, transcriptEntry in
+            Self.capture(transcriptEntry, ordinal: index + 1)
+        }
+
+        self.init(
+            entries: captures.map(\.entry),
+            toolCalls: captures.flatMap(\.calls),
+            toolEvents: captures.flatMap(\.events)
+        )
+    }
+
+    private static func capture(_ transcriptEntry: Transcript.Entry, ordinal: Int) -> Capture {
+        switch transcriptEntry {
+        case .instructions(let instructions):
+            capture(instructions, ordinal: ordinal)
+        case .prompt(let prompt):
+            capture(prompt, ordinal: ordinal)
+        case .reasoning(let reasoning):
+            capture(reasoning, ordinal: ordinal)
+        case .toolCalls(let calls):
+            capture(calls, ordinal: ordinal)
+        case .toolOutput(let output):
+            capture(output, ordinal: ordinal)
+        case .response(let response):
+            capture(response, ordinal: ordinal)
+        @unknown default:
+            Capture(
+                entry: Entry(
+                    id: "\(ordinal)-unknown",
+                    frameworkID: String(localized: "Unavailable"),
+                    ordinal: ordinal,
+                    kind: .unknown,
+                    summary: transcriptEntry.description,
+                    segments: [],
+                    fields: []
+                )
+            )
+        }
+    }
+
+    private static func capture(_ instructions: Transcript.Instructions, ordinal: Int) -> Capture {
+        let segments = segments(from: instructions.segments, entryOrdinal: ordinal)
+        let toolFields = instructions.toolDefinitions.enumerated().map { toolIndex, definition in
+            Entry.Field(
+                name: String(localized: "Tool \(toolIndex + 1)"),
+                value: "\(definition.name): \(definition.description)"
+            )
+        }
+        return Capture(
+            entry: entry(
+                id: instructions.id,
+                ordinal: ordinal,
+                kind: .instructions,
+                segments: segments,
+                fields: toolFields
+            )
+        )
+    }
+
+    private static func capture(_ prompt: Transcript.Prompt, ordinal: Int) -> Capture {
+        let segments = segments(from: prompt.segments, entryOrdinal: ordinal)
+        return Capture(
+            entry: entry(
+                id: prompt.id,
+                ordinal: ordinal,
+                kind: .prompt,
+                segments: segments,
+                fields: metadataFields(prompt.metadata)
+            )
+        )
+    }
+
+    private static func capture(_ reasoning: Transcript.Reasoning, ordinal: Int) -> Capture {
+        let segments = segments(from: reasoning.segments, entryOrdinal: ordinal)
+        var fields = metadataFields(reasoning.metadata)
+        if let signature = reasoning.signature {
+            fields.append(
+                Entry.Field(
+                    name: String(localized: "Signature"),
+                    value: String(localized: "\(signature.count) bytes")
+                )
+            )
+        }
+        return Capture(
+            entry: entry(
+                id: reasoning.id,
+                ordinal: ordinal,
+                kind: .reasoning,
+                segments: segments,
+                fields: fields
+            )
+        )
+    }
+
+    private static func capture(_ calls: Transcript.ToolCalls, ordinal: Int) -> Capture {
+        var observedCalls: [FoundationLabToolTrajectoryEvaluation.Call] = []
+        var events: [ToolEvent] = []
+        let callSegments = calls.enumerated().map { callIndex, call in
+            let arguments = prettyJSON(call.arguments.jsonString)
+            observedCalls.append(
+                FoundationLabToolTrajectoryEvaluation.Call(
+                    id: call.id,
+                    name: call.toolName,
+                    arguments: call.arguments.jsonString
+                )
+            )
+            events.append(
+                ToolEvent(
+                    id: "call-\(ordinal)-\(callIndex)-\(call.id)",
+                    frameworkID: call.id,
+                    kind: .call,
+                    toolName: call.toolName,
+                    detail: arguments
+                )
+            )
+            return Segment(
+                id: "\(ordinal)-call-\(callIndex)-\(call.id)",
+                kind: .toolCall,
+                label: call.toolName,
+                content: arguments
+            )
+        }
+        return Capture(
+            entry: entry(
+                id: calls.id,
+                ordinal: ordinal,
+                kind: .toolCalls,
+                segments: callSegments,
+                fields: [Entry.Field(name: String(localized: "Observed calls"), value: calls.count.formatted())]
+            ),
+            calls: observedCalls,
+            events: events
+        )
+    }
+
+    private static func capture(_ output: Transcript.ToolOutput, ordinal: Int) -> Capture {
+        let segments = segments(from: output.segments, entryOrdinal: ordinal)
+        return Capture(
+            entry: entry(
+                id: output.id,
+                ordinal: ordinal,
+                kind: .toolOutput,
+                segments: segments,
+                fields: [Entry.Field(name: String(localized: "Tool"), value: output.toolName)]
+            ),
+            events: [
+                ToolEvent(
+                    id: "output-\(ordinal)-\(output.id)",
+                    frameworkID: output.id,
+                    kind: .output,
+                    toolName: output.toolName,
+                    detail: combinedContent(segments)
+                )
+            ]
+        )
+    }
+
+    private static func capture(_ response: Transcript.Response, ordinal: Int) -> Capture {
+        let segments = segments(from: response.segments, entryOrdinal: ordinal)
+        return Capture(
+            entry: entry(
+                id: response.id,
+                ordinal: ordinal,
+                kind: .response,
+                segments: segments,
+                fields: metadataFields(response.metadata)
+            )
+        )
+    }
+
+    private static func entry(
+        id: String,
+        ordinal: Int,
+        kind: Entry.Kind,
+        segments: [Segment],
+        fields: [Entry.Field]
+    ) -> Entry {
+        Entry(
+            id: "\(ordinal)-\(id)",
+            frameworkID: id,
+            ordinal: ordinal,
+            kind: kind,
+            summary: summary(for: kind, segments: segments),
+            segments: segments,
+            fields: fields
+        )
+    }
+
+    private static func segments(
+        from transcriptSegments: [Transcript.Segment],
+        entryOrdinal: Int
+    ) -> [Segment] {
+        transcriptSegments.enumerated().map { segmentIndex, segment in
+            let id = "\(entryOrdinal)-\(segmentIndex)-\(segment.id)"
+            switch segment {
+            case .text(let text):
+                return Segment(id: id, kind: .text, label: String(localized: "Text"), content: text.content)
+            case .structure(let structure):
+                return Segment(
+                    id: id,
+                    kind: .structure,
+                    label: structure.schemaName,
+                    content: prettyJSON(structure.content.jsonString)
+                )
+            case .attachment(let attachment):
+                return Segment(
+                    id: id,
+                    kind: .attachment,
+                    label: attachment.label ?? String(localized: "Image attachment"),
+                    content: attachmentDescription(attachment.content)
+                )
+            case .custom(let custom):
+                return Segment(
+                    id: id,
+                    kind: .custom,
+                    label: String(describing: type(of: custom)),
+                    content: custom.description
+                )
+            @unknown default:
+                return Segment(
+                    id: id,
+                    kind: .unknown,
+                    label: String(localized: "Unknown segment"),
+                    content: segment.description
+                )
+            }
+        }
+    }
+
+    private static func attachmentDescription(_ attachment: Transcript.Attachment) -> String {
+        switch attachment {
+        case .image(let image):
+            if let url = image.url {
+                return url.lastPathComponent
+            }
+            return String(localized: "\(image.cgImage.width) × \(image.cgImage.height) pixels")
+        @unknown default:
+            return String(localized: "A newer attachment type was emitted.")
+        }
+    }
+
+    private static func metadataFields(
+        _ metadata: [String: any Codable & Sendable & Equatable]
+    ) -> [Entry.Field] {
+        metadata.keys.sorted().compactMap { key in
+            guard let value = metadata[key] else { return nil }
+            return Entry.Field(name: key, value: String(describing: value))
+        }
+    }
+
+    private static func summary(for kind: Entry.Kind, segments: [Segment]) -> String {
+        guard let first = segments.first else {
+            switch kind {
+            case .reasoning:
+                return String(localized: "The framework emitted a reasoning entry without displayable segments.")
+            case .toolCalls:
+                return String(localized: "The framework emitted an empty tool-call group.")
+            default:
+                return String(localized: "No displayable segments were emitted.")
+            }
+        }
+
+        let flattened = first.content.replacing("\n", with: " ")
+        if flattened.count <= 120 {
+            return flattened
+        }
+        return String(flattened.prefix(117)) + "…"
+    }
+
+    private static func combinedContent(_ segments: [Segment]) -> String {
+        let content = segments.map(\.content).filter { !$0.isEmpty }.joined(separator: "\n\n")
+        return content.isEmpty ? String(localized: "No displayable output segments were emitted.") : content
+    }
+
+    private static func prettyJSON(_ source: String) -> String {
+        guard let data = source.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              JSONSerialization.isValidJSONObject(object),
+              let prettyData = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+              ),
+              let result = String(data: prettyData, encoding: .utf8) else {
+            return source
+        }
+
+        return result
+    }
+}
+#endif

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewModel.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewModel.swift
@@ -37,8 +37,7 @@ final class ToolCallTrajectoryViewModel {
     }
 
     func run() async {
-        let capturedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !capturedPrompt.isEmpty else { return }
+        guard let capturedPrompt = promptForNewRun else { return }
 
         let runID = UUID()
         activeRunID = runID
@@ -63,6 +62,7 @@ final class ToolCallTrajectoryViewModel {
         }
 
         do {
+            try Task.checkCancellation()
             let snapshot = try await SessionObservabilityRunner.run(
                 prompt: capturedPrompt,
                 labIdentifier: "tool-trajectory"
@@ -106,5 +106,11 @@ final class ToolCallTrajectoryViewModel {
         evaluation = nil
         errorMessage = nil
         isRunning = false
+    }
+
+    private var promptForNewRun: String? {
+        guard !Task.isCancelled else { return nil }
+        let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
     }
 }

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewModel.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewModel.swift
@@ -1,0 +1,110 @@
+//
+//  ToolCallTrajectoryViewModel.swift
+//  FoundationLab
+//
+
+import Foundation
+import FoundationLabCore
+import FoundationModels
+import Observation
+
+@MainActor
+@Observable
+final class ToolCallTrajectoryViewModel {
+    static let defaultPrompt = "Call readFoundationLabFact exactly once with the transcript topic, then answer in one sentence."
+    static let forbiddenToolNames: Set<String> = ["deleteItem", "sendMessage"]
+
+    var prompt = defaultPrompt
+    var observedEvents: [SessionTranscriptSnapshot.ToolEvent] = []
+    var response: String?
+    var evaluation: FoundationLabToolTrajectoryEvaluation?
+    var errorMessage: String?
+    var isRunning = false
+
+    let expectedCalls: [FoundationLabToolTrajectoryEvaluation.Call]
+
+    private var activeRunID: UUID?
+
+    init() {
+        let arguments = FoundationLabSessionObservabilityTool.Arguments(topic: .transcript)
+        self.expectedCalls = [
+            FoundationLabToolTrajectoryEvaluation.Call(
+                id: "expected-1",
+                name: FoundationLabSessionObservabilityTool().name,
+                arguments: arguments.generatedContent.jsonString
+            )
+        ]
+    }
+
+    func run() async {
+        let capturedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !capturedPrompt.isEmpty else { return }
+
+        let runID = UUID()
+        activeRunID = runID
+        isRunning = true
+        observedEvents = []
+        response = nil
+        evaluation = nil
+        errorMessage = nil
+
+        defer {
+            if activeRunID == runID {
+                activeRunID = nil
+                isRunning = false
+            }
+        }
+
+        #if compiler(>=6.4)
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else {
+            guard activeRunID == runID else { return }
+            errorMessage = String(localized: "Live trajectory capture requires an OS 27 runtime.")
+            return
+        }
+
+        do {
+            let snapshot = try await SessionObservabilityRunner.run(
+                prompt: capturedPrompt,
+                labIdentifier: "tool-trajectory"
+            )
+            try Task.checkCancellation()
+            guard activeRunID == runID else { return }
+            guard prompt.trimmingCharacters(in: .whitespacesAndNewlines) == capturedPrompt else {
+                errorMessage = String(
+                    localized: "The prompt changed while the session was running. Run it again to inspect matching results."
+                )
+                return
+            }
+
+            observedEvents = snapshot.toolEvents
+            response = snapshot.entries.last(where: { $0.kind == .response })?.segments
+                .map(\.content)
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n\n")
+            evaluation = FoundationLabToolTrajectoryEvaluation(
+                expected: expectedCalls,
+                observed: snapshot.toolCalls,
+                forbiddenToolNames: Self.forbiddenToolNames
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeRunID == runID else { return }
+            errorMessage = error.localizedDescription
+        }
+        #else
+        guard activeRunID == runID else { return }
+        errorMessage = String(localized: "Live trajectory capture requires the Xcode 27 SDK.")
+        #endif
+    }
+
+    func reset() {
+        activeRunID = nil
+        prompt = Self.defaultPrompt
+        observedEvents = []
+        response = nil
+        evaluation = nil
+        errorMessage = nil
+        isRunning = false
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolCallTrajectoryViewerView.swift
@@ -2,241 +2,63 @@
 //  ToolCallTrajectoryViewerView.swift
 //  FoundationLab
 //
-//  Created by Codex on 6/8/26.
-//
 
 import SwiftUI
 
 struct ToolCallTrajectoryViewerView: View {
-    @State private var fixture = TrajectoryFixture.match
+    @State private var model = ToolCallTrajectoryViewModel()
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.large) {
-                Text(
-                    String(
-                        localized: """
-                        A trajectory is the ordered path a model takes through tools. These are labeled teaching fixtures, not calls \
-                        captured from this device. In a real app, derive the path from the session transcript and score it in a test.
-                        """
-                    )
+        @Bindable var model = model
+
+        ExampleViewBase(
+            title: String(localized: "Tool Trajectories"),
+            description: String(localized: "Run a real tool turn and compare transcript evidence with an authored expectation"),
+            currentPrompt: $model.prompt,
+            isRunning: model.isRunning,
+            errorMessage: model.errorMessage,
+            codeExample: Self.codeExample,
+            runLabel: String(localized: "Run Trajectory"),
+            onRun: model.run,
+            onReset: model.reset
+        ) {
+            if let evaluation = model.evaluation {
+                ToolTrajectoryResultView(
+                    evaluation: evaluation,
+                    observedEvents: model.observedEvents,
+                    response: model.response,
+                    forbiddenToolNames: ToolCallTrajectoryViewModel.forbiddenToolNames
                 )
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-
-                Picker("Teaching fixture", selection: $fixture) {
-                    ForEach(TrajectoryFixture.allCases) { fixture in
-                        Text(fixture.title).tag(fixture)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Xcode27StatusRow(
-                    title: String(localized: "Fixture comparison"),
-                    value: fixture.result.title,
-                    systemImage: fixture.result.icon,
-                    tint: fixture.result.tint
-                )
-
-                Xcode27Section(String(localized: "Expected tool path")) {
-                    TrajectoryPathView(steps: TrajectoryFixture.expected)
-                }
-
-                Xcode27Section(String(localized: "Authored fixture")) {
-                    TrajectoryPathView(steps: fixture.steps)
-                }
-
-                Xcode27Section(String(localized: "Why the fixture is classified this way")) {
-                    Text(fixture.explanation)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-
-                Xcode27Section(String(localized: "Production workflow")) {
-                    Xcode27KeyValueList(items: [
-                        (String(localized: "Observe"), "session.transcript"),
-                        (String(localized: "Extract"), String(localized: "Tool call names and arguments")),
-                        (String(localized: "Compare"), String(localized: "Declared expectation")),
-                        (String(localized: "Report"), String(localized: "Evaluations test result"))
-                    ])
-                }
-
-                CodeDisclosure(code: codeExample)
-            }
-            .padding(.horizontal, Spacing.medium)
-            .padding(.vertical, Spacing.large)
-        }
-        .navigationTitle("Tool Trajectories")
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.large)
-        .navigationSubtitle("Compare explicit fixtures, not imaginary runs")
-        #endif
-    }
-
-    private var codeExample: String {
-        """
-        let observedCalls = session.transcript.flatMap { entry -> [Transcript.ToolCall] in
-            if case .toolCalls(let calls) = entry {
-                Array(calls)
             } else {
-                []
-            }
-        }
-
-        // Pass observedCalls and your declared expectation to an
-        // evaluation in the test target. Keep the full arguments when
-        // correctness depends on more than tool names and order.
-        """
-    }
-}
-
-private struct TrajectoryPathView: View {
-    let steps: [TrajectoryStep]
-
-    var body: some View {
-        VStack(spacing: 0) {
-            ForEach(steps.enumerated(), id: \.element.id) { index, step in
-                HStack(alignment: .top, spacing: Spacing.medium) {
-                    Text(index + 1, format: .number)
-                        .font(.footnote.monospacedDigit())
-                        .bold()
-                        .frame(width: 24, height: 24)
-                        .foregroundStyle(step.tint)
-
-                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                        Text(step.name)
-                            .font(.subheadline)
-                            .bold()
-                        Text(step.detail)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Spacer(minLength: Spacing.small)
-                }
-                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
-                .padding(.vertical, Spacing.small)
-                .accessibilityElement(children: .combine)
-
-                if index < steps.count - 1 {
-                    Divider()
-                        .padding(.leading, Spacing.xxLarge)
+                ContentUnavailableView {
+                    Label(
+                        model.isRunning ? "Tool Turn Running" : "No Observed Trajectory",
+                        systemImage: model.isRunning ? "ellipsis" : "point.topleft.down.to.point.bottomright.curvepath"
+                    )
+                } description: {
+                    Text(
+                        model.isRunning
+                            ? "The path will appear after the session finishes or the run is cancelled."
+                            : "Run the prompt to capture ordered tool calls and outputs from session.transcript."
+                    )
                 }
             }
         }
     }
-}
 
-private struct TrajectoryStep: Identifiable, Equatable {
-    let name: String
-    let detail: String
-    var tint: Color = .blue
+    private static let codeExample = """
+    let session = LanguageModelSession(profile: SessionObservabilityProfile())
+    _ = try await session.respond(to: prompt)
 
-    var id: String { "\(name)-\(detail)" }
-
-    static func == (lhs: TrajectoryStep, rhs: TrajectoryStep) -> Bool {
-        lhs.name == rhs.name && lhs.detail == rhs.detail
-    }
-}
-
-private enum TrajectoryResult {
-    case match
-    case review
-    case fail
-
-    var title: String {
-        switch self {
-        case .match: String(localized: "Exact match")
-        case .review: String(localized: "Different path")
-        case .fail: String(localized: "Forbidden call")
-        }
+    let observedCalls = session.transcript.flatMap { entry -> [Transcript.ToolCall] in
+        guard case .toolCalls(let calls) = entry else { return [] }
+        return Array(calls)
     }
 
-    var icon: String {
-        switch self {
-        case .match: "checkmark.circle.fill"
-        case .review: "exclamationmark.circle.fill"
-        case .fail: "xmark.circle.fill"
-        }
-    }
-
-    var tint: Color {
-        switch self {
-        case .match: .green
-        case .review: .orange
-        case .fail: .red
-        }
-    }
-}
-
-private enum TrajectoryFixture: String, CaseIterable, Identifiable {
-    case match
-    case repeated
-    case forbidden
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .match: String(localized: "Match")
-        case .repeated: String(localized: "Repeated")
-        case .forbidden: String(localized: "Forbidden")
-        }
-    }
-
-    static let expected = [
-        TrajectoryStep(name: "spotlightSearch", detail: String(localized: "Search notes for hikes near water")),
-        TrajectoryStep(name: "fetchItem", detail: String(localized: "Load the selected note"))
-    ]
-
-    var steps: [TrajectoryStep] {
-        switch self {
-        case .match:
-            Self.expected
-        case .repeated:
-            [
-                TrajectoryStep(name: "spotlightSearch", detail: String(localized: "Search notes for hikes near water")),
-                TrajectoryStep(name: "spotlightSearch", detail: String(localized: "Repeat the same search"), tint: .orange),
-                TrajectoryStep(name: "fetchItem", detail: String(localized: "Load the selected note"))
-            ]
-        case .forbidden:
-            [
-                TrajectoryStep(name: "spotlightSearch", detail: String(localized: "Search notes for hikes near water")),
-                TrajectoryStep(
-                    name: "deleteItem",
-                    detail: String(localized: "Delete a note the user only asked to read"),
-                    tint: .red
-                )
-            ]
-        }
-    }
-
-    var result: TrajectoryResult {
-        if steps.contains(where: { $0.name == "deleteItem" }) {
-            .fail
-        } else if steps == Self.expected {
-            .match
-        } else {
-            .review
-        }
-    }
-
-    var explanation: String {
-        switch result {
-        case .match:
-            String(
-                localized: "The authored calls exactly match the declared names, arguments, and order in this fixture."
-            )
-        case .review:
-            String(
-                localized: "The fixture reaches the same read operation through an extra call. Your evaluation must declare if that fails."
-            )
-        case .fail:
-            String(
-                localized: "The fixture contains a forbidden tool. A destructive call is a hard failure even if the answer looks useful."
-            )
-        }
-    }
+    // Compare observed names, canonical arguments, and order with an
+    // expectation declared by your app or test. Never score authored
+    // fixtures as though they came from this session.
+    """
 }
 
 #Preview {

--- a/Foundation Lab/Views/Examples/Xcode27/ToolTrajectoryPathView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolTrajectoryPathView.swift
@@ -1,0 +1,86 @@
+//
+//  ToolTrajectoryPathView.swift
+//  FoundationLab
+//
+
+import FoundationLabCore
+import SwiftUI
+
+struct ToolTrajectoryPathView: View {
+    private struct Item: Identifiable {
+        let id: String
+        let title: String
+        let detail: String
+        let systemImage: String
+        let tint: Color
+    }
+
+    private let items: [Item]
+
+    init(expectedCalls: [FoundationLabToolTrajectoryEvaluation.Call]) {
+        self.items = expectedCalls.enumerated().map { index, call in
+            Item(
+                id: "expected-\(index)-\(call.id)",
+                title: call.name,
+                detail: call.arguments,
+                systemImage: "hammer",
+                tint: .blue
+            )
+        }
+    }
+
+    init(observedEvents: [SessionTranscriptSnapshot.ToolEvent]) {
+        self.items = observedEvents.map { event in
+            switch event.kind {
+            case .call:
+                Item(
+                    id: event.id,
+                    title: String(localized: "Call · \(event.toolName)"),
+                    detail: event.detail,
+                    systemImage: "hammer.fill",
+                    tint: .blue
+                )
+            case .output:
+                Item(
+                    id: event.id,
+                    title: String(localized: "Output · \(event.toolName)"),
+                    detail: event.detail,
+                    systemImage: "arrow.turn.down.right",
+                    tint: .secondary
+                )
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(items.enumerated(), id: \.element.id) { index, item in
+                HStack(alignment: .top, spacing: Spacing.medium) {
+                    Image(systemName: item.systemImage)
+                        .foregroundStyle(item.tint)
+                        .frame(width: 24, height: 24)
+
+                    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                        Text(item.title)
+                            .font(.subheadline)
+                            .bold()
+                        Text(item.detail)
+                            .font(.footnote.monospaced())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+
+                    Spacer(minLength: Spacing.small)
+                }
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                .padding(.vertical, Spacing.small)
+                .accessibilityElement(children: .combine)
+
+                if index < items.count - 1 {
+                    Divider()
+                        .padding(.leading, Spacing.xxLarge)
+                }
+            }
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/ToolTrajectoryResultView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/ToolTrajectoryResultView.swift
@@ -1,0 +1,163 @@
+//
+//  ToolTrajectoryResultView.swift
+//  FoundationLab
+//
+
+import FoundationLabCore
+import SwiftUI
+
+struct ToolTrajectoryResultView: View {
+    let evaluation: FoundationLabToolTrajectoryEvaluation
+    let observedEvents: [SessionTranscriptSnapshot.ToolEvent]
+    let response: String?
+    let forbiddenToolNames: Set<String>
+
+    var body: some View {
+        VStack(spacing: Spacing.large) {
+            Xcode27StatusRow(
+                title: String(localized: "Observed comparison"),
+                value: verdictTitle,
+                systemImage: verdictIcon,
+                tint: verdictTint
+            )
+
+            Xcode27Section(String(localized: "Observed Transcript Path")) {
+                if observedEvents.isEmpty {
+                    Text("No tool call or output entries were present in this session transcript.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ToolTrajectoryPathView(observedEvents: observedEvents)
+                }
+            }
+
+            Xcode27Section(String(localized: "Comparison Evidence")) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
+                    Xcode27KeyValueList(items: [
+                        (String(localized: "Observed calls"), evaluation.observed.count.formatted()),
+                        (String(localized: "Position mismatches"), evaluation.mismatches.count.formatted()),
+                        (String(localized: "Missing calls"), evaluation.missingCalls.count.formatted()),
+                        (String(localized: "Extra calls"), evaluation.extraCalls.count.formatted()),
+                        (String(localized: "Forbidden calls"), evaluation.forbiddenCalls.count.formatted())
+                    ])
+
+                    Text(evidenceSummary)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if !evidenceDetails.isEmpty {
+                        DisclosureGroup(String(localized: "Inspect Differences")) {
+                            Text(evidenceDetails.joined(separator: "\n"))
+                                .font(.callout.monospaced())
+                                .textSelection(.enabled)
+                                .padding(.top, Spacing.small)
+                        }
+                        .font(.callout)
+                    }
+                }
+            }
+
+            DisclosureGroup(String(localized: "Authored Comparison Contract")) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
+                    Text(
+                        "This path is declared by the lab; it is not presented as model output. Arguments and order must match."
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                    ToolTrajectoryPathView(expectedCalls: evaluation.expected)
+
+                    LabeledContent(String(localized: "Forbidden names")) {
+                        Text(forbiddenToolNames.sorted().joined(separator: ", "))
+                            .font(.callout.monospaced())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+                .padding(.top, Spacing.small)
+            }
+            .font(.callout)
+
+            if let response, !response.isEmpty {
+                DisclosureGroup(String(localized: "Model Response")) {
+                    Text(response)
+                        .font(.body)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                        .padding(.top, Spacing.small)
+                }
+                .font(.callout)
+            }
+        }
+    }
+
+    private var verdictTitle: String {
+        switch evaluation.verdict {
+        case .exactMatch:
+            String(localized: "Exact match")
+        case .differentPath:
+            String(localized: "Different path")
+        case .forbiddenCall:
+            String(localized: "Forbidden call observed")
+        }
+    }
+
+    private var verdictIcon: String {
+        switch evaluation.verdict {
+        case .exactMatch:
+            "checkmark.circle.fill"
+        case .differentPath:
+            "exclamationmark.circle.fill"
+        case .forbiddenCall:
+            "xmark.octagon.fill"
+        }
+    }
+
+    private var verdictTint: Color {
+        switch evaluation.verdict {
+        case .exactMatch:
+            .green
+        case .differentPath:
+            .orange
+        case .forbiddenCall:
+            .red
+        }
+    }
+
+    private var evidenceSummary: String {
+        switch evaluation.verdict {
+        case .exactMatch:
+            String(localized: "The actual transcript contains the declared tool name, canonical arguments, and order with no extra calls.")
+        case .differentPath:
+            String(
+                localized: """
+                The actual transcript differs from the authored contract. Inspect the counts and differences before trusting the path.
+                """
+            )
+        case .forbiddenCall:
+            String(localized: "The actual transcript contains a tool name the contract explicitly forbids.")
+        }
+    }
+
+    private var evidenceDetails: [String] {
+        var details = evaluation.mismatches.map { mismatch in
+            switch mismatch.kind {
+            case .toolName:
+                return String(
+                    localized: "Position \(mismatch.position + 1): expected \(mismatch.expected.name), observed \(mismatch.observed.name)"
+                )
+            case .arguments:
+                return String(
+                    localized: """
+                    Position \(mismatch.position + 1): expected \(mismatch.expected.arguments), observed \(mismatch.observed.arguments)
+                    """
+                )
+            }
+        }
+        details.append(contentsOf: evaluation.missingCalls.map { String(localized: "Missing: \($0.name) \($0.arguments)") })
+        details.append(contentsOf: evaluation.extraCalls.map { String(localized: "Extra: \($0.name) \($0.arguments)") })
+        details.append(contentsOf: evaluation.forbiddenCalls.map { String(localized: "Forbidden: \($0.name) \($0.arguments)") })
+        return details
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptEntryBrowserView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptEntryBrowserView.swift
@@ -1,0 +1,62 @@
+//
+//  TranscriptEntryBrowserView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct TranscriptEntryBrowserView: View {
+    let entries: [SessionTranscriptSnapshot.Entry]
+    let selectedEntryID: String?
+    let onSelect: (String?) -> Void
+
+    var body: some View {
+        Xcode27Section(String(localized: "Observed Transcript")) {
+            VStack(spacing: 0) {
+                ForEach(entries) { entry in
+                    Button(action: { onSelect(entry.id) }, label: {
+                        HStack(alignment: .top, spacing: Spacing.medium) {
+                            Text(entry.ordinal, format: .number)
+                                .font(.footnote.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .frame(width: 24, alignment: .trailing)
+
+                            VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                                Label(entry.kind.title, systemImage: entry.kind.systemImage)
+                                    .font(.subheadline)
+                                    .bold()
+
+                                Text(entry.summary)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.leading)
+                            }
+
+                            Spacer(minLength: Spacing.small)
+
+                            Image(systemName: entry.id == selectedEntryID ? "checkmark.circle.fill" : "chevron.right")
+                                .foregroundStyle(entry.id == selectedEntryID ? Color.accentColor : .secondary)
+                                .accessibilityHidden(true)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                        .padding(.horizontal, Spacing.small)
+                        .padding(.vertical, Spacing.small)
+                        .contentShape(.rect)
+                        .background(
+                            entry.id == selectedEntryID ? Color.accentColor.opacity(0.08) : .clear,
+                            in: .rect(cornerRadius: CornerRadius.small)
+                        )
+                    })
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Entry \(entry.ordinal), \(entry.kind.title), \(entry.summary)")
+                    .accessibilityValue(entry.id == selectedEntryID ? "Selected" : "")
+
+                    if entry.id != entries.last?.id {
+                        Divider()
+                            .padding(.leading, Spacing.xxLarge)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptEntryDetailView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptEntryDetailView.swift
@@ -1,0 +1,63 @@
+//
+//  TranscriptEntryDetailView.swift
+//  FoundationLab
+//
+
+import SwiftUI
+
+struct TranscriptEntryDetailView: View {
+    let entry: SessionTranscriptSnapshot.Entry
+    @Binding var selectedSegmentID: String?
+
+    private var selectedSegment: SessionTranscriptSnapshot.Segment? {
+        entry.segments.first { $0.id == selectedSegmentID } ?? entry.segments.first
+    }
+
+    var body: some View {
+        Xcode27Section(String(localized: "Selected Entry")) {
+            VStack(alignment: .leading, spacing: Spacing.medium) {
+                LabeledContent(String(localized: "Framework ID")) {
+                    Text(entry.frameworkID)
+                        .font(.callout.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+
+                if !entry.fields.isEmpty {
+                    DisclosureGroup(String(localized: "Entry Details")) {
+                        Xcode27KeyValueList(items: entry.fields.map { ($0.name, $0.value) })
+                            .padding(.top, Spacing.small)
+                    }
+                    .font(.callout)
+                }
+
+                if entry.segments.isEmpty {
+                    Text("This observed entry has no displayable segments.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Picker(String(localized: "Segment"), selection: $selectedSegmentID) {
+                        ForEach(entry.segments) { segment in
+                            Text("\(segment.kind.title): \(segment.label)")
+                                .tag(Optional(segment.id))
+                        }
+                    }
+
+                    if let selectedSegment {
+                        VStack(alignment: .leading, spacing: Spacing.small) {
+                            Text(selectedSegment.label)
+                                .font(.subheadline)
+                                .bold()
+
+                            Text(selectedSegment.content)
+                                .font(selectedSegment.kind == .text ? .body : .body.monospaced())
+                                .foregroundStyle(selectedSegment.content.isEmpty ? .secondary : .primary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerView.swift
@@ -2,172 +2,95 @@
 //  TranscriptExplorerView.swift
 //  FoundationLab
 //
-//  Created by Codex on 6/8/26.
-//
 
 import SwiftUI
 
 struct TranscriptExplorerView: View {
-    @State private var selectedSegment = TranscriptSegmentExample.reasoning
+    @State private var model = TranscriptExplorerViewModel()
 
     var body: some View {
-        ReferenceExampleView(
+        @Bindable var model = model
+
+        ExampleViewBase(
             title: String(localized: "Transcript Explorer"),
-            description: String(localized: "Inspect reasoning, attachment, and custom transcript cases"),
-            codeExample: codeExample,
-            referenceNote: String(
-                localized: "Choose a segment to inspect its API case and code path. This page does not create a session or transcript."
-            )
+            description: String(localized: "Run a real session and inspect the transcript entries it actually emits"),
+            currentPrompt: $model.prompt,
+            isRunning: model.isRunning,
+            errorMessage: model.errorMessage,
+            codeExample: Self.codeExample,
+            runLabel: String(localized: "Run Session"),
+            onRun: model.run,
+            onReset: model.reset
         ) {
-            VStack(spacing: Spacing.medium) {
-                Picker("Segment", selection: $selectedSegment) {
-                    ForEach(TranscriptSegmentExample.allCases) { segment in
-                        Label(segment.title, systemImage: segment.icon)
-                            .tag(segment)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Xcode27Section(selectedSegment.title) {
-                    VStack(alignment: .leading, spacing: Spacing.medium) {
-                        Text(selectedSegment.detail)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-
-                        Text(selectedSegment.sample)
-                            .font(.body.monospaced())
-                            .textSelection(.enabled)
-                            .padding(.vertical, Spacing.small)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-
-                Xcode27Section(String(localized: "Why this matters")) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Xcode27InfoRow(
-                            title: String(localized: "Switches need new cases"),
-                            detail: String(localized: """
-                            Code that walked transcript entries or segments in Xcode 26 should explicitly handle the new Xcode 27 cases.
-                            """),
-                            systemImage: "switch.2"
+            VStack(spacing: Spacing.large) {
+                if model.entries.isEmpty {
+                    ContentUnavailableView {
+                        Label(
+                            model.isRunning ? "Session Running" : "No Transcript Yet",
+                            systemImage: model.isRunning ? "ellipsis" : "list.bullet.rectangle.portrait"
                         )
-                        .padding(.vertical, Spacing.small)
-
-                        Divider()
-
-                        Xcode27InfoRow(
-                            title: String(localized: "Debug views get richer"),
-                            detail: String(localized: """
-                            A transcript debugger can now show reasoning, image attachments, generated references, and app-defined \
-                            custom content.
-                            """),
-                            systemImage: "ladybug"
+                    } description: {
+                        Text(
+                            model.isRunning
+                                ? "The transcript will appear after the model finishes or the run is cancelled."
+                                : "Run the prompt to create a session. Only entries captured from that session will appear here."
                         )
-                        .padding(.vertical, Spacing.small)
+                    }
+                } else {
+                    TranscriptEntryBrowserView(
+                        entries: model.entries,
+                        selectedEntryID: model.selectedEntryID,
+                        onSelect: model.selectEntry
+                    )
+
+                    if let selectedEntry = model.selectedEntry {
+                        TranscriptEntryDetailView(
+                            entry: selectedEntry,
+                            selectedSegmentID: $model.selectedSegmentID
+                        )
                     }
                 }
-            }
-        }
-    }
 
-    private var codeExample: String {
-        """
-        func render(_ entry: Transcript.Entry) {
-            switch entry {
-            case .instructions(let instructions):
-                render(instructions.segments)
-            case .prompt(let prompt):
-                render(prompt.segments)
-            case .toolCalls(let calls):
-                for call in calls {
-                    render(call.toolName)
-                    render(String(describing: call.arguments))
-                }
-            case .toolOutput(let output):
-                render(output.segments)
-            case .response(let response):
-                render(response.segments)
-            case .reasoning(let reasoning):
-                render(reasoning.segments)
-            @unknown default:
-                render("Unknown entry")
-            }
-        }
-
-        func render(_ segments: [Transcript.Segment]) {
-            for segment in segments {
-                switch segment {
-                case .text(let text):
-                    render(text.content)
-                case .structure(let structured):
-                    render(structured.schemaName)
-                case .attachment(let attachment):
-                    render(attachment.label ?? "Attachment")
-                case .custom(let custom):
-                    render(custom.description)
-                @unknown default:
-                    render("Unknown segment")
+                Xcode27Section(String(localized: "Observation Boundary")) {
+                    Text(
+                        String(
+                            localized: """
+                            Entry and segment labels are derived from session.transcript after this run. If the active model does not \
+                            emit reasoning, attachments, custom content, or a tool event, the lab does not manufacture one.
+                            """
+                        )
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
-        """
     }
-}
 
-private enum TranscriptSegmentExample: String, CaseIterable, Identifiable {
-    case reasoning
-    case attachment
-    case custom
+    private static let codeExample = """
+    let session = LanguageModelSession(profile: SessionObservabilityProfile())
+    _ = try await session.respond(to: prompt)
 
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .reasoning:
-            return String(localized: "Reasoning")
-        case .attachment:
-            return String(localized: "Attachment")
-        case .custom:
-            return String(localized: "Custom")
+    for entry in session.transcript {
+        switch entry {
+        case .instructions(let instructions):
+            inspect(instructions.segments)
+        case .prompt(let prompt):
+            inspect(prompt.segments)
+        case .reasoning(let reasoning):
+            inspect(reasoning.segments)
+        case .toolCalls(let calls):
+            calls.forEach { inspect($0.toolName, $0.arguments) }
+        case .toolOutput(let output):
+            inspect(output.toolName, output.segments)
+        case .response(let response):
+            inspect(response.segments)
+        @unknown default:
+            inspectUnknown(entry)
         }
     }
-
-    var icon: String {
-        switch self {
-        case .reasoning:
-            return "brain"
-        case .attachment:
-            return "paperclip"
-        case .custom:
-            return "puzzlepiece.extension"
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .reasoning:
-            return String(
-                localized: """
-                Xcode 27 adds transcript reasoning entries so developer tools can separate reasoning from ordinary assistant text.
-                """
-            )
-        case .attachment:
-            return String(localized: "Attachment segments let image inputs and generated image references travel through the transcript.")
-        case .custom:
-            return String(localized: "Custom segments give framework and app integrations room to preserve extra typed transcript content.")
-        }
-    }
-
-    var sample: String {
-        switch self {
-        case .reasoning:
-            return "Transcript.Entry.reasoning(...)"
-        case .attachment:
-            return "Transcript.Segment.attachment(...)"
-        case .custom:
-            return "Transcript.Segment.custom(...)"
-        }
-    }
+    """
 }
 
 #Preview {

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerViewModel.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerViewModel.swift
@@ -1,0 +1,103 @@
+//
+//  TranscriptExplorerViewModel.swift
+//  FoundationLab
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class TranscriptExplorerViewModel {
+    static let defaultPrompt = "Use the fact tool with the transcript topic, then explain what a session transcript records."
+
+    var prompt = defaultPrompt
+    var entries: [SessionTranscriptSnapshot.Entry] = []
+    var selectedEntryID: String?
+    var selectedSegmentID: String?
+    var errorMessage: String?
+    var isRunning = false
+
+    private var activeRunID: UUID?
+
+    var selectedEntry: SessionTranscriptSnapshot.Entry? {
+        entries.first { $0.id == selectedEntryID }
+    }
+
+    var selectedSegment: SessionTranscriptSnapshot.Segment? {
+        selectedEntry?.segments.first { $0.id == selectedSegmentID }
+    }
+
+    func run() async {
+        let capturedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !capturedPrompt.isEmpty else { return }
+
+        let runID = UUID()
+        activeRunID = runID
+        isRunning = true
+        entries = []
+        selectedEntryID = nil
+        selectedSegmentID = nil
+        errorMessage = nil
+
+        defer {
+            if activeRunID == runID {
+                activeRunID = nil
+                isRunning = false
+            }
+        }
+
+        #if compiler(>=6.4)
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else {
+            guard activeRunID == runID else { return }
+            errorMessage = String(localized: "Live reasoning and segment inspection requires an OS 27 runtime.")
+            return
+        }
+
+        do {
+            let snapshot = try await SessionObservabilityRunner.run(
+                prompt: capturedPrompt,
+                labIdentifier: "transcript-explorer",
+                requestsReasoning: true
+            )
+            try Task.checkCancellation()
+            guard activeRunID == runID else { return }
+            guard prompt.trimmingCharacters(in: .whitespacesAndNewlines) == capturedPrompt else {
+                errorMessage = String(
+                    localized: "The prompt changed while the session was running. Run it again to inspect matching results."
+                )
+                return
+            }
+            entries = snapshot.entries
+            selectEntry(snapshot.entries.first?.id)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeRunID == runID else { return }
+            errorMessage = error.localizedDescription
+        }
+        #else
+        guard activeRunID == runID else { return }
+        errorMessage = String(localized: "Live transcript inspection requires the Xcode 27 SDK.")
+        #endif
+    }
+
+    func selectEntry(_ id: String?) {
+        selectedEntryID = id
+        selectedSegmentID = entries.first { $0.id == id }?.segments.first?.id
+    }
+
+    func selectSegment(_ id: String?) {
+        selectedSegmentID = id
+    }
+
+    func reset() {
+        activeRunID = nil
+        prompt = Self.defaultPrompt
+        entries = []
+        selectedEntryID = nil
+        selectedSegmentID = nil
+        errorMessage = nil
+        isRunning = false
+    }
+}

--- a/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerViewModel.swift
+++ b/Foundation Lab/Views/Examples/Xcode27/TranscriptExplorerViewModel.swift
@@ -29,8 +29,7 @@ final class TranscriptExplorerViewModel {
     }
 
     func run() async {
-        let capturedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !capturedPrompt.isEmpty else { return }
+        guard let capturedPrompt = promptForNewRun else { return }
 
         let runID = UUID()
         activeRunID = runID
@@ -55,6 +54,7 @@ final class TranscriptExplorerViewModel {
         }
 
         do {
+            try Task.checkCancellation()
             let snapshot = try await SessionObservabilityRunner.run(
                 prompt: capturedPrompt,
                 labIdentifier: "transcript-explorer",
@@ -99,5 +99,11 @@ final class TranscriptExplorerViewModel {
         selectedSegmentID = nil
         errorMessage = nil
         isRunning = false
+    }
+
+    private var promptForNewRun: String? {
+        guard !Task.isCancelled else { return nil }
+        let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
     }
 }

--- a/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
+++ b/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
@@ -232,13 +232,13 @@ private extension ExampleType {
         case .foundationModelsSecurityPlayground:
             String(localized: "Inspect the boundary between Foundation Models and your app")
         case .toolCallTrajectoryViewer:
-            String(localized: "Compare explicit fixtures, not imaginary runs")
+            String(localized: "Capture actual calls and outputs, then compare an authored expectation")
         case .dynamicProfileBuilder:
             String(localized: "Compose a LanguageModelSession.Profile recipe")
         case .reasoningLevelComparison:
             String(localized: "Inspect light, moderate, and deep ContextOptions")
         case .transcriptExplorer:
-            String(localized: "Inspect reasoning, attachment, and custom transcript cases")
+            String(localized: "Run a session and inspect only the entries it emits")
         case .agentFlowInspector:
             String(localized: "Know which layer owns each decision")
         case .historyTransformLab:

--- a/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabToolTrajectoryEvaluation.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabToolTrajectoryEvaluation.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Compares tool calls captured from a session transcript with an explicitly declared path.
+public struct FoundationLabToolTrajectoryEvaluation: Equatable, Sendable {
+    public struct Call: Equatable, Identifiable, Sendable {
+        public let id: String
+        public let name: String
+        public let arguments: String
+
+        public init(id: String, name: String, arguments: String) {
+            self.id = id
+            self.name = name
+            self.arguments = Self.canonicalJSON(arguments)
+        }
+
+        private static func canonicalJSON(_ source: String) -> String {
+            guard let data = source.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  JSONSerialization.isValidJSONObject(object),
+                  let normalized = try? JSONSerialization.data(
+                    withJSONObject: object,
+                    options: [.sortedKeys]
+                  ),
+                  let result = String(data: normalized, encoding: .utf8) else {
+                return source.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+
+            return result
+        }
+    }
+
+    public struct Mismatch: Equatable, Identifiable, Sendable {
+        public enum Kind: Equatable, Sendable {
+            case toolName
+            case arguments
+        }
+
+        public let position: Int
+        public let kind: Kind
+        public let expected: Call
+        public let observed: Call
+
+        public var id: String {
+            "\(position)-\(kind)"
+        }
+    }
+
+    public enum Verdict: Equatable, Sendable {
+        case exactMatch
+        case differentPath
+        case forbiddenCall
+    }
+
+    public let expected: [Call]
+    public let observed: [Call]
+    public let forbiddenCalls: [Call]
+    public let missingCalls: [Call]
+    public let extraCalls: [Call]
+    public let mismatches: [Mismatch]
+    public let verdict: Verdict
+
+    public init(
+        expected: [Call],
+        observed: [Call],
+        forbiddenToolNames: Set<String>
+    ) {
+        self.expected = expected
+        self.observed = observed
+        self.forbiddenCalls = observed.filter { forbiddenToolNames.contains($0.name) }
+
+        let pairedCount = min(expected.count, observed.count)
+        var differences: [Mismatch] = []
+        for index in 0..<pairedCount {
+            let expectedCall = expected[index]
+            let observedCall = observed[index]
+
+            if expectedCall.name != observedCall.name {
+                differences.append(
+                    Mismatch(
+                        position: index,
+                        kind: .toolName,
+                        expected: expectedCall,
+                        observed: observedCall
+                    )
+                )
+            } else if expectedCall.arguments != observedCall.arguments {
+                differences.append(
+                    Mismatch(
+                        position: index,
+                        kind: .arguments,
+                        expected: expectedCall,
+                        observed: observedCall
+                    )
+                )
+            }
+        }
+
+        self.mismatches = differences
+        self.missingCalls = expected.count > pairedCount ? Array(expected[pairedCount...]) : []
+        self.extraCalls = observed.count > pairedCount ? Array(observed[pairedCount...]) : []
+
+        if !forbiddenCalls.isEmpty {
+            self.verdict = .forbiddenCall
+        } else if differences.isEmpty && missingCalls.isEmpty && extraCalls.isEmpty {
+            self.verdict = .exactMatch
+        } else {
+            self.verdict = .differentPath
+        }
+    }
+}

--- a/FoundationLabCore/Sources/FoundationLabCore/Tools/FoundationLabSessionObservabilityTool.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Tools/FoundationLabSessionObservabilityTool.swift
@@ -1,0 +1,56 @@
+import FoundationModels
+
+/// A deterministic, read-only tool for labs that need an observable tool call without external data.
+public struct FoundationLabSessionObservabilityTool: Tool {
+    public let name = "readFoundationLabFact"
+    public let description = "Read a fixed Foundation Lab fact from an in-memory catalog"
+
+    public init() {}
+
+    @Generable
+    public struct Arguments {
+        @Guide(description: "The Foundation Lab topic to read")
+        public let topic: Topic
+
+        public init(topic: Topic) {
+            self.topic = topic
+        }
+    }
+
+    @Generable
+    public enum Topic {
+        case transcript
+        case tools
+        case privacy
+
+        public var canonicalName: String {
+            switch self {
+            case .transcript:
+                "transcript"
+            case .tools:
+                "tools"
+            case .privacy:
+                "privacy"
+            }
+        }
+
+        fileprivate var fact: String {
+            switch self {
+            case .transcript:
+                "A session transcript records instructions, prompts, tool calls, tool outputs, responses, and supported reasoning."
+            case .tools:
+                "A Tool exposes app code to the model; the app still owns validation, authorization, and side-effect policy."
+            case .privacy:
+                "This lab tool reads only a fixed in-memory catalog and never accesses files, accounts, sensors, or the network."
+            }
+        }
+    }
+
+    public func call(arguments: Arguments) async throws -> GeneratedContent {
+        GeneratedContent(properties: [
+            "topic": arguments.topic.canonicalName,
+            "fact": arguments.topic.fact,
+            "source": "Foundation Lab in-memory catalog"
+        ])
+    }
+}

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabToolTrajectoryEvaluationTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabToolTrajectoryEvaluationTests.swift
@@ -1,0 +1,93 @@
+import FoundationLabCore
+import XCTest
+
+final class FoundationLabToolTrajectoryEvaluationTests: XCTestCase {
+    private let expected = [
+        FoundationLabToolTrajectoryEvaluation.Call(
+            id: "expected",
+            name: "readFoundationLabFact",
+            arguments: #"{"topic":"transcript"}"#
+        )
+    ]
+
+    func testExactMatchCanonicalizesJSONFormatting() {
+        let observed = [
+            FoundationLabToolTrajectoryEvaluation.Call(
+                id: "observed",
+                name: "readFoundationLabFact",
+                arguments: #"{ "topic" : "transcript" }"#
+            )
+        ]
+
+        let result = FoundationLabToolTrajectoryEvaluation(
+            expected: expected,
+            observed: observed,
+            forbiddenToolNames: ["deleteItem", "sendMessage"]
+        )
+
+        XCTAssertEqual(result.verdict, .exactMatch)
+        XCTAssertTrue(result.mismatches.isEmpty)
+        XCTAssertTrue(result.extraCalls.isEmpty)
+        XCTAssertTrue(result.missingCalls.isEmpty)
+    }
+
+    func testArgumentsMismatchIsReportedAtObservedPosition() {
+        let observed = [
+            FoundationLabToolTrajectoryEvaluation.Call(
+                id: "observed",
+                name: "readFoundationLabFact",
+                arguments: #"{"topic":"privacy"}"#
+            )
+        ]
+
+        let result = FoundationLabToolTrajectoryEvaluation(
+            expected: expected,
+            observed: observed,
+            forbiddenToolNames: []
+        )
+
+        XCTAssertEqual(result.verdict, .differentPath)
+        XCTAssertEqual(result.mismatches.map(\.kind), [.arguments])
+        XCTAssertEqual(result.mismatches.map(\.position), [0])
+    }
+
+    func testExtraCallIsNotCollapsedIntoANameMismatch() {
+        let repeated = expected + [
+            FoundationLabToolTrajectoryEvaluation.Call(
+                id: "extra",
+                name: "readFoundationLabFact",
+                arguments: #"{"topic":"transcript"}"#
+            )
+        ]
+
+        let result = FoundationLabToolTrajectoryEvaluation(
+            expected: expected,
+            observed: repeated,
+            forbiddenToolNames: []
+        )
+
+        XCTAssertEqual(result.verdict, .differentPath)
+        XCTAssertEqual(result.extraCalls.map(\.id), ["extra"])
+        XCTAssertTrue(result.mismatches.isEmpty)
+    }
+
+    func testForbiddenCallTakesPriorityOverOtherDifferences() {
+        let observed = [
+            FoundationLabToolTrajectoryEvaluation.Call(
+                id: "forbidden",
+                name: "deleteItem",
+                arguments: "{}"
+            )
+        ]
+
+        let result = FoundationLabToolTrajectoryEvaluation(
+            expected: expected,
+            observed: observed,
+            forbiddenToolNames: ["deleteItem"]
+        )
+
+        XCTAssertEqual(result.verdict, .forbiddenCall)
+        XCTAssertEqual(result.forbiddenCalls.map(\.name), ["deleteItem"])
+        XCTAssertEqual(result.mismatches.map(\.kind), [.toolName])
+    }
+}


### PR DESCRIPTION
## Summary

- replace the Transcript Explorer teaching fixture with a real LanguageModelSession run and entry/segment inspection over session.transcript
- replace tool-trajectory fixtures with a deterministic read-only tool turn, ordered call/output capture, and an authored-vs-observed evaluator
- gate the labs on live model and tool-calling capabilities, keep unsupported reasoning optional, and surface errors/cancellation/stale prompts without manufacturing evidence
- prevent an already-cancelled UI task from entering a model request before its run body starts
- update library copy so both experiments describe their live behavior

## Validation

- strict SwiftLint: 0 violations
- full combined package suite: 52 XCTest + 197 Swift Testing tests
- Xcode 27 beta 2 generic macOS build
- Xcode 27 beta 2 generic iOS Simulator build
- combined branch includes merged #184–#187
- iOS 27 simulator: completed both real sessions; Transcript Explorer captured instructions, prompt, tool call, tool output, and response; Tool Trajectories reported an exact match
- UI QA in light/dark appearances and Accessibility Extra Large text
