### PR TITLE
[codex] Add bundled demo weather tool fixture

### DIFF
--- a/.afm/tools/demo-weather.yaml
+++ b/.afm/tools/demo-weather.yaml
@@ -1,0 +1,17 @@
+name: demo_weather
+description: Return a deterministic sample weather report for Cupertino. This fixture never fetches live weather.
+parameters:
+  title: DemoWeatherArguments
+  type: object
+  properties: {}
+  additionalProperties: false
+runner:
+  kind: static
+  outputFormat: json
+  json:
+    status: sample
+    location: Cupertino
+    condition: clear
+    temperatureCelsius: 21
+    source: bundled-demo
+    note: Deterministic sample data, not current weather.

--- a/Tools/AFMCLI/README.md
+++ b/Tools/AFMCLI/README.md
@@ -194,6 +194,10 @@ afm tool validate --tool echo-json --tool-dir .afm/tools
 afm tool call --tool echo-json --tool-dir .afm/tools --args @args.json
 ```
 
+The repository also includes `.afm/tools/demo-weather.yaml` for the root-help
+quick starts. It returns a deterministic Cupertino sample, never current weather,
+so it is safe for inspection, validation, dry-runs, and direct tool-call testing.
+
 ### Export transcripts and feedback
 
 Use export commands when you want artifacts you can keep, diff, or send elsewhere.

--- a/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBundledToolTests.swift
+++ b/Tools/AFMCLI/Tests/AFMCLITests/AFMCLIBundledToolTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@Test("Quick-start tool names resolve from the default tool directory")
+func quickStartToolNamesResolve() throws {
+    let help = try runAFM("--help")
+    let tokens = help.stdout.split(whereSeparator: \.isWhitespace).map(String.init)
+    let toolNames = Set(tokens.indices.dropLast().compactMap { index in
+        tokens[index] == "--tool" ? tokens[index + 1] : nil
+    })
+
+    #expect(help.status == 0)
+    #expect(toolNames == ["demo-weather"])
+
+    for toolName in toolNames.sorted() {
+        let inspect = try runAFM("tool", "inspect", "--output", "json", "--tool", toolName)
+        let validate = try runAFM("tool", "validate", "--output", "json", "--tool", toolName)
+        let call = try runAFM(
+            "tool", "call", "--output", "json",
+            "--tool", toolName,
+            "--args", "{}"
+        )
+        let session = try runAFM(
+            "session", "respond", "--output", "json", "--dry-run",
+            "--prompt", "Use the bundled weather sample.",
+            "--tool", toolName
+        )
+
+        #expect(inspect.status == 0)
+        #expect(validate.status == 0)
+        #expect(call.status == 0)
+        #expect(session.status == 0)
+
+        let inspectJSON = try parseJSONObject(inspect.stdout)
+        let validateJSON = try parseJSONObject(validate.stdout)
+        let callJSON = try parseJSONObject(call.stdout)
+        let sessionJSON = try parseJSONObject(session.stdout)
+        let output = try #require(callJSON["output"] as? String)
+        let outputJSON = try parseJSONObject(output)
+
+        #expect(inspectJSON["name"] as? String == "demo_weather")
+        #expect(inspectJSON["runner"] as? String == "static")
+        #expect(validateJSON["status"] as? String == "valid")
+        #expect(callJSON["name"] as? String == "demo_weather")
+        #expect(outputJSON["status"] as? String == "sample")
+        #expect(outputJSON["source"] as? String == "bundled-demo")
+        #expect(sessionJSON["status"] as? String == "dry_run")
+    }
+}


### PR DESCRIPTION
## Summary

- ship `.afm/tools/demo-weather.yaml` at the default path used by AFM CLI quick starts
- keep the fixture deterministic, static, non-personal, and explicit that it is not current weather
- add regression coverage that discovers every `--tool` name advertised by root help and proves inspect, validate, direct call, and session dry-run all resolve
- document the bundled fixture's safe sample behavior

## Root cause

Root help advertised `demo-weather`, but the repository did not contain a matching manifest under the default `.afm/tools` directory. Every advertised inspect or dry-run command therefore exited with an unresolved-tool error.

## Validation

- `swiftlint lint --strict --config .swiftlint-core-cli.yml`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer swift build --product afm`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer swift test --filter quickStartToolNamesResolve`
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.2.app/Contents/Developer swift test --skip 'AFMCLITests\.(feedbackExportCreatesNestedDirectories|streamingJSONEmitsEvents|modelCommandsReturnStructuredJSON)'`
- `afm tool inspect --tool demo-weather --output json --pretty`
- `afm tool validate --tool demo-weather --output json --pretty`
- `afm tool call --tool demo-weather --args '{}' --output json --pretty`
- `afm tool call --tool demo-weather --args '{}' --dry-run --output json --pretty`
- `afm session respond --prompt 'Use the bundled weather sample.' --tool demo-weather --dry-run --output json --pretty`
- live, safe session call returned the Cupertino sample and explicitly stated that it is not current weather
