### PR TITLE
[codex] Pin dependencies and guard copied samples

### DIFF
--- a/.github/workflows/foundation-lab-pr.yml
+++ b/.github/workflows/foundation-lab-pr.yml
@@ -1,0 +1,36 @@
+name: Foundation Lab PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'BookPlaygrounds/**'
+      - 'Foundation Lab/**'
+      - 'FoundationLabCore/**'
+      - 'FoundationLab.xcodeproj/**'
+      - 'Package.swift'
+      - 'Package.resolved'
+      - 'SampleCode.xcconfig'
+      - 'Tools/BookPlaygrounds/**'
+      - '.github/workflows/foundation-lab-pr.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: foundation-lab-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: macos-26
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Build and test FoundationLabCore
+        run: swift test
+
+      - name: Typecheck book playgrounds
+        run: bash Tools/BookPlaygrounds/typecheck.sh

--- a/BookPlaygrounds/03_GenerationOptionsAndSamplingControl/05_SamplingStrategies.swift
+++ b/BookPlaygrounds/03_GenerationOptionsAndSamplingControl/05_SamplingStrategies.swift
@@ -8,7 +8,7 @@ import Playgrounds
     // Greedy sampling - always chooses most likely token
     debugPrint("Greedy Sampling (Deterministic)")
     let greedyOptions = GenerationOptions(
-        samplingMode: .greedy,
+        sampling: .greedy,
         temperature: nil // Temperature is ignored with greedy sampling
     )
     let greedyResponse = try await session.respond(to: prompt, options: greedyOptions)
@@ -17,7 +17,7 @@ import Playgrounds
     // Top-K sampling with smaller K (more deterministic)
     debugPrint("Top-K Sampling (K=30, More Focused)")
     let topKSmallOptions = GenerationOptions(
-        samplingMode: .random(top: 30, seed: nil),
+        sampling: .random(top: 30, seed: nil),
         temperature: 0.7
     )
     let topKSmallResponse = try await session.respond(to: prompt, options: topKSmallOptions)
@@ -26,7 +26,7 @@ import Playgrounds
     // Top-K sampling with larger K (more creative)
     debugPrint("Top-K Sampling (K=50, More Creative)")
     let topKLargeOptions = GenerationOptions(
-        samplingMode: .random(top: 50, seed: nil),
+        sampling: .random(top: 50, seed: nil),
         temperature: 0.7
     )
     let topKLargeResponse = try await session.respond(to: prompt, options: topKLargeOptions)
@@ -35,7 +35,7 @@ import Playgrounds
     // Top-P sampling with conservative threshold
     debugPrint("Top-P Sampling (P=0.8, Conservative)")
     let topPConservativeOptions = GenerationOptions(
-        samplingMode: .random(probabilityThreshold: 0.8, seed: nil),
+        sampling: .random(probabilityThreshold: 0.8, seed: nil),
         temperature: 0.6
     )
     let topPConservativeResponse = try await session.respond(to: prompt, options: topPConservativeOptions)
@@ -44,7 +44,7 @@ import Playgrounds
     // Top-P sampling with higher threshold
     debugPrint("Top-P Sampling (P=0.9, More Creative)")
     let topPCreativeOptions = GenerationOptions(
-        samplingMode: .random(probabilityThreshold: 0.9, seed: nil),
+        sampling: .random(probabilityThreshold: 0.9, seed: nil),
         temperature: 0.7
     )
     let topPCreativeResponse = try await session.respond(to: prompt, options: topPCreativeOptions)
@@ -53,7 +53,7 @@ import Playgrounds
     // Reproducible results with seed
     debugPrint("Reproducible Results (With Seed)")
     let seededOptions = GenerationOptions(
-        samplingMode: .random(top: 30, seed: 12345),
+        sampling: .random(top: 30, seed: 12345),
         temperature: 0.8
     )
     let seededResponse1 = try await session.respond(to: prompt, options: seededOptions)
@@ -65,7 +65,7 @@ import Playgrounds
     // System default (recommended)
     debugPrint("System Default (Recommended)")
     let systemDefaultOptions = GenerationOptions(
-        samplingMode: nil,
+        sampling: nil,
         temperature: nil
     )
     let systemDefaultResponse = try await session.respond(to: prompt, options: systemDefaultOptions)

