### PR TITLE
[codex] Refine Foundation Lab macOS workspace UX

### DIFF
--- a/Foundation Lab/Commands/FoundationLabNavigationCommands.swift
+++ b/Foundation Lab/Commands/FoundationLabNavigationCommands.swift
@@ -1,0 +1,33 @@
+#if os(macOS)
+import SwiftUI
+
+struct FoundationLabNavigationCommands: Commands {
+    @FocusedValue(\.foundationLabNavigationCoordinator) private var navigationCoordinator
+
+    var body: some Commands {
+        CommandMenu("Navigate") {
+            destinationButton(.library, shortcut: "1")
+            destinationButton(.playground, shortcut: "2")
+            destinationButton(.runs, shortcut: "3")
+        }
+    }
+
+    private func destinationButton(
+        _ destination: TabSelection,
+        shortcut: KeyEquivalent
+    ) -> some View {
+        Button(
+            destination.displayName,
+            systemImage: destination.systemImage
+        ) {
+            navigationCoordinator?.navigate(to: destination)
+        }
+        .keyboardShortcut(shortcut, modifiers: .command)
+        .disabled(navigationCoordinator == nil)
+    }
+}
+
+extension FocusedValues {
+    @Entry var foundationLabNavigationCoordinator: NavigationCoordinator?
+}
+#endif

--- a/Foundation Lab/FoundationLabApp.swift
+++ b/Foundation Lab/FoundationLabApp.swift
@@ -23,7 +23,10 @@ struct FoundationLabApp: App {
             AdaptiveNavigationView()
                 .modelContainer(for: [HealthMetric.self, HealthSession.self])
 #if os(macOS)
-                .frame(minWidth: 800, minHeight: 600)
+                .frame(
+                    minWidth: FoundationLabLayout.macOSMinimumWindowWidth,
+                    minHeight: FoundationLabLayout.macOSMinimumWindowHeight
+                )
                 .environment(agentBridgeController)
                 .task {
                     agentBridgeController.activatePersistedPreference()
@@ -38,6 +41,18 @@ struct FoundationLabApp: App {
                     ModelUnavailableView(reason: unavailabilityReason)
                 }
         }
+#if os(macOS)
+        .defaultSize(
+            width: FoundationLabLayout.macOSDefaultWindowWidth,
+            height: FoundationLabLayout.macOSDefaultWindowHeight
+        )
+        .commands {
+            SidebarCommands()
+            InspectorCommands()
+            FoundationLabNavigationCommands()
+        }
+#endif
+
 #if os(macOS)
         Settings {
             SettingsView()

--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -11064,6 +11064,71 @@
         }
       }
     },
+    "Navigate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navegar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naviga"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ナビゲート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탐색"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navegar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导航"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "導覽"
+          }
+        }
+      }
+    },
     "Name" : {
       "localizations" : {
         "de" : {

--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -11064,6 +11064,201 @@
         }
       }
     },
+    "Phase" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phase"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phase"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phase"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フェーズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단계"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阶段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "階段"
+          }
+        }
+      }
+    },
+    "Phase %lld of %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phase %lld von %lld"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phase %lld of %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase %lld de %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phase %lld sur %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase %lld di %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フェーズ %lld／%lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld단계"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fase %lld de %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %lld 阶段，共 %lld 阶段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %lld 階段，共 %lld 階段"
+          }
+        }
+      }
+    },
+    "Reference workspace" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzarbeitsbereich"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reference workspace"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espacio de trabajo de referencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace de travail de référence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Area di lavoro di riferimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リファレンスワークスペース"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "참조 작업 공간"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaço de trabalho de referência"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参考工作区"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "參考工作區"
+          }
+        }
+      }
+    },
     "Navigate" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -79137,66 +79332,66 @@
         }
       }
     },
