### PR TITLE
Stop microphone permission prompts from looping

### DIFF
--- a/Foundation Lab/FoundationLab-macOS.entitlements
+++ b/Foundation Lab/FoundationLab-macOS.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>

--- a/Foundation Lab/ViewModels/ChatViewModel+Voice.swift
+++ b/Foundation Lab/ViewModels/ChatViewModel+Voice.swift
@@ -10,6 +10,7 @@ extension ChatViewModel {
 
     /// Releases microphone and speech resources without canceling an active text response.
     func suspendVoiceMode() {
+        activeVoiceStartID = nil
         stopSpeechObservation()
         speechRecognizer?.stopRecognition()
         speechRecognizer = nil
@@ -18,39 +19,76 @@ extension ChatViewModel {
     }
 
     func startVoiceMode() async {
-        guard !isLoading, !session.isResponding else { return }
+        guard let startID = beginVoiceStart() else { return }
+
+        let granted = await permissionManager.requestAllPermissions()
+        guard canContinueVoiceStart(startID) else { return }
+        guard granted else {
+            handleVoiceError(permissionManager.permissionAlertMessage)
+            return
+        }
+
+        await activateVoiceRecognizer(for: startID)
+    }
+
+    private func beginVoiceStart() -> UUID? {
+        guard !isLoading, !session.isResponding else { return nil }
 
         if case .error = voiceState {
             errorMessage = nil
             showError = false
             voiceState = .idle
         } else if voiceState.isActive {
-            return
+            return nil
         }
 
-        if !permissionManager.allPermissionsGranted {
-            let granted = await permissionManager.requestAllPermissions()
-            if !granted {
-                errorMessage = permissionManager.permissionAlertMessage
-                showError = true
-                return
-            }
-        }
-
+        let startID = UUID()
+        activeVoiceStartID = startID
         voiceState = .preparing
+        return startID
+    }
+
+    private func activateVoiceRecognizer(for startID: UUID) async {
         conversationEngine.prewarm()
         stopSpeechObservation()
         speechRecognizer?.stopRecognition()
         speechRecognizer = nil
 
-        let didStart = await initializeSpeechRecognizer()
-        guard didStart, case .preparing = voiceState else {
-            speechRecognizer?.stopRecognition()
-            speechRecognizer = nil
+        let recognizer: SpeechRecognizer
+        do {
+            recognizer = try await makeStartedSpeechRecognizer()
+        } catch is CancellationError {
+            abandonVoiceStart(startID)
+            return
+        } catch {
+            guard activeVoiceStartID == startID else { return }
+            handleVoiceError(error.localizedDescription)
             return
         }
+
+        guard canContinueVoiceStart(startID) else {
+            recognizer.stopRecognition()
+            return
+        }
+        speechRecognizer = recognizer
+        activeVoiceStartID = nil
         voiceState = .listening(partialText: "")
         startSpeechObservation()
+    }
+
+    private func canContinueVoiceStart(_ startID: UUID) -> Bool {
+        if Task.isCancelled {
+            abandonVoiceStart(startID)
+            return false
+        }
+        guard activeVoiceStartID == startID, case .preparing = voiceState else { return false }
+        return true
+    }
+
+    private func abandonVoiceStart(_ startID: UUID) {
+        guard activeVoiceStartID == startID else { return }
+        activeVoiceStartID = nil
+        voiceState = .idle
     }
 
     func cancelVoiceMode() {
@@ -125,18 +163,14 @@ extension ChatViewModel {
         }
     }
 
-    func initializeSpeechRecognizer() async -> Bool {
+    func makeStartedSpeechRecognizer() async throws -> SpeechRecognizer {
         let recognizer = SpeechRecognizer()
-        speechRecognizer = recognizer
-
         do {
             try await recognizer.startRecognition()
-            return true
-        } catch is CancellationError {
-            return false
+            return recognizer
         } catch {
-            handleVoiceError(error.localizedDescription)
-            return false
+            recognizer.stopRecognition()
+            throw error
         }
     }
 
@@ -170,6 +204,7 @@ extension ChatViewModel {
     }
 
     func handleVoiceError(_ message: String) {
+        activeVoiceStartID = nil
         stopSpeechObservation()
         speechRecognizer?.stopRecognition()
         speechRecognizer = nil

--- a/Foundation Lab/ViewModels/ChatViewModel.swift
+++ b/Foundation Lab/ViewModels/ChatViewModel.swift
@@ -25,6 +25,7 @@ final class ChatViewModel {
     var voiceState: VoiceState = .idle
     @ObservationIgnored var speechRecognizer: SpeechRecognizer?
     @ObservationIgnored var speechObservationTask: Task<Void, Never>?
+    @ObservationIgnored var activeVoiceStartID: UUID?
     @ObservationIgnored private var activeGenerationTask: Task<String, Error>?
     @ObservationIgnored private var activeGenerationID: UUID?
     @ObservationIgnored let permissionManager: PermissionManager

--- a/Foundation Lab/Voice/Services/PermissionManager.swift
+++ b/Foundation Lab/Voice/Services/PermissionManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FoundationLabCore
 import Speech
 
 #if os(iOS)
@@ -75,7 +76,7 @@ protocol PermissionServiceProtocol: AnyObject {
 // MARK: - Permission Manager Implementation
 
 @MainActor
-class PermissionManager: PermissionServiceProtocol {
+final class PermissionManager: PermissionServiceProtocol {
 
 #if os(iOS)
     var microphonePermissionStatus: AVAudioApplication.recordPermission = .undetermined {
@@ -93,6 +94,7 @@ class PermissionManager: PermissionServiceProtocol {
     var allPermissionsGranted = false
     var showPermissionAlert = false
     var permissionAlertMessage = ""
+    private var activePermissionRequest: Task<Bool, Never>?
 
     init() {
         initializeAudioSessionIfNeeded()
@@ -115,10 +117,33 @@ class PermissionManager: PermissionServiceProtocol {
     }
 
     func requestAllPermissions() async -> Bool {
-        _ = await requestMicrophonePermission()
+        if let activePermissionRequest {
+            return await activePermissionRequest.value
+        }
 
-        _ = await requestSpeechPermission()
+        let request = Task { @MainActor [weak self] in
+            guard let self else { return false }
+            return await self.performPermissionRequest()
+        }
+        activePermissionRequest = request
+        let granted = await request.value
+        activePermissionRequest = nil
+        return granted
+    }
 
+    private func performPermissionRequest() async -> Bool {
+        checkAllPermissions()
+        guard await requestMicrophonePermission() else {
+            showSettingsAlert()
+            return false
+        }
+
+        guard await requestSpeechPermission() else {
+            showSettingsAlert()
+            return false
+        }
+
+        checkAllPermissions()
         updateAllPermissionsStatus()
         if allPermissionsGranted {
             permissionAlertMessage = ""
@@ -138,71 +163,50 @@ class PermissionManager: PermissionServiceProtocol {
     }
 
     private func requestMicrophonePermission() async -> Bool {
-        if microphonePermissionStatus == .granted {
+        checkMicrophonePermission()
+        switch microphoneAuthorization.requestAction {
+        case .returnAuthorized:
             return true
+        case .returnDenied:
+            return false
+        case .requestAccess:
+            let granted = await AVAudioApplication.requestRecordPermission()
+            microphonePermissionStatus = granted ? .granted : .denied
+            return granted
         }
-
-        let granted = await AVAudioApplication.requestRecordPermission()
-        microphonePermissionStatus = granted ? .granted : .denied
-        return granted
     }
 #else
-    // macOS implementations for microphone permission
-
     private func checkMicrophonePermission() {
-        // On macOS, we can't directly check microphone permission status
-        // We need to attempt access to determine the status
-        // For now, keep the current status unless it's the initial state
-        if microphonePermissionStatus == .undetermined {
-            // Try to determine status by attempting a quick access test
-            Task { @MainActor in
-                _ = await self.testMicrophoneAccess()
-            }
-        }
-    }
-
-    private func testMicrophoneAccess() async -> Bool {
-        let audioEngine = AVAudioEngine()
-        let inputNode = audioEngine.inputNode
-
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-        let recordingFormat: AVAudioFormat
-
-        if inputFormat.sampleRate > 0 && inputFormat.channelCount > 0 {
-            recordingFormat = inputFormat
-        } else {
-            guard let fallbackFormat = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1) else {
-                self.microphonePermissionStatus = .denied
-                return false
-            }
-            recordingFormat = fallbackFormat
-        }
-
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { _, _ in
-            // Empty tap
-        }
-
-        do {
-            try audioEngine.start()
-            audioEngine.stop()
-            inputNode.removeTap(onBus: 0)
-            self.microphonePermissionStatus = .granted
-            return true
-        } catch {
-            audioEngine.stop()
-            inputNode.removeTap(onBus: 0)
-            self.microphonePermissionStatus = .denied
-            return false
+        // This startup check must stay side-effect free. Starting an audio input path here
+        // asks for access when the status is undetermined and can repeatedly prompt as views reload.
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .notDetermined:
+            microphonePermissionStatus = .undetermined
+        case .restricted, .denied:
+            microphonePermissionStatus = .denied
+        case .authorized:
+            microphonePermissionStatus = .granted
+        @unknown default:
+            microphonePermissionStatus = .denied
         }
     }
 
     private func requestMicrophonePermission() async -> Bool {
-
-        if microphonePermissionStatus == .granted {
+        checkMicrophonePermission()
+        switch microphoneAuthorization.requestAction {
+        case .returnAuthorized:
             return true
+        case .returnDenied:
+            return false
+        case .requestAccess:
+            let granted = await withCheckedContinuation { continuation in
+                AVCaptureDevice.requestAccess(for: .audio) { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+            microphonePermissionStatus = granted ? .granted : .denied
+            return granted
         }
-
-        return await testMicrophoneAccess()
     }
     #endif
 
@@ -213,27 +217,52 @@ class PermissionManager: PermissionServiceProtocol {
     }
 
     private func requestSpeechPermission() async -> Bool {
-        if speechPermissionStatus == .authorized {
+        checkSpeechPermission()
+        switch speechAuthorization.requestAction {
+        case .returnAuthorized:
             return true
+        case .returnDenied:
+            return false
+        case .requestAccess:
+            let status = await SpeechAuthorizationRequester.request()
+            speechPermissionStatus = status
+            return status == .authorized
         }
-
-        let status = await SpeechAuthorizationRequester.request()
-        speechPermissionStatus = status
-        return status == .authorized
     }
 
     // MARK: - Helpers
 
     private func updateAllPermissionsStatus() {
-        #if os(iOS)
         let micGranted = microphonePermissionStatus == .granted
-        #else
-        let micGranted = microphonePermissionStatus == .granted
-        #endif
-
         let speechGranted = speechPermissionStatus == .authorized
 
         allPermissionsGranted = micGranted && speechGranted
+    }
+
+    private var microphoneAuthorization: VoicePermissionAuthorization {
+        switch microphonePermissionStatus {
+        case .undetermined:
+            .notDetermined
+        case .denied:
+            .denied
+        case .granted:
+            .authorized
+        @unknown default:
+            .denied
+        }
+    }
+
+    private var speechAuthorization: VoicePermissionAuthorization {
+        switch speechPermissionStatus {
+        case .notDetermined:
+            .notDetermined
+        case .denied, .restricted:
+            .denied
+        case .authorized:
+            .authorized
+        @unknown default:
+            .denied
+        }
     }
 
     func showSettingsAlert() {

--- a/FoundationLab.xcodeproj/project.pbxproj
+++ b/FoundationLab.xcodeproj/project.pbxproj
@@ -345,10 +345,10 @@
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "This app does not write health data.";
 				INFOPLIST_KEY_NSLocationUsageDescription = "This app needs access to your location to provide weather information and location-based services.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This app needs access to your location to provide weather information and location-based services.";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Foundation Lab needs access to your microphone to listen to your voice commands for creating reminders.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Foundation Lab uses the microphone to transcribe voice input in Playground.";
 				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "Foundation Lab needs full access to create and manage reminders from your voice commands.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app needs access to your reminders to create and manage reminder tasks.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Foundation Lab uses speech recognition to convert your voice into text for creating reminders.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Foundation Lab uses speech recognition to turn Playground voice input into text.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -428,10 +428,10 @@
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "This app does not write health data.";
 				INFOPLIST_KEY_NSLocationUsageDescription = "This app needs access to your location to provide weather information and location-based services.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This app needs access to your location to provide weather information and location-based services.";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Foundation Lab needs access to your microphone to listen to your voice commands for creating reminders.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Foundation Lab uses the microphone to transcribe voice input in Playground.";
 				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "Foundation Lab needs full access to create and manage reminders from your voice commands.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app needs access to your reminders to create and manage reminder tasks.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Foundation Lab uses speech recognition to convert your voice into text for creating reminders.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Foundation Lab uses speech recognition to turn Playground voice input into text.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/FoundationLabCore/Sources/FoundationLabCore/Models/VoicePermissionAuthorization.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Models/VoicePermissionAuthorization.swift
@@ -1,0 +1,24 @@
+/// The platform-independent authorization states used by the voice permission flow.
+public enum VoicePermissionAuthorization: Sendable, Equatable {
+    case notDetermined
+    case denied
+    case authorized
+
+    /// The only safe next step for a user-initiated permission request.
+    public var requestAction: RequestAction {
+        switch self {
+        case .notDetermined:
+            .requestAccess
+        case .denied:
+            .returnDenied
+        case .authorized:
+            .returnAuthorized
+        }
+    }
+
+    public enum RequestAction: Sendable, Equatable {
+        case requestAccess
+        case returnDenied
+        case returnAuthorized
+    }
+}

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/VoicePermissionAuthorizationTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/VoicePermissionAuthorizationTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import FoundationLabCore
+
+@Suite("Voice permission authorization")
+struct VoicePermissionAuthorizationTests {
+    @Test("Only an undetermined status can request system access")
+    func requestActionRequiresUndeterminedStatus() {
+        #expect(VoicePermissionAuthorization.notDetermined.requestAction == .requestAccess)
+        #expect(VoicePermissionAuthorization.denied.requestAction == .returnDenied)
+        #expect(VoicePermissionAuthorization.authorized.requestAction == .returnAuthorized)
+    }
+}


### PR DESCRIPTION
## Summary

- make macOS permission status checks side-effect free with `AVCaptureDevice.authorizationStatus(for: .audio)`
- request microphone and speech access only from the explicit Voice action, never retry denied access, and coalesce concurrent permission requests
- give each asynchronous voice startup an ownership ID so Cancel then Restart cannot let a stale attempt tear down the new recognizer
- add the macOS audio-input sandbox entitlement and replace the reminder-specific privacy copy with truthful Playground voice copy
- cover the authorization decision policy with a focused unit test

## Root cause

`PermissionManager.init()` refreshed permissions, but the macOS refresh path started an `AVAudioEngine` to infer status. Starting audio input while authorization is undetermined is itself a request, so every recreated chat model could trigger another system sheet. The request path also retried denied statuses and had no in-flight coalescing.

## Validation

- Xcode 27 beta 2: macOS arm64 build passed
- Xcode 27 beta 2: iOS Simulator arm64 build passed
- Xcode 26.6 RC 2: macOS arm64 build passed
- Xcode 26.6 RC 2: iOS Simulator arm64 build passed
- Xcode 26.6 RC 2 full package suite: 48 XCTest + 198 Swift Testing tests passed
- SwiftLint strict: 0 violations across 235 files
- macOS entitlement plist validated with audio input enabled
- launched the rebuilt Xcode 26 app and navigated Library to Playground; no microphone or speech sheet appeared before the Voice action
- fresh iOS 27 simulator TCC smoke: no prompt before the Voice action; the first tap produced exactly one microphone sheet; denial followed by another Voice tap did not re-open the system sheet

For Xcode 27 package tests, the compile stage passes with companion PR #184 applied temporarily. Test execution on the current macOS beta remains blocked by the known FoundationModels SDK/runtime ABI mismatch (`Generable.promptRepresentation`); app builds are green.