### PR TITLE
[codex] Release Foundation Lab 1.2.0

### DIFF
--- a/.asc/ExportOptions/TestFlight.plist.template
+++ b/.asc/ExportOptions/TestFlight.plist.template
@@ -5,8 +5,13 @@
 	<key>method</key>
 	<string>app-store-connect</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
 	<key>teamID</key>
 	<string>__TEAM_ID__</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>__TARGET_BUNDLE_ID__</key>
+		<string>__PROFILE_NAME__</string>
+	</dict>
 </dict>
 </plist>

--- a/.asc/workflow.json
+++ b/.asc/workflow.json
@@ -17,11 +17,11 @@
         },
         {
           "name": "validate_inputs",
-          "run": "for key in APP_ID TESTFLIGHT_GROUP TARGET_BUNDLE_ID TEAM_ID VERSION; do if [ -z \"${!key}\" ]; then echo \"$key is required\" >&2; exit 1; fi; done"
+          "run": "for key in APP_ID TESTFLIGHT_GROUP TARGET_BUNDLE_ID TEAM_ID PROFILE_NAME SIGNING_KEYCHAIN_PATH VERSION; do if [ -z \"${!key}\" ]; then echo \"$key is required\" >&2; exit 1; fi; done"
         },
         {
           "name": "render_export_options",
-          "run": "sed \"s/__TEAM_ID__/$TEAM_ID/g\" \"$EXPORT_OPTIONS_TEMPLATE\" > \"$EXPORT_OPTIONS\" && plutil -lint \"$EXPORT_OPTIONS\" >/dev/null"
+          "run": "sed -e \"s/__TEAM_ID__/$TEAM_ID/g\" -e \"s/__TARGET_BUNDLE_ID__/$TARGET_BUNDLE_ID/g\" -e \"s/__PROFILE_NAME__/$PROFILE_NAME/g\" \"$EXPORT_OPTIONS_TEMPLATE\" > \"$EXPORT_OPTIONS\" && plutil -lint \"$EXPORT_OPTIONS\" >/dev/null"
         },
         {
           "name": "resolve_next_build",
@@ -32,7 +32,7 @@
         },
         {
           "name": "archive",
-          "run": "asc xcode archive --project \"$PROJECT_PATH\" --scheme \"$SCHEME\" --configuration \"$CONFIGURATION\" --archive-path \".asc/artifacts/FoundationLab-$VERSION-${steps.resolve_next_build.BUILD_NUMBER}.xcarchive\" --clean --overwrite --xcodebuild-flag=-destination --xcodebuild-flag=generic/platform=iOS --xcodebuild-flag=-allowProvisioningUpdates --xcodebuild-flag=-authenticationKeyID --xcodebuild-flag=$ASC_KEY_ID --xcodebuild-flag=-authenticationKeyIssuerID --xcodebuild-flag=$ASC_ISSUER_ID --xcodebuild-flag=-authenticationKeyPath --xcodebuild-flag=$ASC_PRIVATE_KEY_PATH --xcodebuild-flag=PRODUCT_BUNDLE_IDENTIFIER=$TARGET_BUNDLE_ID --xcodebuild-flag=DEVELOPMENT_TEAM=$TEAM_ID --xcodebuild-flag=MARKETING_VERSION=$VERSION --xcodebuild-flag=CURRENT_PROJECT_VERSION=${steps.resolve_next_build.BUILD_NUMBER} --output json",
+          "run": "asc xcode archive --project \"$PROJECT_PATH\" --scheme \"$SCHEME\" --configuration \"$CONFIGURATION\" --archive-path \".asc/artifacts/FoundationLab-$VERSION-${steps.resolve_next_build.BUILD_NUMBER}.xcarchive\" --clean --overwrite --xcodebuild-flag=-destination --xcodebuild-flag=generic/platform=iOS --xcodebuild-flag=PRODUCT_BUNDLE_IDENTIFIER=$TARGET_BUNDLE_ID --xcodebuild-flag=DEVELOPMENT_TEAM=$TEAM_ID --xcodebuild-flag=MARKETING_VERSION=$VERSION --xcodebuild-flag=CURRENT_PROJECT_VERSION=${steps.resolve_next_build.BUILD_NUMBER} \"--xcodebuild-flag=FOUNDATION_LAB_PROFILE_NAME=$PROFILE_NAME\" --output json",
           "outputs": {
             "ARCHIVE_PATH": "$.archive_path",
             "VERSION": "$.version",
@@ -41,7 +41,7 @@
         },
         {
           "name": "export",
-          "run": "asc xcode export --archive-path \"${steps.archive.ARCHIVE_PATH}\" --export-options \"$EXPORT_OPTIONS\" --ipa-path \".asc/artifacts/FoundationLab-$VERSION-${steps.archive.BUILD_NUMBER}.ipa\" --overwrite --xcodebuild-flag=-allowProvisioningUpdates --xcodebuild-flag=-authenticationKeyID --xcodebuild-flag=$ASC_KEY_ID --xcodebuild-flag=-authenticationKeyIssuerID --xcodebuild-flag=$ASC_ISSUER_ID --xcodebuild-flag=-authenticationKeyPath --xcodebuild-flag=$ASC_PRIVATE_KEY_PATH --output json",
+          "run": "asc xcode export --archive-path \"${steps.archive.ARCHIVE_PATH}\" --export-options \"$EXPORT_OPTIONS\" --ipa-path \".asc/artifacts/FoundationLab-$VERSION-${steps.archive.BUILD_NUMBER}.ipa\" --overwrite --output json",
           "outputs": {
             "IPA_PATH": "$.ipa_path",
             "VERSION": "$.version",

--- a/.github/workflows/foundation-lab-testflight.yml
+++ b/.github/workflows/foundation-lab-testflight.yml
@@ -37,6 +37,7 @@ jobs:
       TESTFLIGHT_GROUP: ${{ vars.FOUNDATION_LAB_EXTERNAL_GROUP_ID }}
       TARGET_BUNDLE_ID: ${{ vars.FOUNDATION_LAB_BUNDLE_ID }}
       TEAM_ID: ${{ vars.FOUNDATION_LAB_TEAM_ID }}
+      PROFILE_NAME: ${{ vars.FOUNDATION_LAB_PROFILE_NAME }}
       UPLOAD: ${{ github.event_name == 'push' || inputs.upload }}
     steps:
       - name: Check out repository
@@ -73,17 +74,26 @@ jobs:
           ASC_KEY_ID_SECRET: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID_SECRET: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY_B64_SECRET: ${{ secrets.ASC_PRIVATE_KEY_B64 }}
+          SIGNING_CERTIFICATE_P12_B64_SECRET: ${{ secrets.FOUNDATION_LAB_DISTRIBUTION_P12_B64 }}
+          SIGNING_CERTIFICATE_PASSWORD_SECRET: ${{ secrets.FOUNDATION_LAB_DISTRIBUTION_P12_PASSWORD }}
+          PROVISIONING_PROFILE_B64_SECRET: ${{ secrets.FOUNDATION_LAB_PROVISIONING_PROFILE_B64 }}
         run: |
-          for key in APP_ID TESTFLIGHT_GROUP TARGET_BUNDLE_ID TEAM_ID; do
+          for key in APP_ID TESTFLIGHT_GROUP TARGET_BUNDLE_ID TEAM_ID PROFILE_NAME; do
             if [ -z "${!key}" ]; then
               echo "Missing required repository variable: $key" >&2
               exit 1
             fi
           done
 
-          for key in ASC_KEY_ID_SECRET ASC_ISSUER_ID_SECRET ASC_PRIVATE_KEY_B64_SECRET; do
+          for key in \
+            ASC_KEY_ID_SECRET \
+            ASC_ISSUER_ID_SECRET \
+            ASC_PRIVATE_KEY_B64_SECRET \
+            SIGNING_CERTIFICATE_P12_B64_SECRET \
+            SIGNING_CERTIFICATE_PASSWORD_SECRET \
+            PROVISIONING_PROFILE_B64_SECRET; do
             if [ -z "${!key}" ]; then
-              echo "Missing required repository secret: ${key%_SECRET}" >&2
+              echo "Missing required repository secret for $key" >&2
               exit 1
             fi
           done
@@ -103,6 +113,56 @@ jobs:
             echo "ASC_ISSUER_ID=$ASC_ISSUER_ID_SECRET"
             echo "ASC_PRIVATE_KEY_PATH=$KEY_PATH"
           } >> "$GITHUB_ENV"
+
+      - name: Install distribution signing assets
+        env:
+          SIGNING_CERTIFICATE_P12_B64: ${{ secrets.FOUNDATION_LAB_DISTRIBUTION_P12_B64 }}
+          SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.FOUNDATION_LAB_DISTRIBUTION_P12_PASSWORD }}
+          PROVISIONING_PROFILE_B64: ${{ secrets.FOUNDATION_LAB_PROVISIONING_PROFILE_B64 }}
+        run: |
+          set -euo pipefail
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/foundation-lab-distribution.p12"
+          PROFILE_PATH="$RUNNER_TEMP/foundation-lab.mobileprovision"
+          PROFILE_PLIST="$RUNNER_TEMP/foundation-lab-profile.plist"
+          KEYCHAIN_PATH="$RUNNER_TEMP/foundation-lab-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 36)"
+
+          printf '%s' "$SIGNING_CERTIFICATE_P12_B64" | base64 --decode > "$CERTIFICATE_PATH"
+          printf '%s' "$PROVISIONING_PROFILE_B64" | base64 --decode > "$PROFILE_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$SIGNING_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security list-keychains -d user -s \
+            "$KEYCHAIN_PATH" \
+            "$HOME/Library/Keychains/login.keychain-db"
+
+          security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$PROFILE_PLIST")"
+          INSTALLED_PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$PROFILE_PLIST")"
+
+          if [ "$INSTALLED_PROFILE_NAME" != "$PROFILE_NAME" ]; then
+            echo "Provisioning profile name does not match FOUNDATION_LAB_PROFILE_NAME" >&2
+            exit 1
+          fi
+
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          cp "$PROFILE_PATH" \
+            "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
+
+          security find-identity -v -p codesigning
+          echo "SIGNING_KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
       - name: Resolve marketing version
         id: version