-    "Searches the Apple Music catalog for songs, albums, and artists." : {
+    "Searches the music catalog for songs, albums, and artists." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durchsucht den Apple Music-Katalog nach Titeln, Alben und Künstlern."
+            "value" : "Durchsucht den Musikkatalog nach Titeln, Alben und Künstlern."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Searches the Apple Music catalog for songs, albums, and artists."
+            "value" : "Searches the music catalog for songs, albums, and artists."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Busca canciones, álbumes y artistas en el catálogo de Apple Music."
+            "value" : "Busca canciones, álbumes y artistas en el catálogo de música."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recherche dans le catalogue Apple Music des chansons, des albums et des artistes."
+            "value" : "Recherche des chansons, des albums et des artistes dans le catalogue musical."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cerca brani, album e artisti nel catalogo di Apple Music."
+            "value" : "Cerca brani, album e artisti nel catalogo musicale."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Music カタログで曲、アルバム、アーティストを検索します。"
+            "value" : "音楽カタログで曲、アルバム、アーティストを検索します。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Music 카탈로그에서 노래, 앨범 및 아티스트를 검색합니다."
+            "value" : "음악 카탈로그에서 노래, 앨범 및 아티스트를 검색합니다."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pesquisa músicas, álbuns e artistas no catálogo do Apple Music."
+            "value" : "Pesquisa músicas, álbuns e artistas no catálogo de música."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Apple Music 目录中搜索歌曲、专辑和艺术家。"
+            "value" : "在音乐目录中搜索歌曲、专辑和艺术家。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Apple Music 目錄中搜尋歌曲、專輯和藝人。"
+            "value" : "在音樂目錄中搜尋歌曲、專輯和藝人。"
           }
         }
       }

--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -79332,66 +79332,66 @@
         }
       }
     },
-    "Searches the music catalog for songs, albums, and artists." : {
+    "Searches the Apple Music catalog for songs, albums, and artists." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durchsucht den Musikkatalog nach Titeln, Alben und Künstlern."
+            "value" : "Durchsucht den Apple Music-Katalog nach Titeln, Alben und Künstlern."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Searches the music catalog for songs, albums, and artists."
+            "value" : "Searches the Apple Music catalog for songs, albums, and artists."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Busca canciones, álbumes y artistas en el catálogo de música."
+            "value" : "Busca canciones, álbumes y artistas en el catálogo de Apple Music."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recherche des chansons, des albums et des artistes dans le catalogue musical."
+            "value" : "Recherche dans le catalogue Apple Music des chansons, des albums et des artistes."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cerca brani, album e artisti nel catalogo musicale."
+            "value" : "Cerca brani, album e artisti nel catalogo di Apple Music."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "音楽カタログで曲、アルバム、アーティストを検索します。"
+            "value" : "Apple Music カタログで曲、アルバム、アーティストを検索します。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "음악 카탈로그에서 노래, 앨범 및 아티스트를 검색합니다."
+            "value" : "Apple Music 카탈로그에서 노래, 앨범 및 아티스트를 검색합니다."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pesquisa músicas, álbuns e artistas no catálogo de música."
+            "value" : "Pesquisa músicas, álbuns e artistas no catálogo do Apple Music."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在音乐目录中搜索歌曲、专辑和艺术家。"
+            "value" : "在 Apple Music 目录中搜索歌曲、专辑和艺术家。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在音樂目錄中搜尋歌曲、專輯和藝人。"
+            "value" : "在 Apple Music 目錄中搜尋歌曲、專輯和藝人。"
           }
         }
       }

--- a/Foundation Lab/Models/FoundationLabPreferenceKey.swift
+++ b/Foundation Lab/Models/FoundationLabPreferenceKey.swift
@@ -1,0 +1,11 @@
+enum FoundationLabPreferenceKey {
+    static let navigationSelection = "FoundationLab.navigation.selection"
+    static let sidebarIsVisible = "FoundationLab.navigation.sidebarIsVisible"
+    static let sidebarWidth = "FoundationLab.navigation.sidebarWidth"
+    static let playgroundInspectorIsVisible = "FoundationLab.playground.inspectorIsVisible"
+    static let playgroundInspectorWidth = "FoundationLab.playground.inspectorWidth"
+
+    static func workspaceStage(for workspace: Workspace) -> String {
+        "FoundationLab.workspace.\(workspace.rawValue).stage"
+    }
+}

--- a/Foundation Lab/Models/WorkspaceStage.swift
+++ b/Foundation Lab/Models/WorkspaceStage.swift
@@ -13,4 +13,8 @@ enum WorkspaceStage: String, CaseIterable, Identifiable {
     case output
 
     var id: Self { self }
+
+    var ordinal: Int {
+        Self.allCases.firstIndex(of: self).map { $0 + 1 } ?? 1
+    }
 }

--- a/Foundation Lab/Views/AdaptiveNavigationView.swift
+++ b/Foundation Lab/Views/AdaptiveNavigationView.swift
@@ -5,12 +5,13 @@
 //  Created by Rudrank Riyam on 6/22/25.
 //
 