--- a/Foundation Lab/Views/Playground/ExperimentCodeGenerator.swift
+++ b/Foundation Lab/Views/Playground/ExperimentCodeGenerator.swift
@@ -76,7 +76,7 @@ enum ExperimentCodeGenerator {
 
         return """
         let options = GenerationOptions(
-            samplingMode: \(sampling),
+            sampling: \(sampling),
             temperature: \(temperature),
             maximumResponseTokens: \(maximumResponseTokens)
         )

--- a/FoundationLab.xcodeproj/project.pbxproj
+++ b/FoundationLab.xcodeproj/project.pbxproj
@@ -506,8 +506,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rryam/FoundationModelsKit.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = 672f8231dff61364393bae04c84b1c921695eadc;
 			};
 		};
 		0AC6037E2E1D5288002106F9 /* XCRemoteSwiftPackageReference "HighlightSwift" */ = {
@@ -522,8 +522,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rryam/LumoKit.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = e18baa1e5c7677216350380f298338f1abb45f7c;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FoundationLab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FoundationLab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,11 @@
 {
-  "originHash" : "4aa1eaab8716884035d5b71dec3005a6dadabe058acd9f3d1b79a0b51e1c51fb",
+  "originHash" : "13b6af4b29c5575663bf97598fc5d5a239e5890ac8ae20bf713632b3aa0d41f4",
   "pins" : [
     {
       "identity" : "foundationmodelskit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/FoundationModelsKit.git",
       "state" : {
-        "branch" : "main",
         "revision" : "672f8231dff61364393bae04c84b1c921695eadc"
       }
     },
@@ -33,7 +32,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/LumoKit.git",
       "state" : {
-        "branch" : "main",
         "revision" : "e18baa1e5c7677216350380f298338f1abb45f7c"
       }
     },

--- a/FoundationLabCore/Package.swift
+++ b/FoundationLabCore/Package.swift
@@ -16,7 +16,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/rryam/FoundationModelsKit.git", branch: "main")
+        .package(
+            url: "https://github.com/rryam/FoundationModelsKit.git",
+            revision: "672f8231dff61364393bae04c84b1c921695eadc"
+        )
     ],
     targets: [
         .target(

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,11 @@
 {
-  "originHash" : "c00aa96a879b2bf8d7f476a42ead1e90737d74f5506a8d26beee969c67cbea30",
+  "originHash" : "fa174ac8cb56b4a73735e2dcdf0accd5fb6485ea67337c478e79934f46a5caed",
   "pins" : [
     {
       "identity" : "foundationmodelskit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/FoundationModelsKit.git",
       "state" : {
-        "branch" : "main",
         "revision" : "672f8231dff61364393bae04c84b1c921695eadc"
       }
     }

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,10 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/rryam/FoundationModelsKit.git", branch: "main")
+        .package(
+            url: "https://github.com/rryam/FoundationModelsKit.git",
+            revision: "672f8231dff61364393bae04c84b1c921695eadc"
+        )
     ],
     targets: [
         .target(

--- a/Tools/BookPlaygrounds/typecheck.sh
+++ b/Tools/BookPlaygrounds/typecheck.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+swift build
+
+for dir in BookPlaygrounds/*; do
+    [ -d "$dir" ] || continue
+
+    shopt -s nullglob
+    files=("$dir"/*.swift)
+    shopt -u nullglob
+
+    [ "${#files[@]}" -gt 0 ] || continue
+
+    printf 'Typechecking %s\n' "$dir"
+    xcrun swiftc \
+        -suppress-warnings \
+        -typecheck \
+        -I .build/out/Products/Debug \
+        "${files[@]}"
+done

--- a/Tools/BookPlaygrounds/typecheck.sh
+++ b/Tools/BookPlaygrounds/typecheck.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 swift build
+module_path="$(swift build --show-bin-path)"
 
 for dir in BookPlaygrounds/*; do
     [ -d "$dir" ] || continue
@@ -16,6 +17,6 @@ for dir in BookPlaygrounds/*; do
     xcrun swiftc \
         -suppress-warnings \
         -typecheck \
-        -I .build/out/Products/Debug \
+        -I "$module_path" \
         "${files[@]}"
 done

--- a/Tools/BookPlaygrounds/typecheck.sh
+++ b/Tools/BookPlaygrounds/typecheck.sh
@@ -18,5 +18,6 @@ for dir in BookPlaygrounds/*; do
         -suppress-warnings \
         -typecheck \
         -I "$module_path" \
+        -I "$module_path/Modules" \
         "${files[@]}"
 done


### PR DESCRIPTION
## Summary

- Pins the direct `FoundationModelsKit` package references to the currently resolved commit instead of tracking `main`.
- Pins the direct Xcode project references for `FoundationModelsKit` and `LumoKit` to their currently resolved commits.
- Adds a PR workflow that runs `swift test` and typechecks the copyable `BookPlaygrounds` chapter snippets.
- Fixes the copied generation-options sample/template to use the CI-compatible `GenerationOptions(sampling:)` label.

## Notes

The remaining `branch: main` entries in the Xcode `Package.resolved` file are transitive requirements from the `LumoKit` dependency graph (`swift-embeddings` and `VecturaKit`). I left those alone because hand-editing generated lockfile state would be reverted by Xcode resolution unless the upstream manifests change or this repo takes explicit ownership of those transitive pins.

## Verification

- `swift test`
- `bash Tools/BookPlaygrounds/typecheck.sh`
- `xcodebuild -quiet -project FoundationLab.xcodeproj -scheme 'Foundation Lab' -destination 'generic/platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`