### PR TITLE
Polish Playground chat and inspector presentation

### DIFF
--- a/Foundation Lab/Views/Chat/TranscriptEntryView.swift
+++ b/Foundation Lab/Views/Chat/TranscriptEntryView.swift
@@ -17,7 +17,7 @@ struct TranscriptEntryView: View {
     @Environment(ChatViewModel.self) private var chatViewModel
 
     var body: some View {
-        VStack(spacing: 2) {
+        VStack(alignment: entry.isFromUser ? .trailing : .leading, spacing: 2) {
             entryContent
 
             if let tokenCount {
@@ -31,6 +31,7 @@ struct TranscriptEntryView: View {
                     .padding(.horizontal, Spacing.large)
             }
         }
+        .frame(maxWidth: .infinity)
         .task(id: "\(transcriptIndex)-\(entry.id)") {
             tokenCount = nil
             tokenCount = await resolveTokenCount()

--- a/Foundation Lab/Views/Components/ChatInputView.swift
+++ b/Foundation Lab/Views/Components/ChatInputView.swift
@@ -72,7 +72,11 @@ private extension ChatInputView {
         .padding(.horizontal, Spacing.medium)
         .padding(.vertical, Spacing.small)
         .frame(minHeight: FoundationLabLayout.minimumTouchTarget)
-        .background(Color.secondaryBackgroundColor, in: .rect(cornerRadius: CornerRadius.medium))
+        .background(.background, in: .capsule)
+        .overlay {
+            Capsule()
+                .strokeBorder(.quaternary, lineWidth: 1)
+        }
     }
 
     @ViewBuilder

--- a/Foundation Lab/Views/Components/MessageBubbleView.swift
+++ b/Foundation Lab/Views/Components/MessageBubbleView.swift
@@ -12,8 +12,10 @@ struct MessageBubbleView: View {
     @State private var animatesTyping = false
 
     var body: some View {
-        VStack(alignment: message.isFromUser ? .trailing : .leading, spacing: Spacing.small) {
-            senderLabel
+        VStack(alignment: message.isFromUser ? .trailing : .leading, spacing: Spacing.xSmall) {
+            if !message.isFromUser {
+                senderLabel
+            }
 
             if !message.isFromUser && plainText.isEmpty {
                 typingIndicator
@@ -25,7 +27,10 @@ struct MessageBubbleView: View {
                 contextSummaryLabel
             }
         }
-        .frame(maxWidth: message.isFromUser ? 620 : FoundationLabLayout.transcriptContentWidth)
+        .frame(
+            maxWidth: message.isFromUser ? 620 : FoundationLabLayout.transcriptContentWidth,
+            alignment: message.isFromUser ? .trailing : .leading
+        )
         .frame(maxWidth: .infinity, alignment: message.isFromUser ? .trailing : .leading)
         .padding(.horizontal, Spacing.large)
         .contextMenu {
@@ -45,25 +50,31 @@ struct MessageBubbleView: View {
 
 private extension MessageBubbleView {
     var senderLabel: some View {
-        Label(
-            message.isFromUser ? "You" : "Foundation Models",
-            systemImage: message.isFromUser ? "person.crop.circle" : "apple.intelligence"
-        )
+        Label("Foundation Models", systemImage: "apple.intelligence")
         .font(.subheadline)
         .foregroundStyle(.secondary)
     }
 
     var messageText: some View {
         Text(message.content)
-            .padding(.horizontal, message.isFromUser ? Spacing.large : 0)
-            .padding(.vertical, message.isFromUser ? Spacing.medium : 0)
+            .padding(.horizontal, Spacing.large)
+            .padding(.vertical, Spacing.medium)
             .textSelection(.enabled)
-            .foregroundStyle(.primary)
+            .foregroundStyle(message.isFromUser ? Color.white : Color.primary)
             .background(
-                message.isFromUser ? Color.secondaryBackgroundColor : .clear,
-                in: .rect(cornerRadius: CornerRadius.large)
+                message.isFromUser ? Color.accentColor : Color.secondaryBackgroundColor,
+                in: bubbleShape
             )
             .fixedSize(horizontal: false, vertical: true)
+    }
+
+    var bubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: CornerRadius.large,
+            bottomLeadingRadius: message.isFromUser ? CornerRadius.large : CornerRadius.small,
+            bottomTrailingRadius: message.isFromUser ? CornerRadius.small : CornerRadius.large,
+            topTrailingRadius: CornerRadius.large
+        )
     }
 
     var typingIndicator: some View {

--- a/Foundation Lab/Views/Playground/PlaygroundInspectorView.swift
+++ b/Foundation Lab/Views/Playground/PlaygroundInspectorView.swift
@@ -8,11 +8,24 @@ struct PlaygroundInspectorView: View {
     let applyConfiguration: () -> Void
 
     var body: some View {
-        Form {
+        List {
             Section("Experiment") {
-                TextField("Name", text: $experimentStore.activeExperiment.name)
-                TextField("Description", text: $experimentStore.activeExperiment.summary, axis: .vertical)
-                    .lineLimit(2...4)
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Name")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Name", text: $experimentStore.activeExperiment.name)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Description")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Description", text: $experimentStore.activeExperiment.summary, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(2...4)
+                }
             }
 
             Section("Model") {
@@ -71,24 +84,43 @@ struct PlaygroundInspectorView: View {
                     Toggle("Use Fixed Seed", isOn: fixedSeedBinding)
                 }
 
-                TextField("Temperature", value: temperatureBinding, format: .number)
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Temperature")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Temperature", value: temperatureBinding, format: .number)
+                        .textFieldStyle(.roundedBorder)
 #if os(iOS)
-                    .keyboardType(.decimalPad)
+                        .keyboardType(.decimalPad)
 #endif
-                TextField("Maximum response tokens", value: maximumTokensBinding, format: .number)
+                }
+
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Maximum response tokens")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Maximum response tokens", value: maximumTokensBinding, format: .number)
+                        .textFieldStyle(.roundedBorder)
 #if os(iOS)
-                    .keyboardType(.numberPad)
+                        .keyboardType(.numberPad)
 #endif
+                }
             }
             .disabled(viewModel.isLoading)
 
             Section("Instructions") {
-                TextField(
-                    "Describe how the model should behave",
-                    text: $experimentStore.activeExperiment.instructions,
-                    axis: .vertical
-                )
+                VStack(alignment: .leading, spacing: Spacing.xSmall) {
+                    Text("Describe how the model should behave")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField(
+                        "Describe how the model should behave",
+                        text: $experimentStore.activeExperiment.instructions,
+                        axis: .vertical
+                    )
+                    .textFieldStyle(.roundedBorder)
                     .lineLimit(4...10)
+                }
             }
             .disabled(viewModel.isLoading)
 
@@ -97,6 +129,7 @@ struct PlaygroundInspectorView: View {
                     Toggle(isOn: toolSelectionBinding(for: tool)) {
                         ToolSelectionLabel(tool: tool)
                     }
+                    .toggleStyle(.switch)
                     .disabled(viewModel.isLoading)
                 }
             }
@@ -124,7 +157,13 @@ struct PlaygroundInspectorView: View {
                 }
             }
         }
-        .formStyle(.grouped)
+#if os(macOS)
+        .listStyle(.inset)
+        .contentMargins(.horizontal, Spacing.large, for: .scrollContent)
+        .contentMargins(.vertical, Spacing.large, for: .scrollContent)
+#else
+        .listStyle(.insetGrouped)
+#endif
     }
 }
 


### PR DESCRIPTION
## What changed

- Restyled user prompts as blue outgoing bubbles and kept prompt token metadata on the right.
- Changed the composer to a thin bordered capsule while leaving the voice button and its behavior alone.
- Replaced the inspector's grouped card stack with a flat inset list that fits the narrow column.
- Added persistent labels and compact rounded fields for editable values.
- Kept every inspector control, including runtime, reasoning, sampling, tools, save, apply, and Swift export.

## Why

The transcript read more like a document than a conversation, and the inspector felt dense because each section sat inside another gray container. The new layout gives prompts a clear sender edge and lets spacing, labels, and dividers organize the inspector.

The reference app's plus and emoji controls were not copied because Foundation Lab has no matching actions.

## Checks

- `swiftlint lint --strict --config .swiftlint.yml`
- `swift test` (59 tests ran; 4 Xcode 27 runtime tests skipped on the installed runtime)
- Fresh macOS build and launch after deleting the dedicated Derived Data directory
- Live macOS inspection of the transcript, composer, inspector fields, tool switches, and lower inspector actions
- Fresh generic iOS Simulator build with code signing disabled