-import SwiftUI
+import Foundation
 import FoundationModels
+import SwiftUI
 
 struct AdaptiveNavigationView: View {
     @State private var languageService = LanguageService()
-    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
+    @State private var columnVisibility: NavigationSplitViewVisibility
     @State private var navigationCoordinator = NavigationCoordinator()
     @State private var experimentStore = ExperimentStore()
     @State private var playgroundViewModel = ChatViewModel()
@@ -222,6 +223,21 @@ struct AdaptiveNavigationView: View {
             return
         }
         persistedSidebarWidth = Double(width)
+#endif
+    }
+}
+
+extension AdaptiveNavigationView {
+    init() {
+#if os(macOS)
+        let isSidebarVisible = UserDefaults.standard.object(
+            forKey: FoundationLabPreferenceKey.sidebarIsVisible
+        ) as? Bool ?? true
+        _columnVisibility = State(
+            initialValue: isSidebarVisible ? .all : .detailOnly
+        )
+#else
+        _columnVisibility = State(initialValue: .automatic)
 #endif
     }
 }

--- a/Foundation Lab/Views/AdaptiveNavigationView.swift
+++ b/Foundation Lab/Views/AdaptiveNavigationView.swift
@@ -36,6 +36,9 @@ struct AdaptiveNavigationView: View {
         .environment(languageService)
         .environment(navigationCoordinator)
         .environment(experimentStore)
+#if os(macOS)
+        .focusedSceneValue(\.foundationLabNavigationCoordinator, navigationCoordinator)
+#endif
         .onAppear {
             navigationCoordinator.activate()
             experimentStore.activate()

--- a/Foundation Lab/Views/AdaptiveNavigationView.swift
+++ b/Foundation Lab/Views/AdaptiveNavigationView.swift
@@ -17,6 +17,14 @@ struct AdaptiveNavigationView: View {
     @State private var persistenceFlushTask: Task<Void, Never>?
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.scenePhase) private var scenePhase
+#if os(macOS)
+    @AppStorage(FoundationLabPreferenceKey.navigationSelection)
+    private var persistedSelection = TabSelection.library.rawValue
+    @AppStorage(FoundationLabPreferenceKey.sidebarIsVisible)
+    private var persistedSidebarIsVisible = true
+    @AppStorage(FoundationLabPreferenceKey.sidebarWidth)
+    private var persistedSidebarWidth = Double(FoundationLabLayout.sidebarIdealWidth)
+#endif
 
     var body: some View {
         Group {
@@ -40,10 +48,12 @@ struct AdaptiveNavigationView: View {
         .focusedSceneValue(\.foundationLabNavigationCoordinator, navigationCoordinator)
 #endif
         .onAppear {
+            restorePersistedNavigationState()
             navigationCoordinator.activate()
             experimentStore.activate()
         }
         .onChange(of: navigationCoordinator.tabSelection) { oldValue, newValue in
+            persistNavigationSelection(newValue)
             if oldValue == .playground, newValue != .playground {
                 playgroundViewModel.suspendVoiceMode()
             }
@@ -116,7 +126,11 @@ struct AdaptiveNavigationView: View {
         NavigationSplitView(
             columnVisibility: $columnVisibility
         ) {
-            SidebarView(selection: $navigationCoordinator.splitViewSelection)
+            SidebarView(
+                selection: $navigationCoordinator.splitViewSelection,
+                preferredWidth: sidebarPreferredWidth,
+                onWidthChange: persistSidebarWidth
+            )
         } detail: {
             detailView
         }
@@ -125,6 +139,9 @@ struct AdaptiveNavigationView: View {
             if let newValue {
                 navigationCoordinator.tabSelection = newValue
             }
+        }
+        .onChange(of: columnVisibility) { _, newValue in
+            persistSidebarVisibility(newValue)
         }
     }
 
@@ -163,6 +180,49 @@ struct AdaptiveNavigationView: View {
         persistenceFlushTask = Task {
             _ = await experimentStore.flushPendingPersistence()
         }
+    }
+
+    private var sidebarPreferredWidth: CGFloat {
+#if os(macOS)
+        min(
+            max(CGFloat(persistedSidebarWidth), FoundationLabLayout.sidebarMinimumWidth),
+            FoundationLabLayout.sidebarMaximumWidth
+        )
+#else
+        FoundationLabLayout.sidebarIdealWidth
+#endif
+    }
+
+    private func restorePersistedNavigationState() {
+#if os(macOS)
+        if let selection = TabSelection(rawValue: persistedSelection) {
+            navigationCoordinator.tabSelection = selection
+            navigationCoordinator.splitViewSelection = selection
+        }
+        columnVisibility = persistedSidebarIsVisible ? .all : .detailOnly
+#endif
+    }
+
+    private func persistNavigationSelection(_ selection: TabSelection) {
+#if os(macOS)
+        persistedSelection = selection.rawValue
+#endif
+    }
+
+    private func persistSidebarVisibility(_ visibility: NavigationSplitViewVisibility) {
+#if os(macOS)
+        persistedSidebarIsVisible = visibility != .detailOnly
+#endif
+    }
+
+    private func persistSidebarWidth(_ width: CGFloat) {
+#if os(macOS)
+        guard (FoundationLabLayout.sidebarMinimumWidth ... FoundationLabLayout.sidebarMaximumWidth).contains(width),
+              abs(persistedSidebarWidth - Double(width)) >= 0.5 else {
+            return
+        }
+        persistedSidebarWidth = Double(width)
+#endif
     }
 }
 

--- a/Foundation Lab/Views/Components/FoundationLabLayout.swift
+++ b/Foundation Lab/Views/Components/FoundationLabLayout.swift
@@ -10,6 +10,9 @@ enum FoundationLabLayout {
     static let readableContentWidth: CGFloat = 760
     static let transcriptContentWidth: CGFloat = 820
     static let workspaceContentWidth: CGFloat = 960
+    static let sidebarMinimumWidth: CGFloat = 180
+    static let sidebarIdealWidth: CGFloat = 220
+    static let sidebarMaximumWidth: CGFloat = 280
     static let inspectorMinimumWidth: CGFloat = 300
     static let inspectorIdealWidth: CGFloat = 360
     static let inspectorMaximumWidth: CGFloat = 440

--- a/Foundation Lab/Views/Components/FoundationLabLayout.swift
+++ b/Foundation Lab/Views/Components/FoundationLabLayout.swift
@@ -13,4 +13,11 @@ enum FoundationLabLayout {
     static let inspectorMinimumWidth: CGFloat = 300
     static let inspectorIdealWidth: CGFloat = 360
     static let inspectorMaximumWidth: CGFloat = 440
+
+#if os(macOS)
+    static let macOSMinimumWindowWidth: CGFloat = 960
+    static let macOSMinimumWindowHeight: CGFloat = 640
+    static let macOSDefaultWindowWidth: CGFloat = 1_320
+    static let macOSDefaultWindowHeight: CGFloat = 820
+#endif
 }

--- a/Foundation Lab/Views/Playground/PlaygroundView.swift
+++ b/Foundation Lab/Views/Playground/PlaygroundView.swift
@@ -9,7 +9,14 @@ struct PlaygroundView: View {
     let viewModel: ChatViewModel
     @State private var messageText = ""
     @State private var scrollID: String?
+#if os(macOS)
+    @AppStorage(FoundationLabPreferenceKey.playgroundInspectorIsVisible)
+    private var showsInspector = true
+    @AppStorage(FoundationLabPreferenceKey.playgroundInspectorWidth)
+    private var persistedInspectorWidth = Double(FoundationLabLayout.inspectorIdealWidth)
+#else
     @State private var showsInspector = false
+#endif
 #if os(iOS)
     @State private var showsSettings = false
 #endif
@@ -61,9 +68,6 @@ struct PlaygroundView: View {
                 Button("Configure Experiment", systemImage: "sidebar.trailing") {
                     showsInspector.toggle()
                 }
-#if os(macOS)
-                .keyboardShortcut("i", modifiers: [.command, .option])
-#endif
 
                 ExperimentActionsMenu(
                     isShowingDiscardConfirmation: $showsDiscardConfirmation,
@@ -121,9 +125,16 @@ struct PlaygroundView: View {
                 }
                 .inspectorColumnWidth(
                     min: FoundationLabLayout.inspectorMinimumWidth,
-                    ideal: FoundationLabLayout.inspectorIdealWidth,
+                    ideal: inspectorPreferredWidth,
                     max: FoundationLabLayout.inspectorMaximumWidth
                 )
+#if os(macOS)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { width in
+                    persistInspectorWidth(width)
+                }
+#endif
             }
         }
 #if os(iOS)
@@ -148,15 +159,31 @@ struct PlaygroundView: View {
         .task(id: experimentStore.activeExperimentLoadRevision) {
             loadActiveExperiment()
         }
-        .task {
-#if os(macOS)
-            showsInspector = true
-#endif
-        }
     }
 }
 
 private extension PlaygroundView {
+    private var inspectorPreferredWidth: CGFloat {
+#if os(macOS)
+        min(
+            max(CGFloat(persistedInspectorWidth), FoundationLabLayout.inspectorMinimumWidth),
+            FoundationLabLayout.inspectorMaximumWidth
+        )
+#else
+        FoundationLabLayout.inspectorIdealWidth
+#endif
+    }
+
+    private func persistInspectorWidth(_ width: CGFloat) {
+#if os(macOS)
+        guard (FoundationLabLayout.inspectorMinimumWidth ... FoundationLabLayout.inspectorMaximumWidth).contains(width),
+              abs(persistedInspectorWidth - Double(width)) >= 0.5 else {
+            return
+        }
+        persistedInspectorWidth = Double(width)
+#endif
+    }
+
     private func loadActiveExperiment() {
         guard viewModel.activeExperimentLoadRevision != experimentStore.activeExperimentLoadRevision else {
             return

--- a/Foundation Lab/Views/SidebarView.swift
+++ b/Foundation Lab/Views/SidebarView.swift
@@ -15,9 +15,6 @@ struct SidebarView: View {
             ForEach(TabSelection.allCases, id: \.self) { tab in
                 Label(tab.displayName, systemImage: tab.systemImage)
                     .tag(tab)
-#if os(macOS)
-                    .keyboardShortcut(tab.keyboardShortcut, modifiers: .command)
-#endif
             }
         }
         .listStyle(.sidebar)
@@ -40,15 +37,6 @@ extension TabSelection {
         }
     }
 
-#if os(macOS)
-    var keyboardShortcut: KeyEquivalent {
-        switch self {
-        case .library: return "1"
-        case .playground: return "2"
-        case .runs: return "3"
-        }
-    }
-#endif
 }
 
 #Preview {

--- a/Foundation Lab/Views/SidebarView.swift
+++ b/Foundation Lab/Views/SidebarView.swift
@@ -9,6 +9,18 @@ import SwiftUI
 
 struct SidebarView: View {
     @Binding var selection: TabSelection?
+    let preferredWidth: CGFloat
+    let onWidthChange: (CGFloat) -> Void
+
+    init(
+        selection: Binding<TabSelection?>,
+        preferredWidth: CGFloat = FoundationLabLayout.sidebarIdealWidth,
+        onWidthChange: @escaping (CGFloat) -> Void = { _ in }
+    ) {
+        _selection = selection
+        self.preferredWidth = preferredWidth
+        self.onWidthChange = onWidthChange
+    }
 
     var body: some View {
         List(selection: $selection) {
@@ -20,7 +32,16 @@ struct SidebarView: View {
         .listStyle(.sidebar)
         .navigationTitle("Foundation Lab")
 #if os(macOS)
-        .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 280)
+        .navigationSplitViewColumnWidth(
+            min: FoundationLabLayout.sidebarMinimumWidth,
+            ideal: preferredWidth,
+            max: FoundationLabLayout.sidebarMaximumWidth
+        )
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            onWidthChange(width)
+        }
 #endif
     }
 }

--- a/Foundation Lab/Views/WorkspacePhaseHeader.swift
+++ b/Foundation Lab/Views/WorkspacePhaseHeader.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct WorkspacePhaseHeader: View {
+    let workspace: Workspace
+    let stage: WorkspaceStage
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.large) {
+                titleAndSummary
+                Spacer(minLength: Spacing.large)
+                phasePosition
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                titleAndSummary
+                phasePosition
+            }
+        }
+    }
+
+    private var titleAndSummary: some View {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
+            Label(workspace.title(for: stage), systemImage: workspace.systemImage(for: stage))
+                .font(.title2.bold())
+
+            Text(workspace.summary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var phasePosition: some View {
+        Text(
+            String(
+                localized: "Phase \(stage.ordinal) of \(WorkspaceStage.allCases.count)"
+            )
+        )
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+    }
+}
+
+#Preview {
+    WorkspacePhaseHeader(workspace: .adapterComparison, stage: .runs)
+        .padding()
+}

--- a/Foundation Lab/Views/WorkspaceStatusRail.swift
+++ b/Foundation Lab/Views/WorkspaceStatusRail.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct WorkspaceStatusRail: View {
+    let title: String
+    let context: String
+    let systemImage: String
+    let isActive: Bool
+
+    var body: some View {
+        HStack(spacing: Spacing.small) {
+            if isActive {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel(title)
+            } else {
+                Image(systemName: systemImage)
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+
+            Text(title)
+                .lineLimit(1)
+                .help(title)
+
+            Spacer(minLength: Spacing.medium)
+
+            Text(context)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .font(.callout)
+        .padding(.horizontal, Spacing.medium)
+        .padding(.vertical, Spacing.xSmall)
+        .background(.bar)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    WorkspaceStatusRail(
+        title: "Comparison complete",
+        context: "Results",
+        systemImage: "checkmark.circle",
+        isActive: false
+    )
+}

--- a/Foundation Lab/Views/WorkspaceStatusRail.swift
+++ b/Foundation Lab/Views/WorkspaceStatusRail.swift
@@ -11,7 +11,7 @@ struct WorkspaceStatusRail: View {
             if isActive {
                 ProgressView()
                     .controlSize(.small)
-                    .accessibilityLabel(title)
+                    .accessibilityHidden(true)
             } else {
                 Image(systemName: systemImage)
                     .foregroundStyle(.secondary)
@@ -20,7 +20,6 @@ struct WorkspaceStatusRail: View {
 
             Text(title)
                 .lineLimit(1)
-                .help(title)
 
             Spacer(minLength: Spacing.medium)
 

--- a/Foundation Lab/Views/WorkspaceView.swift
+++ b/Foundation Lab/Views/WorkspaceView.swift
@@ -8,13 +8,21 @@ import SwiftUI
 struct WorkspaceView: View {
     let workspace: Workspace
 
-    @State private var selectedStage = WorkspaceStage.settings
+    @AppStorage private var selectedStageRawValue: String
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
 #if os(macOS)
     @State private var adapterStudioViewModel = AdapterStudioViewModel()
 #endif
+
+    init(workspace: Workspace) {
+        self.workspace = workspace
+        _selectedStageRawValue = AppStorage(
+            wrappedValue: WorkspaceStage.settings.rawValue,
+            FoundationLabPreferenceKey.workspaceStage(for: workspace)
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -43,7 +51,7 @@ struct WorkspaceView: View {
     @ViewBuilder
     private var stagePicker: some View {
         if horizontalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize {
-            Picker("Stage", selection: $selectedStage) {
+            Picker("Stage", selection: $selectedStageRawValue) {
                 stages
             }
             .pickerStyle(.menu)
@@ -52,7 +60,7 @@ struct WorkspaceView: View {
             .frame(minHeight: FoundationLabLayout.minimumTouchTarget)
             .background(.bar)
         } else {
-            Picker("Stage", selection: $selectedStage) {
+            Picker("Stage", selection: $selectedStageRawValue) {
                 stages
             }
             .pickerStyle(.segmented)
@@ -68,7 +76,7 @@ struct WorkspaceView: View {
     private var stages: some View {
         ForEach(WorkspaceStage.allCases) { stage in
             Label(workspace.title(for: stage), systemImage: workspace.systemImage(for: stage))
-                .tag(stage)
+                .tag(stage.rawValue)
         }
     }
 
@@ -86,6 +94,7 @@ struct WorkspaceView: View {
 
     @ViewBuilder
     private var workspaceContent: some View {
+        let selectedStage = WorkspaceStage(rawValue: selectedStageRawValue) ?? .settings
         switch workspace {
         case .adapterComparison:
 #if os(macOS)

--- a/Foundation Lab/Views/WorkspaceView.swift
+++ b/Foundation Lab/Views/WorkspaceView.swift
@@ -31,7 +31,10 @@ struct WorkspaceView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: Spacing.xLarge) {
-                    workspaceHeader
+                    WorkspacePhaseHeader(
+                        workspace: workspace,
+                        stage: selectedStage
+                    )
                     workspaceContent
                 }
                 .padding(.horizontal, Spacing.xxLarge)
@@ -39,6 +42,15 @@ struct WorkspaceView: View {
                 .frame(maxWidth: FoundationLabLayout.workspaceContentWidth, alignment: .leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+
+            Divider()
+
+            WorkspaceStatusRail(
+                title: workspaceStatusTitle,
+                context: workspace.title(for: selectedStage),
+                systemImage: workspaceStatusSystemImage,
+                isActive: workspaceStatusIsActive
+            )
         }
         .navigationTitle(workspace.title)
 #if os(iOS)
@@ -51,7 +63,7 @@ struct WorkspaceView: View {
     @ViewBuilder
     private var stagePicker: some View {
         if horizontalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize {
-            Picker("Stage", selection: $selectedStageRawValue) {
+            Picker("Phase", selection: $selectedStageRawValue) {
                 stages
             }
             .pickerStyle(.menu)
@@ -60,7 +72,7 @@ struct WorkspaceView: View {
             .frame(minHeight: FoundationLabLayout.minimumTouchTarget)
             .background(.bar)
         } else {
-            Picker("Stage", selection: $selectedStageRawValue) {
+            Picker("Phase", selection: $selectedStageRawValue) {
                 stages
             }
             .pickerStyle(.segmented)
@@ -80,21 +92,12 @@ struct WorkspaceView: View {
         }
     }
 
-    private var workspaceHeader: some View {
-        VStack(alignment: .leading, spacing: Spacing.xSmall) {
-            Label(workspace.title, systemImage: workspace.systemImage)
-                .font(.title2.bold())
-
-            Text(workspace.summary)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
+    private var selectedStage: WorkspaceStage {
+        WorkspaceStage(rawValue: selectedStageRawValue) ?? .settings
     }
 
     @ViewBuilder
     private var workspaceContent: some View {
-        let selectedStage = WorkspaceStage(rawValue: selectedStageRawValue) ?? .settings
         switch workspace {
         case .adapterComparison:
 #if os(macOS)
@@ -108,6 +111,49 @@ struct WorkspaceView: View {
         case .fmfBench:
             FMFBenchStudioContent(stage: selectedStage)
         }
+    }
+
+    private var workspaceStatusTitle: String {
+        switch workspace {
+        case .adapterComparison:
+#if os(macOS)
+            adapterStudioViewModel.statusDescription
+#else
+            String(localized: "Adapter Comparison Requires macOS")
+#endif
+        case .fmfBench:
+            String(localized: "Reference workspace")
+        }
+    }
+
+    private var workspaceStatusSystemImage: String {
+        switch workspace {
+        case .adapterComparison:
+#if os(macOS)
+            switch adapterStudioViewModel.state {
+            case .idle:
+                adapterStudioViewModel.adapterContext == nil ? "shippingbox" : "circle"
+            case .running:
+                "circle.dotted"
+            case .failed:
+                "exclamationmark.triangle"
+            case .completed:
+                "checkmark.circle"
+            }
+#else
+            "macbook"
+#endif
+        case .fmfBench:
+            "terminal"
+        }
+    }
+
+    private var workspaceStatusIsActive: Bool {
+#if os(macOS)
+        workspace == .adapterComparison && adapterStudioViewModel.isRunning
+#else
+        false
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary

- increase the macOS default window to keep the Playground canvas generous with its configuration inspector open
- add native Sidebar and Inspector commands plus a localized Navigate menu for Library, Playground, and Runs
- restore the selected destination, sidebar and inspector visibility, user-resized split widths, and each expert workspace phase across launches
- make Adapter Comparison and FMFBench read as explicit five-phase workflows with contextual, truthful status rails
- localize the new navigation and phase copy across all ten supported languages

## User impact

Foundation Lab now behaves more like a native Apple developer tool on Mac: key panels are discoverable from the menu bar, the Playground remains the visual center, window state survives relaunches, and expert workspaces communicate both the current phase and actual activity without decorative chrome or invented progress.

## Validation

- `swiftlint lint --strict --config .swiftlint.yml`
- `swift test` with Xcode 26.6
- `swift test` with Xcode 27 beta 2 (four runtime-gated modern error tests skipped on the installed older Foundation Models runtime)
- macOS and iOS Simulator builds with Xcode 26.6
- macOS and iOS Simulator builds with Xcode 27 beta 2
- native macOS visual QA for menu commands, Playground inspector behavior, expert phase/status presentation, and state restoration after quit and relaunch
