### PR TITLE
Fix missing generation experiment symbol

### DIFF
--- a/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabExperimentKind.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabExperimentKind.swift
@@ -31,7 +31,7 @@ public enum FoundationLabExperimentKind: String, CaseIterable, Codable, Hashable
         case .conversation:
             "bubble.left.and.bubble.right"
         case .generation:
-            "text.sparkle"
+            "sparkles"
         case .structuredOutput:
             "curlybraces"
         case .toolUse:


### PR DESCRIPTION
## What changed

Replaced the invalid generation experiment SF Symbol `text.sparkle` with `sparkles`.

## Why

`text.sparkle` isn't in the system symbol set, so each label backed by `FoundationLabExperimentKind.generation` logged the missing-symbol warning again. `sparkles` resolves on macOS and keeps the intended meaning.

Generation labels now render their icon without filling the console with repeated lookup failures.

## Checks

- `swiftlint lint --strict --config .swiftlint.yml`
- `swift test` (59 tests ran; 4 Xcode 27 runtime tests skipped on the installed runtime)
- macOS app build with code signing disabled
- iOS Simulator app build with code signing disabled
- AppKit symbol lookup confirmed `text.sparkle` is missing and `sparkles` resolves