### PR TITLE
[codex] Fix invalid Siri support metadata

### DIFF
--- a/Foundation Lab/AppIntents/SearchMusicCatalogIntent.swift
+++ b/Foundation Lab/AppIntents/SearchMusicCatalogIntent.swift
@@ -5,7 +5,7 @@ import FoundationLabCore
 struct SearchMusicCatalogIntent: AppIntent {
     static let title: LocalizedStringResource = "Search Music Catalog"
     static let description = IntentDescription(
-        "Searches the Apple Music catalog for songs, albums, and artists."
+        "Searches the music catalog for songs, albums, and artists."
     )
     static let openAppWhenRun = true
 

--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -79072,66 +79072,66 @@
         }
       }
     },
-    "Searches the Apple Music catalog for songs, albums, and artists." : {
+    "Searches the music catalog for songs, albums, and artists." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durchsucht den Apple Music-Katalog nach Titeln, Alben und Künstlern."
+            "value" : "Durchsucht den Musikkatalog nach Titeln, Alben und Künstlern."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Searches the Apple Music catalog for songs, albums, and artists."
+            "value" : "Searches the music catalog for songs, albums, and artists."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Busca canciones, álbumes y artistas en el catálogo de Apple Music."
+            "value" : "Busca canciones, álbumes y artistas en el catálogo de música."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recherche dans le catalogue Apple Music des chansons, des albums et des artistes."
+            "value" : "Recherche des chansons, des albums et des artistes dans le catalogue musical."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cerca brani, album e artisti nel catalogo di Apple Music."
+            "value" : "Cerca brani, album e artisti nel catalogo musicale."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Music カタログで曲、アルバム、アーティストを検索します。"
+            "value" : "音楽カタログで曲、アルバム、アーティストを検索します。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Music 카탈로그에서 노래, 앨범 및 아티스트를 검색합니다."
+            "value" : "음악 카탈로그에서 노래, 앨범 및 아티스트를 검색합니다."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pesquisa músicas, álbuns e artistas no catálogo do Apple Music."
+            "value" : "Pesquisa músicas, álbuns e artistas no catálogo de música."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Apple Music 目录中搜索歌曲、专辑和艺术家。"
+            "value" : "在音乐目录中搜索歌曲、专辑和艺术家。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Apple Music 目錄中搜尋歌曲、專輯和藝人。"
+            "value" : "在音樂目錄中搜尋歌曲、專輯和藝人。"
           }
         }
       }


### PR DESCRIPTION
## Summary

- remove the reserved `Apple` term from the Search Music Catalog App Intent description
- update all ten localized description values to use the same generic music-catalog wording

## Root cause

App Store Connect rejected version 1.2.0 build 3 with `ITMS-90626` because Siri App Intent descriptions cannot contain `apple`. The `SearchMusicCatalogIntent` description used “Apple Music catalog.”

## Impact

The intent behavior is unchanged. A newly numbered binary can carry valid Siri metadata through App Store Connect validation.

## Validation

- `swiftlint lint --strict --config .swiftlint.yml 'Foundation Lab/AppIntents/SearchMusicCatalogIntent.swift'`
- parsed `Foundation Lab/Localizable.xcstrings` with `jq`
- confirmed no App Intent source contains the prohibited term
- Xcode 27 iOS Simulator build with `CODE_SIGNING_ALLOWED=NO`
- confirmed generated `Metadata.appintents/extract.actionsdata` contains the new description and no App Intent description contains `apple`