@@ -139,3 +199,12 @@ jobs:
           asc workflow run foundation_lab_testflight \
             "VERSION:${{ steps.version.outputs.version }}" \
             "UPLOAD:$UPLOAD"
+
+      - name: Remove temporary signing keychain
+        if: always()
+        run: |
+          if [ -n "${SIGNING_KEYCHAIN_PATH:-}" ]; then
+            security list-keychains -d user -s \
+              "$HOME/Library/Keychains/login.keychain-db" || true
+            security delete-keychain "$SIGNING_KEYCHAIN_PATH" || true
+          fi

--- a/.github/workflows/foundation-lab-testflight.yml
+++ b/.github/workflows/foundation-lab-testflight.yml
@@ -41,7 +41,7 @@ jobs:
       UPLOAD: ${{ github.event_name == 'push' || inputs.upload }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/FoundationLab.xcodeproj/project.pbxproj
+++ b/FoundationLab.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rudrankriyam.foundationlab${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -398,7 +398,9 @@
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_ENTITLEMENTS = "Foundation Lab/FoundationLab.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Foundation Lab/FoundationLab-macOS.entitlements";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = YQZQG7N4WG;
@@ -446,10 +448,11 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rudrankriyam.foundationlab${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "$(FOUNDATION_LAB_PROFILE_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
 				RUNTIME_EXCEPTION_ALLOW_JIT = NO;


### PR DESCRIPTION
## Summary

- bump Foundation Lab's marketing version to 1.2.0
- replace hosted-runner automatic provisioning with a dedicated Apple Distribution identity and App Store profile stored in encrypted GitHub secrets
- install signing assets in an ephemeral keychain, verify the profile name, and clean the keychain after every run
- render manual App Store Connect export options for the Foundation Lab bundle

## Why

The previous TestFlight job asked Xcode to manage signing automatically. On a fresh runner, Xcode attempted to create another development certificate, but the Apple team had reached its certificate limit and no matching provisioning profile was installed. A reusable distribution identity and profile make archive/export deterministic without revoking any existing certificate.

## Impact

Merging this PR triggers the 1.2.0 archive and TestFlight upload. Local Debug signing remains automatic; manual distribution signing is scoped to iPhoneOS Release builds only.

## Validation

- `actionlint .github/workflows/foundation-lab-testflight.yml`
- `asc workflow validate --pretty`
- ASC workflow dry runs with upload disabled and enabled
- Xcode 26.6 archive and IPA export using the dedicated distribution identity
- `codesign --verify --deep --strict` on the archived app
- verified version `1.2.0`, build `1`, bundle `com.rudrankriyam.foundationlab`, distribution entitlements, and 23 MB IPA
- strict SwiftLint
- FoundationLabCore: 52 XCTest + 15 Swift Testing tests
- FoundationModelsKit and tools: 90 tests
- AFMServer: 118 tests
