### PR TITLE
Fix audited defects: FoundationModelsKit 2.1.0 bump, docs, and safety fixes

### DIFF
--- a/BookPlaygrounds/08_BasicToolUse/03_CalculatorTool.swift
+++ b/BookPlaygrounds/08_BasicToolUse/03_CalculatorTool.swift
@@ -15,12 +15,20 @@ struct CalculatorTool: Tool {
                       "division"
 
     @Generable
+    enum Operation: String {
+        case add
+        case subtract
+        case multiply
+        case divide
+    }
+
+    @Generable
     struct Arguments {
         @Guide(description: "The first number in the calculation")
         var firstNumber: Double
 
-        @Guide(description: "The mathematical operation: 'add', 'subtract', 'multiply', or 'divide'")
-        var operation: String
+        @Guide(description: "The mathematical operation to perform")
+        var operation: Operation
 
         @Guide(description: "The second number in the calculation")
         var secondNumber: Double
@@ -36,19 +44,17 @@ struct CalculatorTool: Tool {
     }
 
     func call(arguments: Arguments) async throws -> CalculationResult {
-        let operation = arguments.operation.lowercased()
+        let operation = arguments.operation
 
-        guard let result = performCalculation(
+        if operation == .divide && arguments.secondNumber == 0 {
+            throw CalculationError.divisionByZero
+        }
+
+        let result = performCalculation(
             first: arguments.firstNumber,
             operation: operation,
             second: arguments.secondNumber
-        ) else {
-            if operation == "divide" && arguments.secondNumber == 0 {
-                throw CalculationError.divisionByZero
-            } else {
-                throw CalculationError.unsupportedOperation(operation)
-            }
-        }
+        )
 
         let expression = formatExpression(
             first: arguments.firstNumber,
@@ -58,7 +64,7 @@ struct CalculatorTool: Tool {
         )
 
         return CalculationResult(
-            operation: operation,
+            operation: operation.rawValue,
             firstNumber: arguments.firstNumber,
             secondNumber: arguments.secondNumber,
             result: result,
@@ -66,33 +72,30 @@ struct CalculatorTool: Tool {
         )
     }
 
-    private func performCalculation(first: Double, operation: String, second: Double) -> Double? {
+    private func performCalculation(first: Double, operation: Operation, second: Double) -> Double {
         switch operation {
-        case "add", "addition", "+":
+        case .add:
             return first + second
-        case "subtract", "subtraction", "-":
+        case .subtract:
             return first - second
-        case "multiply", "multiplication", "*":
+        case .multiply:
             return first * second
-        case "divide", "division", "/":
-            return second != 0 ? first / second : nil
-        default:
-            return nil
+        case .divide:
+            return first / second
         }
     }
 
-    private func formatExpression(first: Double, operation: String, second: Double, result: Double) -> String {
+    private func formatExpression(first: Double, operation: Operation, second: Double, result: Double) -> String {
         let operatorSymbol = getOperatorSymbol(for: operation)
         return "\(formatNumber(first)) \(operatorSymbol) \(formatNumber(second)) = \(formatNumber(result))"
     }
 
-    private func getOperatorSymbol(for operation: String) -> String {
+    private func getOperatorSymbol(for operation: Operation) -> String {
         switch operation {
-        case "add", "addition": return "+"
-        case "subtract", "subtraction": return "-"
-        case "multiply", "multiplication": return "×"
-        case "divide", "division": return "÷"
-        default: return operation
+        case .add: return "+"
+        case .subtract: return "-"
+        case .multiply: return "×"
+        case .divide: return "÷"
         }
     }
 
@@ -106,14 +109,11 @@ struct CalculatorTool: Tool {
 
     enum CalculationError: Error, LocalizedError {
         case divisionByZero
-        case unsupportedOperation(String)
 
         var errorDescription: String? {
             switch self {
             case .divisionByZero:
                 return "Cannot divide by zero"
-            case .unsupportedOperation(let operation):
-                return "Unsupported operation: '\(operation)'. Use 'add', 'subtract', 'multiply', or 'divide'."
             }
         }
     }
@@ -124,7 +124,7 @@ struct CalculatorTool: Tool {
 
     let arguments = CalculatorTool.Arguments(
         firstNumber: 15.5,
-        operation: "multiply",
+        operation: .multiply,
         secondNumber: 3.2
     )
 

--- a/BookPlaygrounds/README.md
+++ b/BookPlaygrounds/README.md
@@ -8,7 +8,7 @@ It is part of the [Exploring Foundation Models](https://academy.rudrank.com/prod
 
 The playgrounds are organized into different learning paths, each building upon the previous concepts:
 
-- ** GettingStartedWithSessions** - Core session management and basic interactions
+- **GettingStartedWithSessions** - Core session management and basic interactions
 - **GenerationOptionsAndSamplingControl** - Fine-tuning model behavior and output
 - **BasicToolUse** - Extending model capabilities with custom tools
 - **SupportedLanguagesAndInternationalization** - Working with multiple languages
@@ -20,7 +20,7 @@ Each playground consists of Swift files that demonstrate progressive concepts. A
 ### Prerequisites
 
 - Xcode 26.0 or later
-- iOS 26.0+ or macOS 15.6+
+- iOS 26.0+ or macOS 26.0+
 
 ## Getting Started with Sessions
 

--- a/Foundation Lab/AppIntents/AnalyzeNutritionIntent.swift
+++ b/Foundation Lab/AppIntents/AnalyzeNutritionIntent.swift
@@ -20,11 +20,11 @@ struct AnalyzeNutritionIntent: AppIntent {
     var responseLanguage: String?
 
     func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let trimmedResponseLanguage = responseLanguage?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedResponseLanguage = responseLanguage?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let response = try await AnalyzeNutritionUseCase().execute(
             AnalyzeNutritionRequest(
                 foodDescription: mealDescription,
-                responseLanguage: trimmedResponseLanguage?.isEmpty == false ? trimmedResponseLanguage! : "English",
+                responseLanguage: trimmedResponseLanguage.isEmpty ? "English" : trimmedResponseLanguage,
                 context: FoundationModelInvocationContext(
                     source: .appIntent,
                     localeIdentifier: Locale.current.identifier

--- a/FoundationLab.xcodeproj/project.pbxproj
+++ b/FoundationLab.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 			repositoryURL = "https://github.com/rryam/FoundationModelsKit.git";
 			requirement = {
 				kind = revision;
-				revision = 672f8231dff61364393bae04c84b1c921695eadc;
+				revision = 1cad71a114cd8b321804b4f73a550ac500aafe1b;
 			};
 		};
 		0AC6037E2E1D5288002106F9 /* XCRemoteSwiftPackageReference "HighlightSwift" */ = {

--- a/FoundationLab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FoundationLab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/FoundationModelsKit.git",
       "state" : {
-        "revision" : "672f8231dff61364393bae04c84b1c921695eadc"
+        "revision" : "1cad71a114cd8b321804b4f73a550ac500aafe1b"
       }
     },
     {

--- a/FoundationLabCore/Package.swift
+++ b/FoundationLabCore/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/rryam/FoundationModelsKit.git",
-            revision: "672f8231dff61364393bae04c84b1c921695eadc"
+            revision: "1cad71a114cd8b321804b4f73a550ac500aafe1b"
         )
     ],
     targets: [

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rryam/FoundationModelsKit.git",
       "state" : {
-        "revision" : "672f8231dff61364393bae04c84b1c921695eadc"
+        "revision" : "1cad71a114cd8b321804b4f73a550ac500aafe1b"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/rryam/FoundationModelsKit.git",
-            revision: "672f8231dff61364393bae04c84b1c921695eadc"
+            revision: "1cad71a114cd8b321804b4f73a550ac500aafe1b"
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -224,8 +224,12 @@ swiftlint lint --strict --config .swiftlint.yml
 swift test
 ```
 
-CI additionally builds Foundation Lab for macOS and iOS Simulator and validates
-the Adapter Studio and TestFlight workflows.
+On pull requests, CI runs the FoundationLabCore test suite (`swift test`) and
+typechecks the book playgrounds via `Tools/BookPlaygrounds/typecheck.sh`
+([`foundation-lab-pr.yml`](.github/workflows/foundation-lab-pr.yml)). A
+separate [`adapter-studio.yml`](.github/workflows/adapter-studio.yml) workflow
+lints and builds Foundation Lab for macOS and iOS Simulator when Adapter
+Studio files change.
 
 ## TestFlight
 


### PR DESCRIPTION
## Summary

- Bump pinned rryam/FoundationModelsKit revision to the 2.1.0 release commit (`1cad71a114cd8b321804b4f73a550ac500aafe1b`) in root `Package.swift`, `FoundationLabCore/Package.swift`, both `Package.resolved` files, and the Xcode project pin
- BookPlaygrounds/README.md: correct macOS requirement from 15.6+ to 26.0+ and fix broken bold markdown (`** GettingStartedWithSessions**`)
- AnalyzeNutritionIntent: remove the guarded force unwrap in favor of an unwrap-free empty-check fallback
- README.md Validation section: describe what PR CI actually runs (swift test + book playground typecheck) instead of overstating macOS/iOS Simulator app builds
- 03_CalculatorTool playground: convert the free-form `operation: String` parameter to a `@Generable` enum

## Testing

- `swift test` (root and FoundationLabCore): 59 tests passing (54 XCTest incl. 4 skipped + 5 Swift Testing), 0 failures
- `bash Tools/BookPlaygrounds/typecheck.sh`: all playground directories typecheck cleanly